### PR TITLE
Add BYTE_STREAM_SPLIT encoding

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/segmentio/parquet/encoding"
+	"github.com/segmentio/parquet/encoding/bytestreamsplit"
 	"github.com/segmentio/parquet/encoding/dict"
 	"github.com/segmentio/parquet/encoding/plain"
 	"github.com/segmentio/parquet/encoding/rle"
@@ -25,12 +26,16 @@ var (
 	// writers which used the PLAIN_DICTIONARY encoding.
 	Dict dict.Encoding
 
+	// ByteStreamSplit is an encoding for floating-point data.
+	ByteStreamSplit bytestreamsplit.Encoding
+
 	// Table indexing the encodings supported by this package.
 	encodings = [...]encoding.Encoding{
 		format.Plain:           &Plain,
 		format.PlainDictionary: Dict.PlainEncoding(),
 		format.RLE:             &RLE,
 		format.RLEDictionary:   &Dict,
+		format.ByteStreamSplit: &ByteStreamSplit,
 	}
 )
 

--- a/encoding/bytestreamsplit/bytestreamsplit.go
+++ b/encoding/bytestreamsplit/bytestreamsplit.go
@@ -7,6 +7,8 @@ import (
 	"github.com/segmentio/parquet/format"
 )
 
+// This encoder implements a version of the Byte Stream Split encoding as described
+// in https://github.com/apache/parquet-format/blob/master/Encodings.md#byte-stream-split-byte_stream_split--9
 type Encoding struct{}
 
 func (e *Encoding) Encoding() format.Encoding {
@@ -22,7 +24,7 @@ func (e *Encoding) NewEncoder(w io.Writer) encoding.Encoder {
 }
 
 func (e *Encoding) NewDecoder(r io.Reader) encoding.Decoder {
-	return NewDecorder(r)
+	return NewDecoder(r)
 }
 
 func (e *Encoding) String() string {

--- a/encoding/bytestreamsplit/encoder.go
+++ b/encoding/bytestreamsplit/encoder.go
@@ -5,32 +5,23 @@ import (
 	"math"
 
 	"github.com/segmentio/parquet/encoding"
+	"github.com/segmentio/parquet/format"
 )
 
-// Byte Stream Split: (BYTE_STREAM_SPLIT = 9)
-// Supported Types: FLOAT DOUBLE
-//
-// This encoding does not reduce the size of the data but can lead to a significantly better compression ratio and speed when a compression algorithm is used afterwards.
-//
-// This encoding creates K byte-streams of length N where K is the size in bytes of the data type and N is the number of elements in the data sequence.
-// The bytes of each value are scattered to the corresponding streams. The 0-th byte goes to the 0-th stream, the 1-st byte goes to the 1-st stream and so on.
-// The streams are concatenated in the following order: 0-th stream, 1-st stream, etc.
-//
-// Example: Original data is three 32-bit floats and for simplicity we look at their raw representation.
-//
-//        Element 0      Element 1      Element 2
-// Bytes  AA BB CC DD    00 11 22 33    A3 B4 C5 D6
-// After applying the transformation, the data has the following representation:
-//
-// Bytes  AA 00 A3 BB 11 B4 CC 22 C5 DD 33 D6
-//
 type Encoder struct {
 	encoding.NotSupportedEncoder
 	writer io.Writer
+	buffer []byte
 }
 
 func NewEncoder(w io.Writer) *Encoder {
-	return &Encoder{writer: w}
+	return &Encoder{
+		writer: w,
+	}
+}
+
+func (e *Encoder) Encoding() format.Encoding {
+	return format.ByteStreamSplit
 }
 
 func (e *Encoder) Write(b []byte) (int, error) {
@@ -39,6 +30,7 @@ func (e *Encoder) Write(b []byte) (int, error) {
 
 func (e *Encoder) Reset(w io.Writer) {
 	e.writer = w
+	e.buffer = e.buffer[:0]
 }
 
 func (e *Encoder) EncodeFloat(data []float32) error {
@@ -57,17 +49,19 @@ func (e *Encoder) encode32(data []float32) []byte {
 		return []byte{}
 	}
 
-	buffer := make([]byte, length*4)
+	if len(e.buffer) < length*4 {
+		e.buffer = make([]byte, length*4)
+	}
 
 	for i, f := range data {
 		bits := math.Float32bits(f)
-		buffer[i] = byte(bits)
-		buffer[i+length] = byte(bits >> 8)
-		buffer[i+length*2] = byte(bits >> 16)
-		buffer[i+length*3] = byte(bits >> 24)
+		e.buffer[i] = byte(bits)
+		e.buffer[i+length] = byte(bits >> 8)
+		e.buffer[i+length*2] = byte(bits >> 16)
+		e.buffer[i+length*3] = byte(bits >> 24)
 	}
 
-	return buffer
+	return e.buffer[:length*4]
 }
 
 func (e *Encoder) encode64(data []float64) []byte {
@@ -76,19 +70,21 @@ func (e *Encoder) encode64(data []float64) []byte {
 		return []byte{}
 	}
 
-	buffer := make([]byte, length*8)
+	if len(e.buffer) < length*8 {
+		e.buffer = make([]byte, length*8)
+	}
 
 	for i, f := range data {
 		bits := math.Float64bits(f)
-		buffer[i] = byte(bits)
-		buffer[i+length] = byte(bits >> 8)
-		buffer[i+length*2] = byte(bits >> 16)
-		buffer[i+length*3] = byte(bits >> 24)
-		buffer[i+length*4] = byte(bits >> 32)
-		buffer[i+length*5] = byte(bits >> 40)
-		buffer[i+length*6] = byte(bits >> 48)
-		buffer[i+length*7] = byte(bits >> 56)
+		e.buffer[i] = byte(bits)
+		e.buffer[i+length] = byte(bits >> 8)
+		e.buffer[i+length*2] = byte(bits >> 16)
+		e.buffer[i+length*3] = byte(bits >> 24)
+		e.buffer[i+length*4] = byte(bits >> 32)
+		e.buffer[i+length*5] = byte(bits >> 40)
+		e.buffer[i+length*6] = byte(bits >> 48)
+		e.buffer[i+length*7] = byte(bits >> 56)
 	}
 
-	return buffer
+	return e.buffer[:length*8]
 }

--- a/encoding/bytestreamsplit/encoder_test.go
+++ b/encoding/bytestreamsplit/encoder_test.go
@@ -27,7 +27,13 @@ func TestEncoding(t *testing.T) {
 
 	final := make([]float32, 3)
 
-	d.decode32(final)
+	if err := d.read(); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := d.decode32(final); err != nil {
+		t.Error(err)
+	}
 
 	if !reflect.DeepEqual(data, final) {
 		t.Error("decoding result not expected")

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -745,3 +745,23 @@ func testFixedLenByteArrayEncoding(t *testing.T, e encoding.Encoding) {
 		})
 	}
 }
+
+func BenchmarkFloatEncoding(b *testing.B) {
+	buf := new(bytes.Buffer)
+	enc := bytestreamsplit.NewEncoder(buf)
+	dec := bytestreamsplit.NewDecoder(buf)
+
+	for n := 0; n < b.N; n++ {
+		for _, test := range floatTests {
+			tmp := make([]float32, len(test))
+
+			if err := enc.EncodeFloat(test); err != nil {
+				b.Fatal(err)
+			}
+
+			if _, err := dec.DecodeFloat(tmp); err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+		}
+	}
+}

--- a/encoding/plain/encoder.go
+++ b/encoding/plain/encoder.go
@@ -13,7 +13,6 @@ import (
 type Encoder struct {
 	encoding.NotSupportedEncoder
 	writer io.Writer
-	buffer [8]byte
 	rle    *rle.Encoder
 }
 


### PR DESCRIPTION
This PR adds an implementation of the BYTE_STREM_SPLIT encoding following https://github.com/apache/parquet-format/blob/master/Encodings.md#byte-stream-split-byte_stream_split--9.

Based on the result from https://github.com/martinradev/arrow-fp-compression-bench/blob/master/optimize_byte_stream_split/report_final.pdf there is more we can do once we bring SIMD to the party.