### PR TITLE
fix build on ARM64

### DIFF
--- a/bloom/xxhash/xxhash_purego.go
+++ b/bloom/xxhash/xxhash_purego.go
@@ -1,4 +1,4 @@
-//go:build purego
+//go:build purego || !amd64
 
 package xxhash
 


### PR DESCRIPTION
There was an issue with a build tag on ARM64 that caused the following error:
```
# github.com/segmentio/parquet-go/bloom
bloom/hash.go:24:9: undefined: xxhash.Sum64
FAIL	github.com/segmentio/parquet-go [build failed]
```
We should soon have proper build agents on ARM64 machines and we'll be able to catch those in CI.