### PR TITLE
[O11Y-197] optimize orderOf algorithms on x86 with AVX-512 support

### DIFF
--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -61,7 +61,7 @@ var int8Tests = [...][]int8{
 		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
 		0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
 	},
-	{ // strakes of repeating values
+	{ // streaks of repeating values
 		0, 0, 0, 0, 1, 1, 1, 1,
 		2, 2, 2, 2, 3, 3, 3, 3,
 		4, 4, 4, 4, 5, 5, 5, 5,
@@ -86,7 +86,7 @@ var int16Tests = [...][]int16{
 		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
 		0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
 	},
-	{ // strakes of repeating values
+	{ // streaks of repeating values
 		0, 0, 0, 0, 1, 1, 1, 1,
 		2, 2, 2, 2, 3, 3, 3, 3,
 		4, 4, 4, 4, 5, 5, 5, 5,
@@ -111,7 +111,7 @@ var int32Tests = [...][]int32{
 		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
 		0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
 	},
-	{ // strakes of repeating values
+	{ // streaks of repeating values
 		0, 0, 0, 0, 1, 1, 1, 1,
 		2, 2, 2, 2, 3, 3, 3, 3,
 		4, 4, 4, 4, 5, 5, 5, 5,
@@ -139,14 +139,14 @@ var int64Tests = [...][]int64{
 		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
 		0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
 	},
-	{ // strakes of repeating values
+	{ // streaks of repeating values
 		0, 0, 0, 0, 1, 1, 1, 1,
 		2, 2, 2, 2, 3, 3, 3, 3,
 		4, 4, 4, 4, 5, 5, 5, 5,
 		6, 6, 6, 7, 7, 7, 8, 8,
 		8, 9, 9, 9,
 	},
-	{ // strakes of repeating values
+	{ // streaks of repeating values
 		0, 0, 0, 0, 1, 1, 1, 1,
 		2, 2, 2, 2, 3, 3, 3, 3,
 		4, 4, 4, 4, 5, 5, 5, 5,

--- a/internal/bits/bits_test.go
+++ b/internal/bits/bits_test.go
@@ -218,10 +218,12 @@ func quickCheck(f interface{}) error {
 		2000, 2095, 2048, 2049,
 		4000, 4095, 4096, 4097,
 	} {
-		in := makeArray(n)
-		ok := v.Call([]reflect.Value{reflect.ValueOf(in)})
-		if !ok[0].Bool() {
-			return fmt.Errorf("failed on input of size %d: %#v\n", n, in)
+		for i := 0; i < 3; i++ {
+			in := makeArray(n)
+			ok := v.Call([]reflect.Value{reflect.ValueOf(in)})
+			if !ok[0].Bool() {
+				return fmt.Errorf("test #%d: failed on input of size %d: %#v\n", i+1, n, in)
+			}
 		}
 	}
 	return nil

--- a/internal/bits/order.go
+++ b/internal/bits/order.go
@@ -14,16 +14,16 @@ func OrderOfBool(data []bool) int {
 
 		if data[0] { // true => false: descending
 			k = -1
-			i = strakeOfTrue(data)
+			i = streakOfTrue(data)
 			if i == len(data) {
 				k = +1
 			} else {
-				i += strakeOfFalse(data[i:])
+				i += streakOfFalse(data[i:])
 			}
 		} else { // false => true: ascending
 			k = +1
-			i = strakeOfFalse(data)
-			i += strakeOfTrue(data[i:])
+			i = streakOfFalse(data)
+			i += streakOfTrue(data[i:])
 		}
 
 		if i != len(data) {
@@ -33,14 +33,14 @@ func OrderOfBool(data []bool) int {
 	}
 }
 
-func strakeOfTrue(data []bool) int {
+func streakOfTrue(data []bool) int {
 	if i := bytes.IndexByte(BoolToBytes(data), 0); i >= 0 {
 		return i
 	}
 	return len(data)
 }
 
-func strakeOfFalse(data []bool) int {
+func streakOfFalse(data []bool) int {
 	if i := bytes.IndexByte(BoolToBytes(data), 1); i >= 0 {
 		return i
 	}
@@ -120,7 +120,7 @@ func OrderOfBytes(data [][]byte) int {
 	if len(data) == 1 {
 		return 1
 	}
-	data = skipBytesStrake(data)
+	data = skipBytesStreak(data)
 	if len(data) < 2 {
 		return 1
 	}
@@ -138,7 +138,7 @@ func OrderOfBytes(data [][]byte) int {
 	return 0
 }
 
-func skipBytesStrake(data [][]byte) [][]byte {
+func skipBytesStreak(data [][]byte) [][]byte {
 	for i := 1; i < len(data); i++ {
 		if !bytes.Equal(data[i], data[0]) {
 			return data[i-1:]

--- a/internal/bits/order.go
+++ b/internal/bits/order.go
@@ -15,7 +15,11 @@ func OrderOfBool(data []bool) int {
 		if data[0] { // true => false: descending
 			k = -1
 			i = strakeOfTrue(data)
-			i += strakeOfFalse(data[i:])
+			if i == len(data) {
+				k = +1
+			} else {
+				i += strakeOfFalse(data[i:])
+			}
 		} else { // false => true: ascending
 			k = +1
 			i = strakeOfFalse(data)
@@ -116,7 +120,7 @@ func OrderOfBytes(data [][]byte) int {
 	if len(data) == 1 {
 		return 1
 	}
-	data = skipBytesEqual(data[1:], data[0])
+	data = skipBytesStrake(data)
 	if len(data) < 2 {
 		return 1
 	}
@@ -134,13 +138,13 @@ func OrderOfBytes(data [][]byte) int {
 	return 0
 }
 
-func skipBytesEqual(data [][]byte, value []byte) [][]byte {
-	for i := range data {
-		if !bytes.Equal(data[i], value) {
-			return data[i:]
+func skipBytesStrake(data [][]byte) [][]byte {
+	for i := 1; i < len(data); i++ {
+		if !bytes.Equal(data[i], data[0]) {
+			return data[i-1:]
 		}
 	}
-	return nil
+	return data[len(data)-1:]
 }
 
 func bytesAreInAscendingOrder(data [][]byte) bool {

--- a/internal/bits/order.go
+++ b/internal/bits/order.go
@@ -3,13 +3,13 @@ package bits
 import "bytes"
 
 func OrderOfBool(data []bool) int {
-	k := 0
-
 	switch len(data) {
 	case 0:
+		return 0
 	case 1:
-		k = +1
+		return 1
 	default:
+		k := 0
 		i := 0
 
 		if data[0] { // true => false: descending
@@ -25,81 +25,88 @@ func OrderOfBool(data []bool) int {
 		if i != len(data) {
 			k = 0
 		}
+		return k
 	}
+}
 
-	return k
+func strakeOfTrue(data []bool) int {
+	if i := bytes.IndexByte(BoolToBytes(data), 0); i >= 0 {
+		return i
+	}
+	return len(data)
+}
+
+func strakeOfFalse(data []bool) int {
+	if i := bytes.IndexByte(BoolToBytes(data), 1); i >= 0 {
+		return i
+	}
+	return len(data)
 }
 
 func OrderOfInt32(data []int32) int {
-	if len(data) > 0 {
-		if int32AreInAscendingOrder(data) {
-			return +1
-		}
-		if int32AreInDescendingOrder(data) {
-			return -1
-		}
+	switch len(data) {
+	case 0:
+		return 0
+	case 1:
+		return 1
+	default:
+		return orderOfInt32(data)
 	}
-	return 0
 }
 
 func OrderOfInt64(data []int64) int {
-	if len(data) > 0 {
-		if int64AreInAscendingOrder(data) {
-			return +1
-		}
-		if int64AreInDescendingOrder(data) {
-			return -1
-		}
+	switch len(data) {
+	case 0:
+		return 0
+	case 1:
+		return 1
+	default:
+		return orderOfInt64(data)
 	}
-	return 0
 }
 
 func OrderOfUint32(data []uint32) int {
-	if len(data) > 0 {
-		if uint32AreInAscendingOrder(data) {
-			return +1
-		}
-		if uint32AreInDescendingOrder(data) {
-			return -1
-		}
+	switch len(data) {
+	case 0:
+		return 0
+	case 1:
+		return 1
+	default:
+		return orderOfUint32(data)
 	}
-	return 0
 }
 
 func OrderOfUint64(data []uint64) int {
-	if len(data) > 0 {
-		if uint64AreInAscendingOrder(data) {
-			return +1
-		}
-		if uint64AreInDescendingOrder(data) {
-			return -1
-		}
+	switch len(data) {
+	case 0:
+		return 0
+	case 1:
+		return 1
+	default:
+		return orderOfUint64(data)
 	}
-	return 0
 }
 
 func OrderOfFloat32(data []float32) int {
-	if len(data) > 0 {
-		if float32AreInAscendingOrder(data) {
-			return +1
-		}
-		if float32AreInDescendingOrder(data) {
-			return -1
-		}
+	switch len(data) {
+	case 0:
+		return 0
+	case 1:
+		return 1
+	default:
+		return orderOfFloat32(data)
 	}
-	return 0
 }
 
 func OrderOfFloat64(data []float64) int {
-	if len(data) > 0 {
-		if float64AreInAscendingOrder(data) {
-			return +1
-		}
-		if float64AreInDescendingOrder(data) {
-			return -1
-		}
+	switch len(data) {
+	case 0:
+		return 0
+	case 1:
+		return 1
+	default:
+		return orderOfFloat64(data)
 	}
-	return 0
 }
 
 func OrderOfBytes(data [][]byte) int {
@@ -109,137 +116,47 @@ func OrderOfBytes(data [][]byte) int {
 	if len(data) == 1 {
 		return 1
 	}
-	k := bytes.Compare(data[len(data)-2], data[len(data)-1])
-	for i := len(data) - 2; i > 0; i-- {
-		if bytes.Compare(data[i-1], data[i]) != k {
-			return 0
+	data = skipBytesEqual(data[1:], data[0])
+	if len(data) < 2 {
+		return 1
+	}
+	ordering := bytes.Compare(data[0], data[1])
+	switch {
+	case ordering > 0:
+		if bytesAreInAscendingOrder(data[1:]) {
+			return +1
+		}
+	case ordering < 0:
+		if bytesAreInDescendingOrder(data[1:]) {
+			return -1
 		}
 	}
-	return k
+	return 0
 }
 
-func strakeOfTrue(data []bool) int {
+func skipBytesEqual(data [][]byte, value []byte) [][]byte {
 	for i := range data {
-		if !data[i] {
-			return i
+		if !bytes.Equal(data[i], value) {
+			return data[i:]
 		}
 	}
-	return len(data)
+	return nil
 }
 
-func strakeOfFalse(data []bool) int {
-	for i := range data {
-		if data[i] {
-			return i
-		}
-	}
-	return len(data)
-}
-
-// generics please! :'(
-
-func int32AreInAscendingOrder(data []int32) bool {
+func bytesAreInAscendingOrder(data [][]byte) bool {
 	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] > data[i] {
+		k := bytes.Compare(data[i-1], data[i])
+		if k > 0 {
 			return false
 		}
 	}
 	return true
 }
 
-func int32AreInDescendingOrder(data []int32) bool {
+func bytesAreInDescendingOrder(data [][]byte) bool {
 	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] < data[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func int64AreInAscendingOrder(data []int64) bool {
-	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] > data[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func int64AreInDescendingOrder(data []int64) bool {
-	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] < data[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func uint32AreInAscendingOrder(data []uint32) bool {
-	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] > data[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func uint32AreInDescendingOrder(data []uint32) bool {
-	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] < data[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func uint64AreInAscendingOrder(data []uint64) bool {
-	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] > data[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func uint64AreInDescendingOrder(data []uint64) bool {
-	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] < data[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func float32AreInAscendingOrder(data []float32) bool {
-	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] > data[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func float32AreInDescendingOrder(data []float32) bool {
-	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] < data[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func float64AreInAscendingOrder(data []float64) bool {
-	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] > data[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func float64AreInDescendingOrder(data []float64) bool {
-	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] < data[i] {
+		k := bytes.Compare(data[i-1], data[i])
+		if k < 0 {
 			return false
 		}
 	}

--- a/internal/bits/order.go
+++ b/internal/bits/order.go
@@ -5,15 +5,19 @@ import "bytes"
 func OrderOfBool(data []bool) int {
 	k := 0
 
-	if len(data) > 0 {
+	switch len(data) {
+	case 0:
+	case 1:
+		k = +1
+	default:
 		i := 0
 
 		if data[0] { // true => false: descending
-			k = +1
+			k = -1
 			i = strakeOfTrue(data)
 			i += strakeOfFalse(data[i:])
 		} else { // false => true: ascending
-			k = -1
+			k = +1
 			i = strakeOfFalse(data)
 			i += strakeOfTrue(data[i:])
 		}
@@ -115,15 +119,19 @@ func OrderOfBytes(data [][]byte) int {
 }
 
 func strakeOfTrue(data []bool) int {
-	if i := bytes.IndexByte(BoolToBytes(data), 0); i >= 0 {
-		return i
+	for i := range data {
+		if !data[i] {
+			return i
+		}
 	}
 	return len(data)
 }
 
 func strakeOfFalse(data []bool) int {
-	if i := bytes.IndexByte(BoolToBytes(data), 1); i >= 0 {
-		return i
+	for i := range data {
+		if data[i] {
+			return i
+		}
 	}
 	return len(data)
 }

--- a/internal/bits/order_amd64.go
+++ b/internal/bits/order_amd64.go
@@ -1,0 +1,21 @@
+//go:build !purego
+
+package bits
+
+//go:noescape
+func orderOfInt32(data []int32) int
+
+//go:noescape
+func orderOfInt64(data []int64) int
+
+//go:noescape
+func orderOfUint32(data []uint32) int
+
+//go:noescape
+func orderOfUint64(data []uint64) int
+
+//go:noescape
+func orderOfFloat32(data []float32) int
+
+//go:noescape
+func orderOfFloat64(data []float64) int

--- a/internal/bits/order_amd64.s
+++ b/internal/bits/order_amd64.s
@@ -36,56 +36,60 @@ GLOBL shift1x64<>(SB), RODATA|NOPTR, $64
 
 // func orderOfInt32(data []int32) int
 TEXT ·orderOfInt32(SB), NOSPLIT, $-32
-    MOVQ data_base+0(FP), AX
-    MOVQ data_len+8(FP), CX
+    MOVQ data_base+0(FP), R8
+    MOVQ data_len+8(FP), R9
     XORQ SI, SI
     XORQ DI, DI
 
     CMPB ·hasAVX512(SB), $0
     JE test
 
-    CMPQ CX, $16
+    CMPQ R9, $16
     JB test
 
-    MOVQ CX, DX
-    SHRQ $4, DX
-    SHLQ $4, DX
-    DECQ CX
+    XORQ DX, DX
+    MOVQ R9, AX
+    SHRQ $4, AX
+    SHLQ $4, AX
+    MOVQ $15, CX
+    IDIVQ CX
+    IMULQ $15, AX
+    DECQ R9
 
     VMOVDQU32 shift1x32<>(SB), Z2
     KXORW K2, K2, K2
-testAscending16:
-    VMOVDQU32 (AX)(SI*4), Z0
+testAscending15:
+    VMOVDQU32 (R8)(SI*4), Z0
     VMOVDQU32 Z2, Z1
     VPERMI2D Z0, Z0, Z1
     VPCMPD $2, Z1, Z0, K1
     KORTESTW K2, K1
-    JNC testDescending16
-    ADDQ $16, SI
-    CMPQ SI, DX
-    JNE testAscending16
+    JNC testDescending15
+    ADDQ $15, SI
+    CMPQ SI, AX
+    JNE testAscending15
     VZEROUPPER
     JMP testAscending
-testDescending16:
-    VMOVDQU32 (AX)(DI*4), Z0
+testDescending15:
+    VMOVDQU32 (R8)(DI*4), Z0
     VMOVDQU32 Z2, Z1
     VPERMI2D Z0, Z0, Z1
     VPCMPD $5, Z1, Z0, K1
     KORTESTW K2, K1
-    JNC undefined16
-    ADDQ $16, DI
-    CMPQ DI, DX
-    JNE testDescending16
+    JNC undefined15
+    ADDQ $15, DI
+    CMPQ DI, AX
+    JNE testDescending15
     VZEROUPPER
     JMP testDescending
 
 test:
-    DECQ CX
+    DECQ R9
 testAscending:
-    CMPQ SI, CX
+    CMPQ SI, R9
     JAE ascending
-    MOVL (AX)(SI*4), BX
-    MOVL 4(AX)(SI*4), DX
+    MOVL (R8)(SI*4), BX
+    MOVL 4(R8)(SI*4), DX
     INCQ SI
     CMPL BX, DX
     JLE testAscending
@@ -94,10 +98,10 @@ ascending:
     MOVQ $ASCENDING, ret+24(FP)
     RET
 testDescending:
-    CMPQ DI, CX
+    CMPQ DI, R9
     JAE descending
-    MOVL (AX)(DI*4), BX
-    MOVL 4(AX)(DI*4), DX
+    MOVL (R8)(DI*4), BX
+    MOVL 4(R8)(DI*4), DX
     INCQ DI
     CMPL BX, DX
     JGE testDescending
@@ -105,7 +109,7 @@ testDescending:
 descending:
     MOVQ $DESCENDING, ret+24(FP)
     RET
-undefined16:
+undefined15:
     VZEROUPPER
 undefined:
     MOVQ $UNDEFINED, ret+24(FP)
@@ -113,56 +117,60 @@ undefined:
 
 // func orderOfInt64(data []int64) int
 TEXT ·orderOfInt64(SB), NOSPLIT, $-32
-    MOVQ data_base+0(FP), AX
-    MOVQ data_len+8(FP), CX
+    MOVQ data_base+0(FP), R8
+    MOVQ data_len+8(FP), R9
     XORQ SI, SI
     XORQ DI, DI
 
     CMPB ·hasAVX512(SB), $0
     JE test
 
-    CMPQ CX, $8
+    CMPQ R9, $8
     JB test
 
-    MOVQ CX, DX
-    SHRQ $3, DX
-    SHLQ $3, DX
-    DECQ CX
+    XORQ DX, DX
+    MOVQ R9, AX
+    SHRQ $3, AX
+    SHLQ $3, AX
+    MOVQ $7, CX
+    IDIVQ CX
+    IMULQ $7, AX
+    DECQ R9
 
     VMOVDQU64 shift1x64<>(SB), Z2
     KXORB K2, K2, K2
-testAscending8:
-    VMOVDQU64 (AX)(SI*8), Z0
+testAscending7:
+    VMOVDQU64 (R8)(SI*8), Z0
     VMOVDQU64 Z2, Z1
     VPERMI2Q Z0, Z0, Z1
     VPCMPQ $2, Z1, Z0, K1
     KORTESTB K2, K1
-    JNC testDescending8
-    ADDQ $8, SI
-    CMPQ SI, DX
-    JNE testAscending8
+    JNC testDescending7
+    ADDQ $7, SI
+    CMPQ SI, AX
+    JNE testAscending7
     VZEROUPPER
     JMP testAscending
-testDescending8:
-    VMOVDQU64 (AX)(DI*8), Z0
+testDescending7:
+    VMOVDQU64 (R8)(DI*8), Z0
     VMOVDQU64 Z2, Z1
     VPERMI2Q Z0, Z0, Z1
     VPCMPQ $5, Z1, Z0, K1
     KORTESTB K2, K1
-    JNC undefined8
-    ADDQ $8, DI
-    CMPQ DI, DX
-    JNE testDescending8
+    JNC undefined7
+    ADDQ $7, DI
+    CMPQ DI, AX
+    JNE testDescending7
     VZEROUPPER
     JMP testDescending
 
 test:
-    DECQ CX
+    DECQ R9
 testAscending:
-    CMPQ SI, CX
+    CMPQ SI, R9
     JAE ascending
-    MOVQ (AX)(SI*8), BX
-    MOVQ 8(AX)(SI*8), DX
+    MOVQ (R8)(SI*8), BX
+    MOVQ 8(R8)(SI*8), DX
     INCQ SI
     CMPQ BX, DX
     JLE testAscending
@@ -171,10 +179,10 @@ ascending:
     MOVQ $ASCENDING, ret+24(FP)
     RET
 testDescending:
-    CMPQ DI, CX
+    CMPQ DI, R9
     JAE descending
-    MOVQ (AX)(DI*8), BX
-    MOVQ 8(AX)(DI*8), DX
+    MOVQ (R8)(DI*8), BX
+    MOVQ 8(R8)(DI*8), DX
     INCQ DI
     CMPQ BX, DX
     JGE testDescending
@@ -182,7 +190,7 @@ testDescending:
 descending:
     MOVQ $DESCENDING, ret+24(FP)
     RET
-undefined8:
+undefined7:
     VZEROUPPER
 undefined:
     MOVQ $UNDEFINED, ret+24(FP)
@@ -190,56 +198,60 @@ undefined:
 
 // func orderOfUint32(data []uint32) int
 TEXT ·orderOfUint32(SB), NOSPLIT, $-32
-    MOVQ data_base+0(FP), AX
-    MOVQ data_len+8(FP), CX
+    MOVQ data_base+0(FP), R8
+    MOVQ data_len+8(FP), R9
     XORQ SI, SI
     XORQ DI, DI
 
     CMPB ·hasAVX512(SB), $0
     JE test
 
-    CMPQ CX, $16
+    CMPQ R9, $16
     JB test
 
-    MOVQ CX, DX
-    SHRQ $4, DX
-    SHLQ $4, DX
-    DECQ CX
+    XORQ DX, DX
+    MOVQ R9, AX
+    SHRQ $4, AX
+    SHLQ $4, AX
+    MOVQ $15, CX
+    IDIVQ CX
+    IMULQ $15, AX
+    DECQ R9
 
     VMOVDQU32 shift1x32<>(SB), Z2
     KXORW K2, K2, K2
-testAscending16:
-    VMOVDQU32 (AX)(SI*4), Z0
+testAscending15:
+    VMOVDQU32 (R8)(SI*4), Z0
     VMOVDQU32 Z2, Z1
     VPERMI2D Z0, Z0, Z1
     VPCMPUD $2, Z1, Z0, K1
     KORTESTW K2, K1
-    JNC testDescending16
-    ADDQ $16, SI
-    CMPQ SI, DX
-    JNE testAscending16
+    JNC testDescending15
+    ADDQ $15, SI
+    CMPQ SI, AX
+    JNE testAscending15
     VZEROUPPER
     JMP testAscending
-testDescending16:
-    VMOVDQU32 (AX)(DI*4), Z0
+testDescending15:
+    VMOVDQU32 (R8)(DI*4), Z0
     VMOVDQU32 Z2, Z1
     VPERMI2D Z0, Z0, Z1
     VPCMPUD $5, Z1, Z0, K1
     KORTESTW K2, K1
-    JNC undefined16
-    ADDQ $16, DI
-    CMPQ DI, DX
-    JNE testDescending16
+    JNC undefined15
+    ADDQ $15, DI
+    CMPQ DI, AX
+    JNE testDescending15
     VZEROUPPER
     JMP testDescending
 
 test:
-    DECQ CX
+    DECQ R9
 testAscending:
-    CMPQ SI, CX
+    CMPQ SI, R9
     JAE ascending
-    MOVL (AX)(SI*4), BX
-    MOVL 4(AX)(SI*4), DX
+    MOVL (R8)(SI*4), BX
+    MOVL 4(R8)(SI*4), DX
     INCQ SI
     CMPL BX, DX
     JBE testAscending
@@ -248,10 +260,10 @@ ascending:
     MOVQ $ASCENDING, ret+24(FP)
     RET
 testDescending:
-    CMPQ DI, CX
+    CMPQ DI, R9
     JAE descending
-    MOVL (AX)(DI*4), BX
-    MOVL 4(AX)(DI*4), DX
+    MOVL (R8)(DI*4), BX
+    MOVL 4(R8)(DI*4), DX
     INCQ DI
     CMPL BX, DX
     JAE testDescending
@@ -259,7 +271,7 @@ testDescending:
 descending:
     MOVQ $DESCENDING, ret+24(FP)
     RET
-undefined16:
+undefined15:
     VZEROUPPER
 undefined:
     MOVQ $UNDEFINED, ret+24(FP)
@@ -267,56 +279,60 @@ undefined:
 
 // func orderOfUint64(data []uint64) int
 TEXT ·orderOfUint64(SB), NOSPLIT, $-32
-    MOVQ data_base+0(FP), AX
-    MOVQ data_len+8(FP), CX
+    MOVQ data_base+0(FP), R8
+    MOVQ data_len+8(FP), R9
     XORQ SI, SI
     XORQ DI, DI
 
     CMPB ·hasAVX512(SB), $0
     JE test
 
-    CMPQ CX, $8
+    CMPQ R9, $8
     JB test
 
-    MOVQ CX, DX
-    SHRQ $3, DX
-    SHLQ $3, DX
-    DECQ CX
+    XORQ DX, DX
+    MOVQ R9, AX
+    SHRQ $3, AX
+    SHLQ $3, AX
+    MOVQ $7, CX
+    IDIVQ CX
+    IMULQ $7, AX
+    DECQ R9
 
     VMOVDQU64 shift1x64<>(SB), Z2
     KXORB K2, K2, K2
-testAscending8:
-    VMOVDQU64 (AX)(SI*8), Z0
+testAscending7:
+    VMOVDQU64 (R8)(SI*8), Z0
     VMOVDQU64 Z2, Z1
     VPERMI2Q Z0, Z0, Z1
     VPCMPUQ $2, Z1, Z0, K1
     KORTESTB K2, K1
-    JNC testDescending8
-    ADDQ $8, SI
-    CMPQ SI, DX
-    JNE testAscending8
+    JNC testDescending7
+    ADDQ $7, SI
+    CMPQ SI, AX
+    JNE testAscending7
     VZEROUPPER
     JMP testAscending
-testDescending8:
-    VMOVDQU64 (AX)(DI*8), Z0
+testDescending7:
+    VMOVDQU64 (R8)(DI*8), Z0
     VMOVDQU64 Z2, Z1
     VPERMI2Q Z0, Z0, Z1
     VPCMPUQ $5, Z1, Z0, K1
     KORTESTB K2, K1
-    JNC undefined8
-    ADDQ $8, DI
-    CMPQ DI, DX
-    JNE testDescending8
+    JNC undefined7
+    ADDQ $7, DI
+    CMPQ DI, AX
+    JNE testDescending7
     VZEROUPPER
     JMP testDescending
 
 test:
-    DECQ CX
+    DECQ R9
 testAscending:
-    CMPQ SI, CX
+    CMPQ SI, R9
     JAE ascending
-    MOVQ (AX)(SI*8), BX
-    MOVQ 8(AX)(SI*8), DX
+    MOVQ (R8)(SI*8), BX
+    MOVQ 8(R8)(SI*8), DX
     INCQ SI
     CMPQ BX, DX
     JBE testAscending
@@ -325,10 +341,10 @@ ascending:
     MOVQ $ASCENDING, ret+24(FP)
     RET
 testDescending:
-    CMPQ DI, CX
+    CMPQ DI, R9
     JAE descending
-    MOVQ (AX)(DI*8), BX
-    MOVQ 8(AX)(DI*8), DX
+    MOVQ (R8)(DI*8), BX
+    MOVQ 8(R8)(DI*8), DX
     INCQ DI
     CMPQ BX, DX
     JAE testDescending
@@ -336,7 +352,7 @@ testDescending:
 descending:
     MOVQ $DESCENDING, ret+24(FP)
     RET
-undefined8:
+undefined7:
     VZEROUPPER
 undefined:
     MOVQ $UNDEFINED, ret+24(FP)
@@ -344,56 +360,60 @@ undefined:
 
 // func orderOfFloat32(data []float32) int
 TEXT ·orderOfFloat32(SB), NOSPLIT, $-32
-    MOVQ data_base+0(FP), AX
-    MOVQ data_len+8(FP), CX
+    MOVQ data_base+0(FP), R8
+    MOVQ data_len+8(FP), R9
     XORQ SI, SI
     XORQ DI, DI
 
     CMPB ·hasAVX512(SB), $0
     JE test
 
-    CMPQ CX, $16
+    CMPQ R9, $16
     JB test
 
-    MOVQ CX, DX
-    SHRQ $4, DX
-    SHLQ $4, DX
-    DECQ CX
+    XORQ DX, DX
+    MOVQ R9, AX
+    SHRQ $4, AX
+    SHLQ $4, AX
+    MOVQ $15, CX
+    IDIVQ CX
+    IMULQ $15, AX
+    DECQ R9
 
     VMOVDQU32 shift1x32<>(SB), Z2
     KXORW K2, K2, K2
-testAscending16:
-    VMOVDQU32 (AX)(SI*4), Z0
+testAscending15:
+    VMOVDQU32 (R8)(SI*4), Z0
     VMOVDQU32 Z2, Z1
     VPERMI2D Z0, Z0, Z1
     VCMPPS $2, Z1, Z0, K1
     KORTESTW K2, K1
-    JNC testDescending16
-    ADDQ $16, SI
-    CMPQ SI, DX
-    JNE testAscending16
+    JNC testDescending15
+    ADDQ $15, SI
+    CMPQ SI, AX
+    JNE testAscending15
     VZEROUPPER
     JMP testAscending
-testDescending16:
-    VMOVDQU32 (AX)(DI*4), Z0
+testDescending15:
+    VMOVDQU32 (R8)(DI*4), Z0
     VMOVDQU32 Z2, Z1
     VPERMI2D Z0, Z0, Z1
     VCMPPS $5, Z1, Z0, K1
     KORTESTW K2, K1
-    JNC undefined16
-    ADDQ $16, DI
-    CMPQ DI, DX
-    JNE testDescending16
+    JNC undefined15
+    ADDQ $15, DI
+    CMPQ DI, AX
+    JNE testDescending15
     VZEROUPPER
     JMP testDescending
 
 test:
-    DECQ CX
+    DECQ R9
 testAscending:
-    CMPQ SI, CX
+    CMPQ SI, R9
     JAE ascending
-    MOVLQZX (AX)(SI*4), BX
-    MOVLQZX 4(AX)(SI*4), DX
+    MOVLQZX (R8)(SI*4), BX
+    MOVLQZX 4(R8)(SI*4), DX
     INCQ SI
     MOVQ BX, X0
     MOVQ DX, X1
@@ -404,10 +424,10 @@ ascending:
     MOVQ $ASCENDING, ret+24(FP)
     RET
 testDescending:
-    CMPQ DI, CX
+    CMPQ DI, R9
     JAE descending
-    MOVLQZX (AX)(DI*4), BX
-    MOVLQZX 4(AX)(DI*4), DX
+    MOVLQZX (R8)(DI*4), BX
+    MOVLQZX 4(R8)(DI*4), DX
     INCQ DI
     MOVQ BX, X0
     MOVQ DX, X1
@@ -417,7 +437,7 @@ testDescending:
 descending:
     MOVQ $DESCENDING, ret+24(FP)
     RET
-undefined16:
+undefined15:
     VZEROUPPER
 undefined:
     MOVQ $UNDEFINED, ret+24(FP)
@@ -425,56 +445,60 @@ undefined:
 
 // func orderOfFloat64(data []uint64) int
 TEXT ·orderOfFloat64(SB), NOSPLIT, $-32
-    MOVQ data_base+0(FP), AX
-    MOVQ data_len+8(FP), CX
+    MOVQ data_base+0(FP), R8
+    MOVQ data_len+8(FP), R9
     XORQ SI, SI
     XORQ DI, DI
 
     CMPB ·hasAVX512(SB), $0
     JE test
 
-    CMPQ CX, $8
+    CMPQ R9, $8
     JB test
 
-    MOVQ CX, DX
-    SHRQ $3, DX
-    SHLQ $3, DX
-    DECQ CX
+    XORQ DX, DX
+    MOVQ R9, AX
+    SHRQ $3, AX
+    SHLQ $3, AX
+    MOVQ $7, CX
+    IDIVQ CX
+    IMULQ $7, AX
+    DECQ R9
 
     VMOVDQU64 shift1x64<>(SB), Z2
     KXORB K2, K2, K2
-testAscending8:
-    VMOVDQU64 (AX)(SI*8), Z0
+testAscending7:
+    VMOVDQU64 (R8)(SI*8), Z0
     VMOVDQU64 Z2, Z1
     VPERMI2Q Z0, Z0, Z1
     VCMPPD $2, Z1, Z0, K1
     KORTESTB K2, K1
-    JNC testDescending8
-    ADDQ $8, SI
-    CMPQ SI, DX
-    JNE testAscending8
+    JNC testDescending7
+    ADDQ $7, SI
+    CMPQ SI, AX
+    JNE testAscending7
     VZEROUPPER
     JMP testAscending
-testDescending8:
-    VMOVDQU64 (AX)(DI*8), Z0
+testDescending7:
+    VMOVDQU64 (R8)(DI*8), Z0
     VMOVDQU64 Z2, Z1
     VPERMI2Q Z0, Z0, Z1
     VCMPPD $5, Z1, Z0, K1
     KORTESTB K2, K1
-    JNC undefined8
-    ADDQ $8, DI
-    CMPQ DI, DX
-    JNE testDescending8
+    JNC undefined7
+    ADDQ $7, DI
+    CMPQ DI, AX
+    JNE testDescending7
     VZEROUPPER
     JMP testDescending
 
 test:
-    DECQ CX
+    DECQ R9
 testAscending:
-    CMPQ SI, CX
+    CMPQ SI, R9
     JAE ascending
-    MOVQ (AX)(SI*8), BX
-    MOVQ 8(AX)(SI*8), DX
+    MOVQ (R8)(SI*8), BX
+    MOVQ 8(R8)(SI*8), DX
     INCQ SI
     MOVQ BX, X0
     MOVQ DX, X1
@@ -485,10 +509,10 @@ ascending:
     MOVQ $ASCENDING, ret+24(FP)
     RET
 testDescending:
-    CMPQ DI, CX
+    CMPQ DI, R9
     JAE descending
-    MOVQ (AX)(DI*8), BX
-    MOVQ 8(AX)(DI*8), DX
+    MOVQ (R8)(DI*8), BX
+    MOVQ 8(R8)(DI*8), DX
     INCQ DI
     MOVQ BX, X0
     MOVQ DX, X1
@@ -498,7 +522,7 @@ testDescending:
 descending:
     MOVQ $DESCENDING, ret+24(FP)
     RET
-undefined8:
+undefined7:
     VZEROUPPER
 undefined:
     MOVQ $UNDEFINED, ret+24(FP)

--- a/internal/bits/order_amd64.s
+++ b/internal/bits/order_amd64.s
@@ -1,0 +1,505 @@
+//go:build !purego
+
+#include "textflag.h"
+
+#define UNDEFINED 0
+#define ASCENDING 1
+#define DESCENDING -1
+
+DATA shift1x32<>+0(SB)/4, $1
+DATA shift1x32<>+4(SB)/4, $2
+DATA shift1x32<>+8(SB)/4, $3
+DATA shift1x32<>+12(SB)/4, $4
+DATA shift1x32<>+16(SB)/4, $5
+DATA shift1x32<>+20(SB)/4, $6
+DATA shift1x32<>+24(SB)/4, $7
+DATA shift1x32<>+28(SB)/4, $8
+DATA shift1x32<>+32(SB)/4, $9
+DATA shift1x32<>+36(SB)/4, $10
+DATA shift1x32<>+40(SB)/4, $11
+DATA shift1x32<>+44(SB)/4, $12
+DATA shift1x32<>+48(SB)/4, $13
+DATA shift1x32<>+52(SB)/4, $14
+DATA shift1x32<>+56(SB)/4, $15
+DATA shift1x32<>+60(SB)/4, $15
+GLOBL shift1x32<>(SB), RODATA|NOPTR, $64
+
+DATA shift1x64<>+0(SB)/4, $1
+DATA shift1x64<>+8(SB)/4, $2
+DATA shift1x64<>+16(SB)/4, $3
+DATA shift1x64<>+24(SB)/4, $4
+DATA shift1x64<>+32(SB)/4, $5
+DATA shift1x64<>+40(SB)/4, $6
+DATA shift1x64<>+48(SB)/4, $7
+DATA shift1x64<>+56(SB)/4, $7
+GLOBL shift1x64<>(SB), RODATA|NOPTR, $64
+
+// func orderOfInt32(data []int32) int
+TEXT ·orderOfInt32(SB), NOSPLIT, $-32
+    MOVQ data_base+0(FP), AX
+    MOVQ data_len+8(FP), CX
+    XORQ SI, SI
+    XORQ DI, DI
+
+    CMPB ·hasAVX512(SB), $0
+    JE test
+
+    CMPQ CX, $16
+    JB test
+
+    MOVQ CX, DX
+    SHRQ $4, DX
+    SHLQ $4, DX
+    DECQ CX
+
+    VMOVDQU32 shift1x32<>(SB), Z2
+    KXORW K2, K2, K2
+testAscending16:
+    VMOVDQU32 (AX)(SI*4), Z0
+    VMOVDQU32 Z2, Z1
+    VPERMI2D Z0, Z0, Z1
+    VPCMPD $2, Z1, Z0, K1
+    KORTESTW K2, K1
+    JNC testDescending16
+    ADDQ $16, SI
+    CMPQ SI, DX
+    JNE testAscending16
+    VZEROUPPER
+    JMP testAscending
+testDescending16:
+    VMOVDQU32 (AX)(DI*4), Z0
+    VMOVDQU32 Z2, Z1
+    VPERMI2D Z0, Z0, Z1
+    VPCMPD $5, Z1, Z0, K1
+    KORTESTW K2, K1
+    JNC undefined16
+    ADDQ $16, DI
+    CMPQ DI, DX
+    JNE testDescending16
+    VZEROUPPER
+    JMP testDescending
+
+test:
+    DECQ CX
+testAscending:
+    CMPQ SI, CX
+    JAE ascending
+    MOVL (AX)(SI*4), BX
+    MOVL 4(AX)(SI*4), DX
+    INCQ SI
+    CMPL BX, DX
+    JLE testAscending
+    JMP testDescending
+ascending:
+    MOVQ $ASCENDING, ret+24(FP)
+    RET
+testDescending:
+    CMPQ DI, CX
+    JAE descending
+    MOVL (AX)(DI*4), BX
+    MOVL 4(AX)(DI*4), DX
+    INCQ DI
+    CMPL BX, DX
+    JGE testDescending
+    JMP undefined
+descending:
+    MOVQ $DESCENDING, ret+24(FP)
+    RET
+undefined16:
+    VZEROUPPER
+undefined:
+    MOVQ $UNDEFINED, ret+24(FP)
+    RET
+
+// func orderOfInt64(data []int64) int
+TEXT ·orderOfInt64(SB), NOSPLIT, $-32
+    MOVQ data_base+0(FP), AX
+    MOVQ data_len+8(FP), CX
+    XORQ SI, SI
+    XORQ DI, DI
+
+    CMPB ·hasAVX512(SB), $0
+    JE test
+
+    CMPQ CX, $8
+    JB test
+
+    MOVQ CX, DX
+    SHRQ $3, DX
+    SHLQ $3, DX
+    DECQ CX
+
+    VMOVDQU64 shift1x64<>(SB), Z2
+    KXORB K2, K2, K2
+testAscending8:
+    VMOVDQU64 (AX)(SI*8), Z0
+    VMOVDQU64 Z2, Z1
+    VPERMI2Q Z0, Z0, Z1
+    VPCMPQ $2, Z1, Z0, K1
+    KORTESTB K2, K1
+    JNC testDescending8
+    ADDQ $8, SI
+    CMPQ SI, DX
+    JNE testAscending8
+    VZEROUPPER
+    JMP testAscending
+testDescending8:
+    VMOVDQU64 (AX)(DI*8), Z0
+    VMOVDQU64 Z2, Z1
+    VPERMI2Q Z0, Z0, Z1
+    VPCMPQ $5, Z1, Z0, K1
+    KORTESTB K2, K1
+    JNC undefined8
+    ADDQ $8, DI
+    CMPQ DI, DX
+    JNE testDescending8
+    VZEROUPPER
+    JMP testDescending
+
+test:
+    DECQ CX
+testAscending:
+    CMPQ SI, CX
+    JAE ascending
+    MOVQ (AX)(SI*8), BX
+    MOVQ 8(AX)(SI*8), DX
+    INCQ SI
+    CMPQ BX, DX
+    JLE testAscending
+    JMP testDescending
+ascending:
+    MOVQ $ASCENDING, ret+24(FP)
+    RET
+testDescending:
+    CMPQ DI, CX
+    JAE descending
+    MOVQ (AX)(DI*8), BX
+    MOVQ 8(AX)(DI*8), DX
+    INCQ DI
+    CMPQ BX, DX
+    JGE testDescending
+    JMP undefined
+descending:
+    MOVQ $DESCENDING, ret+24(FP)
+    RET
+undefined8:
+    VZEROUPPER
+undefined:
+    MOVQ $UNDEFINED, ret+24(FP)
+    RET
+
+// func orderOfUint32(data []uint32) int
+TEXT ·orderOfUint32(SB), NOSPLIT, $-32
+    MOVQ data_base+0(FP), AX
+    MOVQ data_len+8(FP), CX
+    XORQ SI, SI
+    XORQ DI, DI
+
+    CMPB ·hasAVX512(SB), $0
+    JE test
+
+    CMPQ CX, $16
+    JB test
+
+    MOVQ CX, DX
+    SHRQ $4, DX
+    SHLQ $4, DX
+    DECQ CX
+
+    VMOVDQU32 shift1x32<>(SB), Z2
+    KXORW K2, K2, K2
+testAscending16:
+    VMOVDQU32 (AX)(SI*4), Z0
+    VMOVDQU32 Z2, Z1
+    VPERMI2D Z0, Z0, Z1
+    VPCMPUD $2, Z1, Z0, K1
+    KORTESTW K2, K1
+    JNC testDescending16
+    ADDQ $16, SI
+    CMPQ SI, DX
+    JNE testAscending16
+    VZEROUPPER
+    JMP testAscending
+testDescending16:
+    VMOVDQU32 (AX)(DI*4), Z0
+    VMOVDQU32 Z2, Z1
+    VPERMI2D Z0, Z0, Z1
+    VPCMPUD $5, Z1, Z0, K1
+    KORTESTW K2, K1
+    JNC undefined16
+    ADDQ $16, DI
+    CMPQ DI, DX
+    JNE testDescending16
+    VZEROUPPER
+    JMP testDescending
+
+test:
+    DECQ CX
+testAscending:
+    CMPQ SI, CX
+    JAE ascending
+    MOVL (AX)(SI*4), BX
+    MOVL 4(AX)(SI*4), DX
+    INCQ SI
+    CMPL BX, DX
+    JBE testAscending
+    JMP testDescending
+ascending:
+    MOVQ $ASCENDING, ret+24(FP)
+    RET
+testDescending:
+    CMPQ DI, CX
+    JAE descending
+    MOVL (AX)(DI*4), BX
+    MOVL 4(AX)(DI*4), DX
+    INCQ DI
+    CMPL BX, DX
+    JAE testDescending
+    JMP undefined
+descending:
+    MOVQ $DESCENDING, ret+24(FP)
+    RET
+undefined16:
+    VZEROUPPER
+undefined:
+    MOVQ $UNDEFINED, ret+24(FP)
+    RET
+
+// func orderOfUint64(data []uint64) int
+TEXT ·orderOfUint64(SB), NOSPLIT, $-32
+    MOVQ data_base+0(FP), AX
+    MOVQ data_len+8(FP), CX
+    XORQ SI, SI
+    XORQ DI, DI
+
+    CMPB ·hasAVX512(SB), $0
+    JE test
+
+    CMPQ CX, $8
+    JB test
+
+    MOVQ CX, DX
+    SHRQ $3, DX
+    SHLQ $3, DX
+    DECQ CX
+
+    VMOVDQU64 shift1x64<>(SB), Z2
+    KXORB K2, K2, K2
+testAscending8:
+    VMOVDQU64 (AX)(SI*8), Z0
+    VMOVDQU64 Z2, Z1
+    VPERMI2Q Z0, Z0, Z1
+    VPCMPUQ $2, Z1, Z0, K1
+    KORTESTB K2, K1
+    JNC testDescending8
+    ADDQ $8, SI
+    CMPQ SI, DX
+    JNE testAscending8
+    VZEROUPPER
+    JMP testAscending
+testDescending8:
+    VMOVDQU64 (AX)(DI*8), Z0
+    VMOVDQU64 Z2, Z1
+    VPERMI2Q Z0, Z0, Z1
+    VPCMPUQ $5, Z1, Z0, K1
+    KORTESTB K2, K1
+    JNC undefined8
+    ADDQ $8, DI
+    CMPQ DI, DX
+    JNE testDescending8
+    VZEROUPPER
+    JMP testDescending
+
+test:
+    DECQ CX
+testAscending:
+    CMPQ SI, CX
+    JAE ascending
+    MOVQ (AX)(SI*8), BX
+    MOVQ 8(AX)(SI*8), DX
+    INCQ SI
+    CMPQ BX, DX
+    JBE testAscending
+    JMP testDescending
+ascending:
+    MOVQ $ASCENDING, ret+24(FP)
+    RET
+testDescending:
+    CMPQ DI, CX
+    JAE descending
+    MOVQ (AX)(DI*8), BX
+    MOVQ 8(AX)(DI*8), DX
+    INCQ DI
+    CMPQ BX, DX
+    JAE testDescending
+    JMP undefined
+descending:
+    MOVQ $DESCENDING, ret+24(FP)
+    RET
+undefined8:
+    VZEROUPPER
+undefined:
+    MOVQ $UNDEFINED, ret+24(FP)
+    RET
+
+// func orderOfFloat32(data []float32) int
+TEXT ·orderOfFloat32(SB), NOSPLIT, $-32
+    MOVQ data_base+0(FP), AX
+    MOVQ data_len+8(FP), CX
+    XORQ SI, SI
+    XORQ DI, DI
+
+    CMPB ·hasAVX512(SB), $0
+    JE test
+
+    CMPQ CX, $16
+    JB test
+
+    MOVQ CX, DX
+    SHRQ $4, DX
+    SHLQ $4, DX
+    DECQ CX
+
+    VMOVDQU32 shift1x32<>(SB), Z2
+    KXORW K2, K2, K2
+testAscending16:
+    VMOVDQU32 (AX)(SI*4), Z0
+    VMOVDQU32 Z2, Z1
+    VPERMI2D Z0, Z0, Z1
+    VCMPPS $2, Z1, Z0, K1
+    KORTESTW K2, K1
+    JNC testDescending16
+    ADDQ $16, SI
+    CMPQ SI, DX
+    JNE testAscending16
+    VZEROUPPER
+    JMP testAscending
+testDescending16:
+    VMOVDQU32 (AX)(DI*4), Z0
+    VMOVDQU32 Z2, Z1
+    VPERMI2D Z0, Z0, Z1
+    VCMPPS $5, Z1, Z0, K1
+    KORTESTW K2, K1
+    JNC undefined16
+    ADDQ $16, DI
+    CMPQ DI, DX
+    JNE testDescending16
+    VZEROUPPER
+    JMP testDescending
+
+test:
+    DECQ CX
+testAscending:
+    CMPQ SI, CX
+    JAE ascending
+    MOVLQZX (AX)(SI*4), BX
+    MOVLQZX 4(AX)(SI*4), DX
+    INCQ SI
+    MOVQ BX, X0
+    MOVQ DX, X1
+    UCOMISS X1, X0
+    JBE testAscending
+    JMP testDescending
+ascending:
+    MOVQ $ASCENDING, ret+24(FP)
+    RET
+testDescending:
+    CMPQ DI, CX
+    JAE descending
+    MOVLQZX (AX)(DI*4), BX
+    MOVLQZX 4(AX)(DI*4), DX
+    INCQ DI
+    MOVQ BX, X0
+    MOVQ DX, X1
+    UCOMISS X1, X0
+    JAE testDescending
+    JMP undefined
+descending:
+    MOVQ $DESCENDING, ret+24(FP)
+    RET
+undefined16:
+    VZEROUPPER
+undefined:
+    MOVQ $UNDEFINED, ret+24(FP)
+    RET
+
+// func orderOfFloat64(data []uint64) int
+TEXT ·orderOfFloat64(SB), NOSPLIT, $-32
+    MOVQ data_base+0(FP), AX
+    MOVQ data_len+8(FP), CX
+    XORQ SI, SI
+    XORQ DI, DI
+
+    CMPB ·hasAVX512(SB), $0
+    JE test
+
+    CMPQ CX, $8
+    JB test
+
+    MOVQ CX, DX
+    SHRQ $3, DX
+    SHLQ $3, DX
+    DECQ CX
+
+    VMOVDQU64 shift1x64<>(SB), Z2
+    KXORB K2, K2, K2
+testAscending8:
+    VMOVDQU64 (AX)(SI*8), Z0
+    VMOVDQU64 Z2, Z1
+    VPERMI2Q Z0, Z0, Z1
+    VCMPPD $2, Z1, Z0, K1
+    KORTESTB K2, K1
+    JNC testDescending8
+    ADDQ $8, SI
+    CMPQ SI, DX
+    JNE testAscending8
+    VZEROUPPER
+    JMP testAscending
+testDescending8:
+    VMOVDQU64 (AX)(DI*8), Z0
+    VMOVDQU64 Z2, Z1
+    VPERMI2Q Z0, Z0, Z1
+    VCMPPD $5, Z1, Z0, K1
+    KORTESTB K2, K1
+    JNC undefined8
+    ADDQ $8, DI
+    CMPQ DI, DX
+    JNE testDescending8
+    VZEROUPPER
+    JMP testDescending
+
+test:
+    DECQ CX
+testAscending:
+    CMPQ SI, CX
+    JAE ascending
+    MOVQ (AX)(SI*8), BX
+    MOVQ 8(AX)(SI*8), DX
+    INCQ SI
+    MOVQ BX, X0
+    MOVQ DX, X1
+    UCOMISD X1, X0
+    JBE testAscending
+    JMP testDescending
+ascending:
+    MOVQ $ASCENDING, ret+24(FP)
+    RET
+testDescending:
+    CMPQ DI, CX
+    JAE descending
+    MOVQ (AX)(DI*8), BX
+    MOVQ 8(AX)(DI*8), DX
+    INCQ DI
+    MOVQ BX, X0
+    MOVQ DX, X1
+    UCOMISD X1, X0
+    JAE testDescending
+    JMP undefined
+descending:
+    MOVQ $DESCENDING, ret+24(FP)
+    RET
+undefined8:
+    VZEROUPPER
+undefined:
+    MOVQ $UNDEFINED, ret+24(FP)
+    RET

--- a/internal/bits/order_default.go
+++ b/internal/bits/order_default.go
@@ -1,0 +1,175 @@
+//go:build purego || !amd64
+
+package bits
+
+// generics please! :'(
+
+func orderOfInt32(data []int32) int {
+	if int32AreInAscendingOrder(data) {
+		return +1
+	}
+	if int32AreInDescendingOrder(data) {
+		return -1
+	}
+	return 0
+}
+
+func orderOfInt64(data []int64) int {
+	if int64AreInAscendingOrder(data) {
+		return +1
+	}
+	if int64AreInDescendingOrder(data) {
+		return -1
+	}
+	return 0
+}
+
+func orderOfUint32(data []uint32) int {
+	if len(data) > 0 {
+		if uint32AreInAscendingOrder(data) {
+			return +1
+		}
+		if uint32AreInDescendingOrder(data) {
+			return -1
+		}
+	}
+	return 0
+}
+
+func orderOfUint64(data []uint64) int {
+	if uint64AreInAscendingOrder(data) {
+		return +1
+	}
+	if uint64AreInDescendingOrder(data) {
+		return -1
+	}
+	return 0
+}
+
+func orderOfFloat32(data []float32) int {
+	if float32AreInAscendingOrder(data) {
+		return +1
+	}
+	if float32AreInDescendingOrder(data) {
+		return -1
+	}
+	return 0
+}
+
+func orderOfFloat64(data []float64) int {
+	if float64AreInAscendingOrder(data) {
+		return +1
+	}
+	if float64AreInDescendingOrder(data) {
+		return -1
+	}
+	return 0
+}
+
+func int32AreInAscendingOrder(data []int32) bool {
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i-1] > data[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func int32AreInDescendingOrder(data []int32) bool {
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i-1] < data[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func int64AreInAscendingOrder(data []int64) bool {
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i-1] > data[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func int64AreInDescendingOrder(data []int64) bool {
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i-1] < data[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func uint32AreInAscendingOrder(data []uint32) bool {
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i-1] > data[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func uint32AreInDescendingOrder(data []uint32) bool {
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i-1] < data[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func uint64AreInAscendingOrder(data []uint64) bool {
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i-1] > data[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func uint64AreInDescendingOrder(data []uint64) bool {
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i-1] < data[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func float32AreInAscendingOrder(data []float32) bool {
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i-1] > data[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func float32AreInDescendingOrder(data []float32) bool {
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i-1] < data[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func float64AreInAscendingOrder(data []float64) bool {
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i-1] > data[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func float64AreInDescendingOrder(data []float64) bool {
+	for i := len(data) - 1; i > 0; i-- {
+		if data[i-1] < data[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/bits/order_test.go
+++ b/internal/bits/order_test.go
@@ -236,7 +236,7 @@ func TestOrderOfUint32(t *testing.T) {
 	}
 
 	if !check(values) {
-		t.Error("failed due to not checking the connection between sequences of of 16 elements")
+		t.Error("failed due to not checking the connection between sequences of 16 elements")
 	}
 }
 

--- a/internal/bits/order_test.go
+++ b/internal/bits/order_test.go
@@ -202,7 +202,7 @@ func TestOrderOfInt64(t *testing.T) {
 	}
 
 	if !check(values) {
-		t.Error("failed due to not checking the connection between sequences of of 8 elements")
+		t.Error("failed due to not checking the connection between sequences of 8 elements")
 	}
 }
 

--- a/internal/bits/order_test.go
+++ b/internal/bits/order_test.go
@@ -1,0 +1,329 @@
+package bits_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/segmentio/parquet-go/internal/bits"
+)
+
+type boolOrder []bool
+
+func (v boolOrder) Len() int           { return len(v) }
+func (v boolOrder) Less(i, j int) bool { return !v[i] && v[j] }
+func (v boolOrder) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
+
+type int32Order []int32
+
+func (v int32Order) Len() int           { return len(v) }
+func (v int32Order) Less(i, j int) bool { return v[i] < v[j] }
+func (v int32Order) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
+
+type int64Order []int64
+
+func (v int64Order) Len() int           { return len(v) }
+func (v int64Order) Less(i, j int) bool { return v[i] < v[j] }
+func (v int64Order) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
+
+type uint32Order []uint32
+
+func (v uint32Order) Len() int           { return len(v) }
+func (v uint32Order) Less(i, j int) bool { return v[i] < v[j] }
+func (v uint32Order) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
+
+type uint64Order []uint64
+
+func (v uint64Order) Len() int           { return len(v) }
+func (v uint64Order) Less(i, j int) bool { return v[i] < v[j] }
+func (v uint64Order) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
+
+type float32Order []float32
+
+func (v float32Order) Len() int           { return len(v) }
+func (v float32Order) Less(i, j int) bool { return v[i] < v[j] }
+func (v float32Order) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
+
+type float64Order []float64
+
+func (v float64Order) Len() int           { return len(v) }
+func (v float64Order) Less(i, j int) bool { return v[i] < v[j] }
+func (v float64Order) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
+
+const (
+	ascending  = "ascending"
+	descending = "descending"
+	undefined  = "undefined"
+)
+
+func orderingName(ordering int) string {
+	switch {
+	case isAscending(ordering):
+		return ascending
+	case isDescending(ordering):
+		return descending
+	default:
+		return undefined
+	}
+}
+
+func isAscending(ordering int) bool {
+	return ordering > 0
+}
+
+func isDescending(ordering int) bool {
+	return ordering < 0
+}
+
+func isUndefined(ordering int) bool {
+	return ordering == 0
+}
+
+func isSorted(set sort.Interface) bool {
+	return set.Len() > 0 && sort.IsSorted(set)
+}
+
+func checkOrdering(t *testing.T, set sort.Interface, ordering int) bool {
+	t.Helper()
+	switch {
+	case isSorted(set):
+		if !isAscending(ordering) {
+			t.Errorf("got=%s want=%s", orderingName(ordering), ascending)
+			return false
+		}
+	case isSorted(sort.Reverse(set)):
+		if !isDescending(ordering) {
+			t.Errorf("got=%s want=%s", orderingName(ordering), descending)
+			return false
+		}
+	default:
+		if !isUndefined(ordering) {
+			t.Errorf("got=%s want=%s", orderingName(ordering), undefined)
+			return false
+		}
+	}
+	return true
+}
+
+func TestOrderOfBool(t *testing.T) {
+	check := func(values []bool) bool {
+		return checkOrdering(t, boolOrder(values), bits.OrderOfBool(values))
+	}
+	err := quickCheck(func(values []bool) bool {
+		if !check(values) {
+			return false
+		}
+		sort.Sort(boolOrder(values))
+		if !check(values) {
+			return false
+		}
+		sort.Sort(sort.Reverse(boolOrder(values)))
+		if !check(values) {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestOrderOfInt32(t *testing.T) {
+	check := func(values []int32) bool {
+		return checkOrdering(t, int32Order(values), bits.OrderOfInt32(values))
+	}
+	err := quickCheck(func(values []int32) bool {
+		if !check(values) {
+			return false
+		}
+		sort.Sort(int32Order(values))
+		if !check(values) {
+			return false
+		}
+		sort.Sort(sort.Reverse(int32Order(values)))
+		if !check(values) {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestOrderOfInt64(t *testing.T) {
+	check := func(values []int64) bool {
+		return checkOrdering(t, int64Order(values), bits.OrderOfInt64(values))
+	}
+	err := quickCheck(func(values []int64) bool {
+		if !check(values) {
+			return false
+		}
+		sort.Sort(int64Order(values))
+		if !check(values) {
+			return false
+		}
+		sort.Sort(sort.Reverse(int64Order(values)))
+		if !check(values) {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestOrderOfUint32(t *testing.T) {
+	check := func(values []uint32) bool {
+		return checkOrdering(t, uint32Order(values), bits.OrderOfUint32(values))
+	}
+	err := quickCheck(func(values []uint32) bool {
+		if !check(values) {
+			return false
+		}
+		sort.Sort(uint32Order(values))
+		if !check(values) {
+			return false
+		}
+		sort.Sort(sort.Reverse(uint32Order(values)))
+		if !check(values) {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestOrderOfUint64(t *testing.T) {
+	check := func(values []uint64) bool {
+		return checkOrdering(t, uint64Order(values), bits.OrderOfUint64(values))
+	}
+	err := quickCheck(func(values []uint64) bool {
+		if !check(values) {
+			return false
+		}
+		sort.Sort(uint64Order(values))
+		if !check(values) {
+			return false
+		}
+		sort.Sort(sort.Reverse(uint64Order(values)))
+		if !check(values) {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestOrderOfFloat32(t *testing.T) {
+	check := func(values []float32) bool {
+		return checkOrdering(t, float32Order(values), bits.OrderOfFloat32(values))
+	}
+	err := quickCheck(func(values []float32) bool {
+		if !check(values) {
+			return false
+		}
+		sort.Sort(float32Order(values))
+		if !check(values) {
+			return false
+		}
+		sort.Sort(sort.Reverse(float32Order(values)))
+		if !check(values) {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestOrderOfFloat64(t *testing.T) {
+	check := func(values []float64) bool {
+		return checkOrdering(t, float64Order(values), bits.OrderOfFloat64(values))
+	}
+	err := quickCheck(func(values []float64) bool {
+		if !check(values) {
+			return false
+		}
+		sort.Sort(float64Order(values))
+		if !check(values) {
+			return false
+		}
+		sort.Sort(sort.Reverse(float64Order(values)))
+		if !check(values) {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkOrderOfBool(b *testing.B) {
+	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
+		values := make([]bool, bufferSize/1)
+		for i := 0; i < b.N; i++ {
+			bits.OrderOfBool(values)
+		}
+	})
+}
+
+func BenchmarkOrderOfInt32(b *testing.B) {
+	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
+		values := make([]int32, bufferSize/1)
+		for i := 0; i < b.N; i++ {
+			bits.OrderOfInt32(values)
+		}
+	})
+}
+
+func BenchmarkOrderOfInt64(b *testing.B) {
+	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
+		values := make([]int64, bufferSize/1)
+		for i := 0; i < b.N; i++ {
+			bits.OrderOfInt64(values)
+		}
+	})
+}
+
+func BenchmarkOrderOfUint32(b *testing.B) {
+	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
+		values := make([]uint32, bufferSize/1)
+		for i := 0; i < b.N; i++ {
+			bits.OrderOfUint32(values)
+		}
+	})
+}
+
+func BenchmarkOrderOfUint64(b *testing.B) {
+	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
+		values := make([]uint64, bufferSize/1)
+		for i := 0; i < b.N; i++ {
+			bits.OrderOfUint64(values)
+		}
+	})
+}
+
+func BenchmarkOrderOfFloat32(b *testing.B) {
+	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
+		values := make([]float32, bufferSize/1)
+		for i := 0; i < b.N; i++ {
+			bits.OrderOfFloat32(values)
+		}
+	})
+}
+
+func BenchmarkOrderOfFloat64(b *testing.B) {
+	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
+		values := make([]float64, bufferSize/1)
+		for i := 0; i < b.N; i++ {
+			bits.OrderOfFloat64(values)
+		}
+	})
+}

--- a/internal/bits/order_test.go
+++ b/internal/bits/order_test.go
@@ -338,7 +338,7 @@ func TestOrderOfFloat64(t *testing.T) {
 	}
 
 	if !check(values) {
-		t.Error("failed due to not checking the connection between sequences of of 8 elements")
+		t.Error("failed due to not checking the connection between sequences of 8 elements")
 	}
 }
 

--- a/internal/bits/order_test.go
+++ b/internal/bits/order_test.go
@@ -168,7 +168,7 @@ func TestOrderOfInt32(t *testing.T) {
 	}
 
 	if !check(values) {
-		t.Error("failed due to not checking the connection between sequences of of 16 elements")
+		t.Error("failed due to not checking the connection between sequences of 16 elements")
 	}
 }
 

--- a/internal/bits/order_test.go
+++ b/internal/bits/order_test.go
@@ -155,6 +155,21 @@ func TestOrderOfInt32(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	// This extra test validates that out-of-order values at 64 byte boundaries
+	// are properly detected; it tests corner cases of the vectorized code path
+	// which works on 64 bytes per loop iteration.
+	values := []int32{
+		0, 1, 2, 3, 4, 5, 6, 7,
+		8, 9, 10, 11, 12, 13, 14, 15,
+		// 15 > 14, the algorithm must detect that the values are not ordered.
+		14, 17, 18, 19, 20, 21, 22, 23,
+		24, 25, 26, 27, 28, 29, 30, 31,
+	}
+
+	if !check(values) {
+		t.Error("failed due to not checking the connection between sequences of of 16 elements")
+	}
 }
 
 func TestOrderOfInt64(t *testing.T) {
@@ -177,6 +192,17 @@ func TestOrderOfInt64(t *testing.T) {
 	})
 	if err != nil {
 		t.Error(err)
+	}
+
+	values := []int64{
+		0, 1, 2, 3, 4, 5, 6, 7,
+		6, 9, 10, 11, 12, 13, 14, 15,
+		14, 17, 18, 19, 20, 21, 22, 23,
+		24, 25, 26, 27, 28, 29, 30, 31,
+	}
+
+	if !check(values) {
+		t.Error("failed due to not checking the connection between sequences of of 8 elements")
 	}
 }
 
@@ -201,6 +227,17 @@ func TestOrderOfUint32(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	values := []uint32{
+		0, 1, 2, 3, 4, 5, 6, 7,
+		8, 9, 10, 11, 12, 13, 14, 15,
+		14, 17, 18, 19, 20, 21, 22, 23,
+		24, 25, 26, 27, 28, 29, 30, 31,
+	}
+
+	if !check(values) {
+		t.Error("failed due to not checking the connection between sequences of of 16 elements")
+	}
 }
 
 func TestOrderOfUint64(t *testing.T) {
@@ -223,6 +260,17 @@ func TestOrderOfUint64(t *testing.T) {
 	})
 	if err != nil {
 		t.Error(err)
+	}
+
+	values := []uint64{
+		0, 1, 2, 3, 4, 5, 6, 7,
+		6, 9, 10, 11, 12, 13, 14, 15,
+		14, 17, 18, 19, 20, 21, 22, 23,
+		24, 25, 26, 27, 28, 29, 30, 31,
+	}
+
+	if !check(values) {
+		t.Error("failed due to not checking the connection between sequences of of 8 elements")
 	}
 }
 
@@ -247,6 +295,17 @@ func TestOrderOfFloat32(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	values := []float32{
+		0, 1, 2, 3, 4, 5, 6, 7,
+		8, 9, 10, 11, 12, 13, 14, 15,
+		14, 17, 18, 19, 20, 21, 22, 23,
+		24, 25, 26, 27, 28, 29, 30, 31,
+	}
+
+	if !check(values) {
+		t.Error("failed due to not checking the connection between sequences of of 16 elements")
+	}
 }
 
 func TestOrderOfFloat64(t *testing.T) {
@@ -269,6 +328,17 @@ func TestOrderOfFloat64(t *testing.T) {
 	})
 	if err != nil {
 		t.Error(err)
+	}
+
+	values := []float64{
+		0, 1, 2, 3, 4, 5, 6, 7,
+		6, 9, 10, 11, 12, 13, 14, 15,
+		14, 17, 18, 19, 20, 21, 22, 23,
+		24, 25, 26, 27, 28, 29, 30, 31,
+	}
+
+	if !check(values) {
+		t.Error("failed due to not checking the connection between sequences of of 8 elements")
 	}
 }
 

--- a/internal/bits/order_test.go
+++ b/internal/bits/order_test.go
@@ -270,7 +270,7 @@ func TestOrderOfUint64(t *testing.T) {
 	}
 
 	if !check(values) {
-		t.Error("failed due to not checking the connection between sequences of of 8 elements")
+		t.Error("failed due to not checking the connection between sequences of 8 elements")
 	}
 }
 

--- a/internal/bits/order_test.go
+++ b/internal/bits/order_test.go
@@ -304,7 +304,7 @@ func TestOrderOfFloat32(t *testing.T) {
 	}
 
 	if !check(values) {
-		t.Error("failed due to not checking the connection between sequences of of 16 elements")
+		t.Error("failed due to not checking the connection between sequences of 16 elements")
 	}
 }
 


### PR DESCRIPTION
Continuing progress on the work initiated in #59 and #59, this PR adds optimizations for other routines operating on arrays of fixed-size values:

```
name                    old time/op    new time/op     delta
OrderOfBool/4KiB          90.7ns ± 0%     90.5ns ± 0%    -0.21%  (p=0.004 n=10+10)
OrderOfBool/256KiB        6.65µs ± 0%     6.65µs ± 0%      ~     (p=0.646 n=10+9)
OrderOfBool/2048KiB       66.7µs ± 5%     67.1µs ± 4%      ~     (p=0.631 n=10+10)
OrderOfInt32/4KiB         1.40µs ± 0%     0.18µs ± 0%   -87.16%  (p=0.000 n=9+9)
OrderOfInt32/256KiB       92.9µs ± 1%     21.9µs ± 1%   -76.45%  (p=0.000 n=10+10)
OrderOfInt32/2048KiB       738µs ± 2%      275µs ± 5%   -62.72%  (p=0.000 n=10+10)
OrderOfInt64/4KiB         1.40µs ± 1%     0.37µs ± 0%   -73.52%  (p=0.000 n=10+8)
OrderOfInt64/256KiB        104µs ± 3%       65µs ± 2%   -37.19%  (p=0.000 n=10+9)
OrderOfInt64/2048KiB      1.31ms ±15%     0.55ms ± 5%   -57.59%  (p=0.000 n=10+10)
OrderOfUint32/4KiB        1.40µs ± 0%     0.18µs ± 1%   -87.16%  (p=0.000 n=10+10)
OrderOfUint32/256KiB      94.5µs ± 1%     23.6µs ± 1%   -75.02%  (p=0.000 n=10+10)
OrderOfUint32/2048KiB      730µs ± 1%      268µs ± 8%   -63.24%  (p=0.000 n=9+10)
OrderOfUint64/4KiB        1.40µs ± 1%     0.37µs ± 1%   -73.46%  (p=0.000 n=9+10)
OrderOfUint64/256KiB       105µs ± 2%       65µs ± 8%   -37.68%  (p=0.000 n=10+10)
OrderOfUint64/2048KiB     1.31ms ±21%     0.55ms ± 7%   -57.55%  (p=0.000 n=10+10)
OrderOfFloat32/4KiB       1.90µs ± 0%     0.18µs ± 1%   -90.59%  (p=0.000 n=9+9)
OrderOfFloat32/256KiB      122µs ± 0%       24µs ± 2%   -80.43%  (p=0.000 n=9+10)
OrderOfFloat32/2048KiB    1.01ms ± 2%     0.27ms ± 5%   -73.24%  (p=0.000 n=10+10)
OrderOfFloat64/4KiB       1.90µs ± 0%     0.37µs ± 1%   -80.46%  (p=0.000 n=6+10)
OrderOfFloat64/256KiB      128µs ± 1%       65µs ± 5%   -49.27%  (p=0.000 n=10+10)
OrderOfFloat64/2048KiB    1.46ms ±21%     0.56ms ± 5%   -61.46%  (p=0.000 n=10+10)
OrderOfBytes/4KiB          851ns ± 1%      772ns ± 0%    -9.20%  (p=0.000 n=10+10)
OrderOfBytes/256KiB       53.7µs ± 0%     49.2µs ± 1%    -8.39%  (p=0.000 n=10+10)
OrderOfBytes/2048KiB       434µs ± 0%      397µs ± 1%    -8.46%  (p=0.000 n=9+10)

name                    old speed      new speed       delta
OrderOfBool/4KiB        45.2GB/s ± 0%   45.3GB/s ± 0%    +0.21%  (p=0.005 n=10+10)
OrderOfBool/256KiB      39.4GB/s ± 0%   39.4GB/s ± 0%      ~     (p=0.661 n=10+9)
OrderOfBool/2048KiB     31.5GB/s ± 5%   31.3GB/s ± 5%      ~     (p=0.631 n=10+10)
OrderOfInt32/4KiB       2.93GB/s ± 0%  22.86GB/s ± 0%  +678.99%  (p=0.000 n=9+9)
OrderOfInt32/256KiB     2.82GB/s ± 1%  11.98GB/s ± 1%  +324.56%  (p=0.000 n=10+10)
OrderOfInt32/2048KiB    2.84GB/s ± 2%   7.63GB/s ± 5%  +168.39%  (p=0.000 n=10+10)
OrderOfInt64/4KiB       2.93GB/s ± 1%  11.07GB/s ± 0%  +277.71%  (p=0.000 n=10+8)
OrderOfInt64/256KiB     2.53GB/s ± 3%   4.02GB/s ± 2%   +59.21%  (p=0.000 n=10+9)
OrderOfInt64/2048KiB    1.62GB/s ±17%   3.79GB/s ± 5%  +134.27%  (p=0.000 n=10+10)
OrderOfUint32/4KiB      2.93GB/s ± 0%  22.85GB/s ± 1%  +678.95%  (p=0.000 n=10+10)
OrderOfUint32/256KiB    2.77GB/s ± 1%  11.10GB/s ± 1%  +300.36%  (p=0.000 n=10+10)
OrderOfUint32/2048KiB   2.87GB/s ± 1%   7.83GB/s ± 8%  +172.67%  (p=0.000 n=9+10)
OrderOfUint64/4KiB      2.93GB/s ± 1%  11.03GB/s ± 1%  +276.79%  (p=0.000 n=9+10)
OrderOfUint64/256KiB    2.50GB/s ± 2%   4.02GB/s ± 7%   +60.71%  (p=0.000 n=10+10)
OrderOfUint64/2048KiB   1.63GB/s ±21%   3.79GB/s ± 7%  +131.79%  (p=0.000 n=10+10)
OrderOfFloat32/4KiB     2.15GB/s ± 0%  22.87GB/s ± 1%  +962.98%  (p=0.000 n=9+9)
OrderOfFloat32/256KiB   2.16GB/s ± 0%  11.02GB/s ± 2%  +410.94%  (p=0.000 n=9+10)
OrderOfFloat32/2048KiB  2.07GB/s ± 2%   7.74GB/s ± 5%  +273.99%  (p=0.000 n=10+10)
OrderOfFloat64/4KiB     2.15GB/s ± 0%  11.01GB/s ± 1%  +411.88%  (p=0.000 n=10+10)
OrderOfFloat64/256KiB   2.04GB/s ± 1%   4.03GB/s ± 5%   +97.21%  (p=0.000 n=10+10)
OrderOfFloat64/2048KiB  1.45GB/s ±24%   3.72GB/s ± 5%  +156.28%  (p=0.000 n=10+10)
OrderOfBytes/4KiB       4.82GB/s ± 1%   5.30GB/s ± 0%   +10.12%  (p=0.000 n=10+10)
OrderOfBytes/256KiB     4.89GB/s ± 0%   5.33GB/s ± 1%    +9.16%  (p=0.000 n=10+10)
OrderOfBytes/2048KiB    4.84GB/s ± 0%   5.28GB/s ± 1%    +9.24%  (p=0.000 n=9+10)
```