### PR TITLE
[O11Y-197] fix AVX512BW extension requirements

### DIFF
--- a/internal/bits/bits_amd64.go
+++ b/internal/bits/bits_amd64.go
@@ -9,6 +9,20 @@ var hasAVX512 = cpu.X86.HasAVX512 &&
 var hasAVX512MinMaxBool = hasAVX512 &&
 	cpu.X86.HasAVX512VPOPCNTDQ
 
+// The use AVX-512 instructions in the minBOol algorithm relies operations
+// that are avilable in the AVX512BW extension:
+// * VPCMPUB
+// * KMOVQ
+var hasAVX512MinBool = hasAVX512 &&
+	cpu.X86.HasAVX512BW
+
+// The use AVX-512 instructions in the maxBOol algorithm relies operations
+// that are avilable in the AVX512BW extension:
+// * VPCMPUB
+// * KMOVQ
+var hasAVX512MaxBool = hasAVX512 &&
+	cpu.X86.HasAVX512BW
+
 // The use AVX-512 instructions in the countByte algorithm relies operations
 // that are avilable in the AVX512BW extension:
 // * VPCMPUB

--- a/internal/bits/bits_amd64.go
+++ b/internal/bits/bits_amd64.go
@@ -8,3 +8,13 @@ var hasAVX512 = cpu.X86.HasAVX512 &&
 
 var hasAVX512MinMaxBool = hasAVX512 &&
 	cpu.X86.HasAVX512VPOPCNTDQ
+
+// The use AVX-512 instructions in the countByte algorithm relies operations
+// that are avilable in the AVX512BW extension:
+// * VPCMPUB
+// * KMOVQ
+//
+// Note that the function will fallback to an AVX2 version if those instructions
+// are not available.
+var hasAVX512CountByte = hasAVX512 &&
+	cpu.X86.HasAVX512BW

--- a/internal/bits/bits_amd64.go
+++ b/internal/bits/bits_amd64.go
@@ -23,7 +23,7 @@ var hasAVX512MinBool = hasAVX512 &&
 var hasAVX512MaxBool = hasAVX512 &&
 	cpu.X86.HasAVX512BW
 
-// The use AVX-512 instructions in the countByte algorithm relies operations
+// These use AVX-512 instructions in the countByte algorithm relies operations
 // that are avilable in the AVX512BW extension:
 // * VPCMPUB
 // * KMOVQ

--- a/internal/bits/bits_amd64.go
+++ b/internal/bits/bits_amd64.go
@@ -9,7 +9,7 @@ var hasAVX512 = cpu.X86.HasAVX512 &&
 var hasAVX512MinMaxBool = hasAVX512 &&
 	cpu.X86.HasAVX512VPOPCNTDQ
 
-// The use AVX-512 instructions in the minBOol algorithm relies operations
+// These use AVX-512 instructions in the minBool algorithm relies operations
 // that are avilable in the AVX512BW extension:
 // * VPCMPUB
 // * KMOVQ

--- a/internal/bits/bits_amd64.go
+++ b/internal/bits/bits_amd64.go
@@ -16,7 +16,7 @@ var hasAVX512MinMaxBool = hasAVX512 &&
 var hasAVX512MinBool = hasAVX512 &&
 	cpu.X86.HasAVX512BW
 
-// The use AVX-512 instructions in the maxBOol algorithm relies operations
+// These use AVX-512 instructions in the maxBool algorithm relies operations
 // that are avilable in the AVX512BW extension:
 // * VPCMPUB
 // * KMOVQ

--- a/internal/bits/count_amd64.s
+++ b/internal/bits/count_amd64.s
@@ -22,7 +22,7 @@ TEXT ·countByte(SB), NOSPLIT, $0-40
     XORQ R14, R14
     XORQ R15, R15
 
-    CMPB ·hasAVX512(SB), $0
+    CMPB ·hasAVX512CountByte(SB), $0
     JE initAVX2
 
     CMPQ DX, $256

--- a/internal/bits/count_amd64.s
+++ b/internal/bits/count_amd64.s
@@ -31,7 +31,7 @@ TEXT ·countByte(SB), NOSPLIT, $0-40
     SHRQ $8, DX
     SHLQ $8, DX
     ADDQ AX, DX
-    VPBROADCASTB value+24(FP), Z0
+    VPBROADCASTB BX, Z0
 loopAVX512:
     VMOVDQU64 (AX), Z1
     VMOVDQU64 64(AX), Z2

--- a/internal/bits/max_amd64.h
+++ b/internal/bits/max_amd64.h
@@ -27,17 +27,17 @@
 #define vpmaxu128(srcValues, srcIndexes, maxValues, maxIndexes, K1, K2, R1, R2, R3, M) \
     VPCMPUQ $0, maxValues, srcValues, K1 \
     VPCMPUQ $6, maxValues, srcValues, K2 \
-    KMOVQ K1, R1 \
-    KMOVQ K2, R2 \
-    MOVQ R2, R3 \
-    SHLQ $1, R3 \
-    ANDQ R3, R1 \
-    ORQ R2, R1 \
-    ANDQ M, R1 \
-    MOVQ R1, R2 \
-    SHRQ $1, R2 \
-    ORQ R2, R1 \
-    KMOVQ R1, K1 \
+    KMOVB K1, R1 \
+    KMOVB K2, R2 \
+    MOVB R2, R3 \
+    SHLB $1, R3 \
+    ANDB R3, R1 \
+    ORB R2, R1 \
+    ANDB M, R1 \
+    MOVB R1, R2 \
+    SHRB $1, R2 \
+    ORB R2, R1 \
+    KMOVB R1, K1 \
     VPBLENDMQ srcValues, maxValues, K1, maxValues \
     VPBLENDMQ srcIndexes, maxIndexes, K1, maxIndexes
 
@@ -48,6 +48,6 @@
 // comparison that are performed on each lane of maximum vectors. The upper bits
 // are used to compute results of the operation to determine which of the pairs
 // of quad words representing the 128 bits elements are the maximums.
-#define vpmaxu128mask(M) MOVQ $0b10101010, M
+#define vpmaxu128mask(M) MOVB $0b10101010, M
 
 #endif

--- a/internal/bits/max_amd64.s
+++ b/internal/bits/max_amd64.s
@@ -12,7 +12,7 @@ TEXT ·maxBool(SB), NOSPLIT, $-25
     JE false
     XORQ SI, SI
 
-    CMPB ·hasAVX512(SB), $0
+    CMPB ·hasAVX512MaxBool(SB), $0
     JE loop
 
     CMPQ CX, $128

--- a/internal/bits/min_amd64.h
+++ b/internal/bits/min_amd64.h
@@ -27,17 +27,17 @@
 #define vpminu128(srcValues, srcIndexes, minValues, minIndexes, K1, K2, R1, R2, R3, M) \
     VPCMPUQ $0, minValues, srcValues, K1 \
     VPCMPUQ $1, minValues, srcValues, K2 \
-    KMOVQ K1, R1 \
-    KMOVQ K2, R2 \
-    MOVQ R2, R3 \
-    SHLQ $1, R3 \
-    ANDQ R3, R1 \
-    ORQ R2, R1 \
-    ANDQ M, R1 \
-    MOVQ R1, R2 \
-    SHRQ $1, R2 \
-    ORQ R2, R1 \
-    KMOVQ R1, K1 \
+    KMOVB K1, R1 \
+    KMOVB K2, R2 \
+    MOVB R2, R3 \
+    SHLB $1, R3 \
+    ANDB R3, R1 \
+    ORB R2, R1 \
+    ANDB M, R1 \
+    MOVB R1, R2 \
+    SHRB $1, R2 \
+    ORB R2, R1 \
+    KMOVB R1, K1 \
     VPBLENDMQ srcValues, minValues, K1, minValues \
     VPBLENDMQ srcIndexes, minIndexes, K1, minIndexes
 
@@ -48,6 +48,6 @@
 // comparison that are performed on each lane of minimum vectors. The upper bits
 // are used to compute results of the operation to determines which of the pairs
 // of quad words representing the 128 bits elements are the minimums.
-#define vpminu128mask(M) MOVQ $0b10101010, M
+#define vpminu128mask(M) MOVB $0b10101010, M
 
 #endif

--- a/internal/bits/min_amd64.s
+++ b/internal/bits/min_amd64.s
@@ -12,7 +12,7 @@ TEXT ·minBool(SB), NOSPLIT, $-25
     JE false
     XORQ SI, SI
 
-    CMPB ·hasAVX512(SB), $0
+    CMPB ·hasAVX512MinBool(SB), $0
     JE loop
 
     CMPQ CX, $128


### PR DESCRIPTION
Follow up from #59, this PR fixes the instructions used and feature checks to minimize the reliance on AVX512BW.