### PR TITLE
[O11Y-218] add interfaces to read columns of values from parquet pages

### DIFF
--- a/deprecated/int96.go
+++ b/deprecated/int96.go
@@ -71,6 +71,15 @@ func Int96ToBytes(data []Int96) []byte {
 	return unsafe.Slice(*(**byte)(unsafe.Pointer(&data)), 12*len(data))
 }
 
+// BytesToInt96 converts the byte slice passed as argument to a slice of Int96
+// sharing the same backing array.
+//
+// When the number of bytes in the input is not a multiple of 12, the function
+// truncates it in the returned slice.
+func BytesToInt96(data []byte) []Int96 {
+	return unsafe.Slice(*(**Int96)(unsafe.Pointer(&data)), len(data)/12)
+}
+
 func MaxLenInt96(data []Int96) int {
 	max := 0
 	for i := range data {

--- a/page_test.go
+++ b/page_test.go
@@ -1,0 +1,341 @@
+package parquet_test
+
+import (
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/segmentio/parquet-go"
+	"github.com/segmentio/parquet-go/deprecated"
+	"github.com/segmentio/parquet-go/encoding/plain"
+	"github.com/segmentio/parquet-go/internal/bits"
+)
+
+func TestPage(t *testing.T) {
+	t.Run("BOOLEAN", testPageBoolean)
+	t.Run("INT32", testPageInt32)
+	t.Run("INT64", testPageInt64)
+	t.Run("INT96", testPageInt96)
+	t.Run("FLOAT", testPageFloat)
+	t.Run("DOUBLE", testPageDouble)
+	t.Run("BYTE_ARRAY", testPageByteArray)
+	t.Run("FIXED_LEN_BYTE_ARRAY", testPageFixedLenByteArray)
+}
+
+func testPageBoolean(t *testing.T) {
+	schema := parquet.SchemaOf(struct{ Value bool }{})
+
+	t.Run("io", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []bool{false, true}
+				n, err := w.(io.Writer).Write(bits.BoolToBytes(values))
+				return values[:n], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]bool, 2)
+				n, err := r.(io.Reader).Read(bits.BoolToBytes(values))
+				return values[:n], err
+			},
+		})
+	})
+
+	t.Run("parquet", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []bool{false, true}
+				n, err := w.(parquet.BooleanWriter).WriteBooleans(values)
+				return values[:n], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]bool, 2)
+				n, err := r.(parquet.BooleanReader).ReadBooleans(values)
+				return values[:n], err
+			},
+		})
+	})
+}
+
+func testPageInt32(t *testing.T) {
+	schema := parquet.SchemaOf(struct{ Value int32 }{})
+
+	t.Run("io", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+				n, err := w.(io.Writer).Write(bits.Int32ToBytes(values))
+				return values[:n/4], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]int32, 10)
+				n, err := r.(io.Reader).Read(bits.Int32ToBytes(values))
+				return values[:n/4], err
+			},
+		})
+	})
+
+	t.Run("parquet", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+				n, err := w.(parquet.Int32Writer).WriteInt32s(values)
+				return values[:n], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]int32, 10)
+				n, err := r.(parquet.Int32Reader).ReadInt32s(values)
+				return values[:n], err
+			},
+		})
+	})
+}
+
+func testPageInt64(t *testing.T) {
+	schema := parquet.SchemaOf(struct{ Value int64 }{})
+
+	t.Run("io", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+				n, err := w.(io.Writer).Write(bits.Int64ToBytes(values))
+				return values[:n/8], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]int64, 10)
+				n, err := r.(io.Reader).Read(bits.Int64ToBytes(values))
+				return values[:n/8], err
+			},
+		})
+	})
+
+	t.Run("parquet", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+				n, err := w.(parquet.Int64Writer).WriteInt64s(values)
+				return values[:n], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]int64, 10)
+				n, err := r.(parquet.Int64Reader).ReadInt64s(values)
+				return values[:n], err
+			},
+		})
+	})
+}
+
+func testPageInt96(t *testing.T) {
+	schema := parquet.SchemaOf(struct{ Value deprecated.Int96 }{})
+
+	t.Run("io", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []deprecated.Int96{{0: 0}, {0: 1}, {0: 2}}
+				n, err := w.(io.Writer).Write(deprecated.Int96ToBytes(values))
+				return values[:n/12], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]deprecated.Int96, 3)
+				n, err := r.(io.Reader).Read(deprecated.Int96ToBytes(values))
+				return values[:n/12], err
+			},
+		})
+	})
+
+	t.Run("parquet", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []deprecated.Int96{{0: 0}, {0: 1}, {0: 2}}
+				n, err := w.(parquet.Int96Writer).WriteInt96s(values)
+				return values[:n], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]deprecated.Int96, 3)
+				n, err := r.(parquet.Int96Reader).ReadInt96s(values)
+				return values[:n], err
+			},
+		})
+	})
+}
+
+func testPageFloat(t *testing.T) {
+	schema := parquet.SchemaOf(struct{ Value float32 }{})
+
+	t.Run("io", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []float32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+				n, err := w.(io.Writer).Write(bits.Float32ToBytes(values))
+				return values[:n/4], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]float32, 10)
+				n, err := r.(io.Reader).Read(bits.Float32ToBytes(values))
+				return values[:n/4], err
+			},
+		})
+	})
+
+	t.Run("parquet", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []float32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+				n, err := w.(parquet.FloatWriter).WriteFloats(values)
+				return values[:n], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]float32, 10)
+				n, err := r.(parquet.FloatReader).ReadFloats(values)
+				return values[:n], err
+			},
+		})
+	})
+}
+
+func testPageDouble(t *testing.T) {
+	schema := parquet.SchemaOf(struct{ Value float64 }{})
+
+	t.Run("io", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+				n, err := w.(io.Writer).Write(bits.Float64ToBytes(values))
+				return values[:n/8], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]float64, 10)
+				n, err := r.(io.Reader).Read(bits.Float64ToBytes(values))
+				return values[:n/8], err
+			},
+		})
+	})
+
+	t.Run("parquet", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+				n, err := w.(parquet.DoubleWriter).WriteDoubles(values)
+				return values[:n], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]float64, 10)
+				n, err := r.(parquet.DoubleReader).ReadDoubles(values)
+				return values[:n], err
+			},
+		})
+	})
+}
+
+func testPageByteArray(t *testing.T) {
+	schema := parquet.SchemaOf(struct{ Value []byte }{})
+
+	t.Run("io", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []byte{}
+				values = plain.AppendByteArray(values, []byte("A"))
+				values = plain.AppendByteArray(values, []byte("B"))
+				values = plain.AppendByteArray(values, []byte("C"))
+				n, err := w.(io.Writer).Write(values)
+				return values[:n], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]byte, 3+3*plain.ByteArrayLengthSize)
+				n, err := r.(io.Reader).Read(values)
+				return values[:n], err
+			},
+		})
+	})
+
+	t.Run("parquet", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []byte{}
+				values = plain.AppendByteArray(values, []byte("A"))
+				values = plain.AppendByteArray(values, []byte("B"))
+				values = plain.AppendByteArray(values, []byte("C"))
+				_, err := w.(parquet.ByteArrayWriter).WriteByteArrays(values)
+				return values, err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]byte, 3+3*plain.ByteArrayLengthSize)
+				_, err := r.(parquet.ByteArrayReader).ReadByteArrays(values)
+				return values, err
+			},
+		})
+	})
+}
+
+func testPageFixedLenByteArray(t *testing.T) {
+	schema := parquet.SchemaOf(struct{ Value [3]byte }{})
+
+	t.Run("io", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []byte("123456789")
+				n, err := w.(io.Writer).Write(values)
+				return values[:n], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]byte, 3*3)
+				n, err := r.(io.Reader).Read(values)
+				return values[:n], err
+			},
+		})
+	})
+
+	t.Run("parquet", func(t *testing.T) {
+		testPage(t, schema, pageTest{
+			write: func(w parquet.ValueWriter) (interface{}, error) {
+				values := []byte("123456789")
+				n, err := w.(parquet.FixedLenByteArrayWriter).WriteFixedLenByteArrays(values)
+				return values[:3*n], err
+			},
+
+			read: func(r parquet.ValueReader) (interface{}, error) {
+				values := make([]byte, 3*3)
+				n, err := r.(parquet.FixedLenByteArrayReader).ReadFixedLenByteArrays(values)
+				return values[:3*n], err
+			},
+		})
+	})
+}
+
+type pageTest struct {
+	write func(parquet.ValueWriter) (interface{}, error)
+	read  func(parquet.ValueReader) (interface{}, error)
+}
+
+func testPage(t *testing.T, schema *parquet.Schema, test pageTest) {
+	buffer := parquet.NewBuffer(schema)
+	column := buffer.Column(0).(parquet.ColumnBuffer)
+
+	w, err := test.write(column)
+	if err != nil {
+		t.Fatal("writing page values:", err)
+	}
+
+	r, err := test.read(column.Page().Values())
+	if err != io.EOF {
+		t.Errorf("expected io.EOF after reading all values but got %v", err)
+	}
+	if !reflect.DeepEqual(w, r) {
+		t.Errorf("wrong values read from the page: got=%+v want=%+v", r, w)
+	}
+
+}

--- a/value.go
+++ b/value.go
@@ -120,6 +120,176 @@ func copyValues(dst ValueWriter, src ValueReader, buf []Value) (written int64, e
 	}
 }
 
+// BooleanReader is an interface implemented by ValueReader instances which
+// expose the content of a column of boolean values.
+type BooleanReader interface {
+	// Read boolean values into the buffer passed as argument.
+	//
+	// The method returns io.EOF when all values have been read.
+	ReadBooleans(values []bool) (int, error)
+}
+
+// BooleanWriter is an interface implemented by ValueWriter instances which
+// support writing columns of boolean values.
+type BooleanWriter interface {
+	// Write boolean values.
+	//
+	// The method returns the number of values written, and any error that
+	// occured while writing the values.
+	WriteBooleans(values []bool) (int, error)
+}
+
+// Int32Reader is an interface implemented by ValueReader instances which expose
+// the content of a column of int32 values.
+type Int32Reader interface {
+	// Read 32 bits integer values into the buffer passed as argument.
+	//
+	// The method returns io.EOF when all values have been read.
+	ReadInt32s(values []int32) (int, error)
+}
+
+// Int32Writer is an interface implemented by ValueWriter instances which
+// support writing columns of 32 bits signed integer values.
+type Int32Writer interface {
+	// Write 32 bits signed integer values.
+	//
+	// The method returns the number of values written, and any error that
+	// occured while writing the values.
+	WriteInt32s(values []int32) (int, error)
+}
+
+// Int64Reader is an interface implemented by ValueReader instances which expose
+// the content of a column of int64 values.
+type Int64Reader interface {
+	// Read 64 bits integer values into the buffer passed as argument.
+	//
+	// The method returns io.EOF when all values have been read.
+	ReadInt64s(values []int64) (int, error)
+}
+
+// Int64Writer is an interface implemented by ValueWriter instances which
+// support writing columns of 64 bits signed integer values.
+type Int64Writer interface {
+	// Write 64 bits signed integer values.
+	//
+	// The method returns the number of values written, and any error that
+	// occured while writing the values.
+	WriteInt64s(values []int64) (int, error)
+}
+
+// Int96Reader is an interface implemented by ValueReader instances which expose
+// the content of a column of int96 values.
+type Int96Reader interface {
+	// Read 96 bits integer values into the buffer passed as argument.
+	//
+	// The method returns io.EOF when all values have been read.
+	ReadInt96s(values []deprecated.Int96) (int, error)
+}
+
+// Int96Writer is an interface implemented by ValueWriter instances which
+// support writing columns of 96 bits signed integer values.
+type Int96Writer interface {
+	// Write 96 bits signed integer values.
+	//
+	// The method returns the number of values written, and any error that
+	// occured while writing the values.
+	WriteInt96s(values []deprecated.Int96) (int, error)
+}
+
+// FloatReader is an interface implemented by ValueReader instances which expose
+// the content of a column of single-precision floating point values.
+type FloatReader interface {
+	// Read single-precision floating point values into the buffer passed as
+	// argument.
+	//
+	// The method returns io.EOF when all values have been read.
+	ReadFloats(values []float32) (int, error)
+}
+
+// FloatWriter is an interface implemented by ValueWriter instances which
+// support writing columns of single-precision floating point values.
+type FloatWriter interface {
+	// Write single-precision floating point values.
+	//
+	// The method returns the number of values written, and any error that
+	// occured while writing the values.
+	WriteFloats(values []float32) (int, error)
+}
+
+// DoubleReader is an interface implemented by ValueReader instances which
+// expose the content of a column of double-precision float point values.
+type DoubleReader interface {
+	// Read double-precision floating point values into the buffer passed as
+	// argument.
+	//
+	// The method returns io.EOF when all values have been read.
+	ReadDoubles(values []float64) (int, error)
+}
+
+// DoubleWriter is an interface implemented by ValueWriter instances which
+// support writing columns of double-precision floating point values.
+type DoubleWriter interface {
+	// Write double-precision floating point values.
+	//
+	// The method returns the number of values written, and any error that
+	// occured while writing the values.
+	WriteDoubles(values []float64) (int, error)
+}
+
+// ByteArrayReader is an interface implemented by ValueReader instances which
+// expose the content of a column of variable length byte array values.
+type ByteArrayReader interface {
+	// Read values into the byte buffer passed as argument, returning the number
+	// of values written to the buffer (not the number of bytes). Values are
+	// written using the PLAIN encoding, each byte array prefixed with its
+	// length encoded as a 4 bytes little endian unsigned integer.
+	//
+	// The method returns io.EOF when all values have been read.
+	//
+	// If the buffer was not empty, but too small to hold at least one value,
+	// io.ErrShortBuffer is returned.
+	ReadByteArrays(values []byte) (int, error)
+}
+
+// ByteArrayWriter is an interface implemented by ValueWriter instances which
+// support writing columns of variable length byte array values.
+type ByteArrayWriter interface {
+	// Write variable length byte array values.
+	//
+	// The values passed as input must be laid out using the PLAIN encoding,
+	// with each byte array prefixed with the four bytes little endian unsigned
+	// integer length.
+	//
+	// The method returns the number of values written to the underlying column
+	// (not the number of bytes), or any error that occured while attempting to
+	// write the values.
+	WriteByteArrays(values []byte) (int, error)
+}
+
+// FixedLenByteArrayReader is an interface implemented by ValueReader instances
+// which expose the content of a column of fixed length byte array values.
+type FixedLenByteArrayReader interface {
+	// Read values into the byte buffer passed as argument, returning the number
+	// of values written to the buffer (not the number of bytes).
+	//
+	// The method returns io.EOF when all values have been read.
+	//
+	// If the buffer was not empty, but too small to hold at least one value,
+	// io.ErrShortBuffer is returned.
+	ReadFixedLenByteArrays(values []byte) (int, error)
+}
+
+// FixedLenByteArrayWriter is an interface implemented by ValueWriter instances
+// which support writing columns of fixed length byte array values.
+type FixedLenByteArrayWriter interface {
+	// Writes the fixed length byte array values.
+	//
+	// The size of the values is assumed to be the same as the expected size of
+	// items in the column. The method errors if the length of the input values
+	// is not a multiple of the expected item size.
+	WriteFixedLenByteArrays(values []byte) (int, error)
+}
+
 // ValueOf constructs a parquet value from a Go value v.
 //
 // The physical type of the value is assumed from the Go type of v using the


### PR DESCRIPTION
This PR adds APIs to read arrays of column values. To experiment with different approaches we discussed, I have implemented two models based on `io.Reader`/`io.Writer` and interfaces with stronger typing. Here are examples of how programs would use these:

### reading columns of typed values
```go
switch p := page.(type) {
case parquet.Int64Reader:
    n, err = p.ReadInt64s(values)
}
```

### writing columns of typed values
```go
column := buffer.Column(0).(parquet.Int64Writer)
n, err := column.WriteInt64s(values)
if err != nil {
    ...
}
```

An similarly with implementations of `io.Reader`/`io.Writer`, in places where those are better interfaces to integrate with the program.

This is definitely just a first step to test the design, the implementation focuses only on in-memory pages, what is NOT in this PR:
- a solution for reading typed arrays from optional or repeated columns, we need to figure out how to extract information about null values or lengths of repetitions, for now programs should still fallback to `parquet.ValueReader` and `parquet.ValueWriter` in those cases.

- implementation of the interfaces for pages read from parquet files, this is a more complex work that I would like to keep as a follow up if we feel good about the approach.

- documentation on those APIs