### PR TITLE
debug issue with misuse of CPU features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,4 @@ jobs:
       run: test -z $(find . -name '*.go' | xargs gofmt -l)
 
     - name: Run Tests
-      run: go test ./...
+      run: go test -v ./internal/bits

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,4 @@ jobs:
       run: test -z $(find . -name '*.go' | xargs gofmt -l)
 
     - name: Run Tests
-      run: go test -v ./internal/bits
+      run: go test ./...

--- a/internal/bits/bits_amd64.go
+++ b/internal/bits/bits_amd64.go
@@ -1,6 +1,14 @@
 package bits
 
-import "golang.org/x/sys/cpu"
+import (
+	"fmt"
+
+	"golang.org/x/sys/cpu"
+)
+
+func init() {
+	fmt.Printf("%#v\n", cpu.X86)
+}
 
 // All functions require at least the F and VL instruction sets (Foundation and
 // Vector Length extensions). Note that Foundation is a requirement of AVX-512,

--- a/internal/bits/bits_amd64.go
+++ b/internal/bits/bits_amd64.go
@@ -1,14 +1,8 @@
 package bits
 
 import (
-	"fmt"
-
 	"golang.org/x/sys/cpu"
 )
-
-func init() {
-	fmt.Printf("%#v\n", cpu.X86)
-}
 
 // All functions require at least the F and VL instruction sets (Foundation and
 // Vector Length extensions). Note that Foundation is a requirement of AVX-512,

--- a/internal/bits/max_amd64.s
+++ b/internal/bits/max_amd64.s
@@ -458,7 +458,7 @@ TEXT ·maxBE128(SB), NOSPLIT, $-48
     CMPQ DX, $256
     JB loop
 
-    CMPQ ·hasAVX512MinMaxBE128(SB), $0
+    CMPB ·hasAVX512MinMaxBE128(SB), $0
     JB loop
 
     // Z19 holds a vector of the count by which we increment the vectors of

--- a/internal/bits/min_amd64.s
+++ b/internal/bits/min_amd64.s
@@ -459,7 +459,7 @@ TEXT ·minBE128(SB), NOSPLIT, $-48
     CMPQ DX, $256
     JB loop
 
-    CMPQ ·hasAVX512MinMaxBE128(SB), $0
+    CMPB ·hasAVX512MinMaxBE128(SB), $0
     JB loop
 
     // Z19 holds a vector of the count by which we increment the vectors of


### PR DESCRIPTION
Fixes https://github.com/segmentio/parquet-go/issues/65

The code was using `CMPQ` instead of `CMPB`, reading 7 extra bytes beyond the limits of the boolean variable that controlled CPU features for the min/max BE128 routines.