### PR TITLE
Increase column limit

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -70,7 +70,7 @@ func (buf *Buffer) configure(schema *Schema) {
 			columnType = dictionary.Type()
 		}
 
-		column := columnType.NewColumnBuffer(leaf.columnIndex, bufferSize)
+		column := columnType.NewColumnBuffer(int(leaf.columnIndex), bufferSize)
 		switch {
 		case leaf.maxRepetitionLevel > 0:
 			column = newRepeatedColumnBuffer(column, leaf.maxRepetitionLevel, leaf.maxDefinitionLevel, nullOrdering)

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -238,8 +238,8 @@ func descending(typ parquet.Type, values []parquet.Value) {
 }
 
 func testBuffer(t *testing.T, node parquet.Node, reader parquet.ValueReader, buffer *parquet.Buffer, encoder encoding.Encoder, values []interface{}, sortFunc sortFunc) {
-	repetitionLevel := int8(0)
-	definitionLevel := int8(0)
+	repetitionLevel := 0
+	definitionLevel := 0
 	if !node.Required() {
 		definitionLevel = 1
 	}

--- a/column.go
+++ b/column.go
@@ -35,7 +35,7 @@ type Column struct {
 	depth              int8
 	maxRepetitionLevel int8
 	maxDefinitionLevel int8
-	index              int8
+	index              int16
 }
 
 // Type returns the type of the column.
@@ -174,19 +174,19 @@ func (r *columnPages) SeekToRow(rowIndex int64) error {
 }
 
 // Depth returns the position of the column relative to the root.
-func (c *Column) Depth() int8 { return c.depth }
+func (c *Column) Depth() int { return int(c.depth) }
 
 // MaxRepetitionLevel returns the maximum value of repetition levels on this
 // column.
-func (c *Column) MaxRepetitionLevel() int8 { return c.maxRepetitionLevel }
+func (c *Column) MaxRepetitionLevel() int { return int(c.maxRepetitionLevel) }
 
 // MaxDefinitionLevel returns the maximum value of definition levels on this
 // column.
-func (c *Column) MaxDefinitionLevel() int8 { return c.maxDefinitionLevel }
+func (c *Column) MaxDefinitionLevel() int { return int(c.maxDefinitionLevel) }
 
 // Index returns the position of the column in a row. Only leaf columns have a
 // column index, the method returns -1 when called on non-leaf columns.
-func (c *Column) Index() int8 { return c.index }
+func (c *Column) Index() int { return int(c.index) }
 
 // ValueByName returns the sub-value with the given name in base.
 func (c *Column) ValueByName(base reflect.Value, name string) reflect.Value {
@@ -270,7 +270,7 @@ func (c *Column) setLevels(depth, repetition, definition, index int) (int, error
 	if len(c.columns) > 0 {
 		c.index = -1
 	} else {
-		c.index = int8(index)
+		c.index = int16(index)
 		index++
 	}
 

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -455,10 +455,10 @@ func (col *repeatedColumnBuffer) Page() BufferedPage {
 			for i := int64(0); i < numValues; i++ {
 				var err error
 				if buffer, err = col.base.ReadRowAt(buffer[:0], int64(row.offset)+i); err != nil {
-					return newErrorPage(col.Column(), "reordering rows of repeated column: %w", err)
+					return newErrorPage(int16(col.Column()), "reordering rows of repeated column: %w", err)
 				}
 				if err = column.base.WriteRow(buffer); err != nil {
-					return newErrorPage(col.Column(), "reordering rows of repeated column: %w", err)
+					return newErrorPage(int16(col.Column()), "reordering rows of repeated column: %w", err)
 				}
 			}
 		}
@@ -681,11 +681,11 @@ type booleanColumnBuffer struct {
 	typ Type
 }
 
-func newBooleanColumnBuffer(typ Type, columnIndex, bufferSize int) *booleanColumnBuffer {
+func newBooleanColumnBuffer(typ Type, columnIndex int16, bufferSize int) *booleanColumnBuffer {
 	return &booleanColumnBuffer{
 		booleanPage: booleanPage{
 			values:      make([]bool, 0, bufferSize),
-			columnIndex: ^int8(columnIndex),
+			columnIndex: ^columnIndex,
 		},
 		typ: typ,
 	}
@@ -774,11 +774,11 @@ type int32ColumnBuffer struct {
 	typ Type
 }
 
-func newInt32ColumnBuffer(typ Type, columnIndex, bufferSize int) *int32ColumnBuffer {
+func newInt32ColumnBuffer(typ Type, columnIndex int16, bufferSize int) *int32ColumnBuffer {
 	return &int32ColumnBuffer{
 		int32Page: int32Page{
 			values:      make([]int32, 0, bufferSize/4),
-			columnIndex: ^int8(columnIndex),
+			columnIndex: ^columnIndex,
 		},
 		typ: typ,
 	}
@@ -869,11 +869,11 @@ type int64ColumnBuffer struct {
 	typ Type
 }
 
-func newInt64ColumnBuffer(typ Type, columnIndex, bufferSize int) *int64ColumnBuffer {
+func newInt64ColumnBuffer(typ Type, columnIndex int16, bufferSize int) *int64ColumnBuffer {
 	return &int64ColumnBuffer{
 		int64Page: int64Page{
 			values:      make([]int64, 0, bufferSize/8),
-			columnIndex: ^int8(columnIndex),
+			columnIndex: ^columnIndex,
 		},
 		typ: typ,
 	}
@@ -964,11 +964,11 @@ type int96ColumnBuffer struct {
 	typ Type
 }
 
-func newInt96ColumnBuffer(typ Type, columnIndex, bufferSize int) *int96ColumnBuffer {
+func newInt96ColumnBuffer(typ Type, columnIndex int16, bufferSize int) *int96ColumnBuffer {
 	return &int96ColumnBuffer{
 		int96Page: int96Page{
 			values:      make([]deprecated.Int96, 0, bufferSize/12),
-			columnIndex: ^int8(columnIndex),
+			columnIndex: ^columnIndex,
 		},
 		typ: typ,
 	}
@@ -1059,11 +1059,11 @@ type floatColumnBuffer struct {
 	typ Type
 }
 
-func newFloatColumnBuffer(typ Type, columnIndex, bufferSize int) *floatColumnBuffer {
+func newFloatColumnBuffer(typ Type, columnIndex int16, bufferSize int) *floatColumnBuffer {
 	return &floatColumnBuffer{
 		floatPage: floatPage{
 			values:      make([]float32, 0, bufferSize/4),
-			columnIndex: ^int8(columnIndex),
+			columnIndex: ^columnIndex,
 		},
 		typ: typ,
 	}
@@ -1154,11 +1154,11 @@ type doubleColumnBuffer struct {
 	typ Type
 }
 
-func newDoubleColumnBuffer(typ Type, columnIndex, bufferSize int) *doubleColumnBuffer {
+func newDoubleColumnBuffer(typ Type, columnIndex int16, bufferSize int) *doubleColumnBuffer {
 	return &doubleColumnBuffer{
 		doublePage: doublePage{
 			values:      make([]float64, 0, bufferSize/8),
-			columnIndex: ^int8(columnIndex),
+			columnIndex: ^columnIndex,
 		},
 		typ: typ,
 	}
@@ -1249,11 +1249,11 @@ type byteArrayColumnBuffer struct {
 	typ Type
 }
 
-func newByteArrayColumnBuffer(typ Type, columnIndex, bufferSize int) *byteArrayColumnBuffer {
+func newByteArrayColumnBuffer(typ Type, columnIndex int16, bufferSize int) *byteArrayColumnBuffer {
 	return &byteArrayColumnBuffer{
 		byteArrayPage: byteArrayPage{
 			values:      encoding.MakeByteArrayList(bufferSize / 16),
-			columnIndex: ^int8(columnIndex),
+			columnIndex: ^columnIndex,
 		},
 		typ: typ,
 	}
@@ -1354,13 +1354,13 @@ type fixedLenByteArrayColumnBuffer struct {
 	tmp []byte
 }
 
-func newFixedLenByteArrayColumnBuffer(typ Type, columnIndex, bufferSize int) *fixedLenByteArrayColumnBuffer {
+func newFixedLenByteArrayColumnBuffer(typ Type, columnIndex int16, bufferSize int) *fixedLenByteArrayColumnBuffer {
 	size := typ.Length()
 	return &fixedLenByteArrayColumnBuffer{
 		fixedLenByteArrayPage: fixedLenByteArrayPage{
 			size:        size,
 			data:        make([]byte, 0, bufferSize),
-			columnIndex: ^int8(columnIndex),
+			columnIndex: ^columnIndex,
 		},
 		typ: typ,
 		tmp: make([]byte, size),
@@ -1469,7 +1469,7 @@ func (col *fixedLenByteArrayColumnBuffer) ReadRowAt(row Row, index int64) (Row, 
 
 type uint32ColumnBuffer struct{ *int32ColumnBuffer }
 
-func newUint32ColumnBuffer(typ Type, columnIndex, bufferSize int) uint32ColumnBuffer {
+func newUint32ColumnBuffer(typ Type, columnIndex int16, bufferSize int) uint32ColumnBuffer {
 	return uint32ColumnBuffer{newInt32ColumnBuffer(typ, columnIndex, bufferSize)}
 }
 
@@ -1493,7 +1493,7 @@ func (col uint32ColumnBuffer) Less(i, j int) bool {
 
 type uint64ColumnBuffer struct{ *int64ColumnBuffer }
 
-func newUint64ColumnBuffer(typ Type, columnIndex, bufferSize int) uint64ColumnBuffer {
+func newUint64ColumnBuffer(typ Type, columnIndex int16, bufferSize int) uint64ColumnBuffer {
 	return uint64ColumnBuffer{newInt64ColumnBuffer(typ, columnIndex, bufferSize)}
 }
 

--- a/column_path.go
+++ b/column_path.go
@@ -53,16 +53,16 @@ func stringsAreOrdered(strings1, strings2 []string) bool {
 type leafColumn struct {
 	node               Node
 	path               columnPath
-	columnIndex        int
 	maxRepetitionLevel int8
 	maxDefinitionLevel int8
+	columnIndex        int16
 }
 
 func forEachLeafColumnOf(node Node, do func(leafColumn)) {
 	forEachLeafColumn(node, nil, 0, 0, 0, do)
 }
 
-func forEachLeafColumn(node Node, path columnPath, columnIndex int, maxRepetitionLevel, maxDefinitionLevel int8, do func(leafColumn)) int {
+func forEachLeafColumn(node Node, path columnPath, columnIndex, maxRepetitionLevel, maxDefinitionLevel int, do func(leafColumn)) int {
 	switch {
 	case node.Optional():
 		maxDefinitionLevel++
@@ -75,9 +75,9 @@ func forEachLeafColumn(node Node, path columnPath, columnIndex int, maxRepetitio
 		do(leafColumn{
 			node:               node,
 			path:               path,
-			columnIndex:        columnIndex,
-			maxRepetitionLevel: maxRepetitionLevel,
-			maxDefinitionLevel: maxDefinitionLevel,
+			maxRepetitionLevel: makeRepetitionLevel(maxRepetitionLevel),
+			maxDefinitionLevel: makeDefinitionLevel(maxDefinitionLevel),
+			columnIndex:        makeColumnIndex(columnIndex),
 		})
 		return columnIndex + 1
 	}

--- a/concat.go
+++ b/concat.go
@@ -13,7 +13,7 @@ func concat(schema *Schema, rowGroups []RowGroup) *concatenatedRowGroup {
 func (c *concatenatedRowGroup) init(schema *Schema, rowGroups []RowGroup) {
 	c.schema = schema
 	c.rowGroups = rowGroups
-	c.columns = make([]concatenatedColumnChunk, numColumnsOf(schema))
+	c.columns = make([]concatenatedColumnChunk, numLeafColumnsOf(schema))
 
 	for i := range c.columns {
 		c.columns[i].rowGroup = c

--- a/dictionary.go
+++ b/dictionary.go
@@ -684,7 +684,7 @@ func newIndexedType(typ Type, dict Dictionary) *indexedType {
 }
 
 func (t *indexedType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newIndexedColumnBuffer(t.dict, t, columnIndex, bufferSize)
+	return newIndexedColumnBuffer(t.dict, t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t *indexedType) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -694,7 +694,7 @@ func (t *indexedType) NewValueDecoder(bufferSize int) ValueDecoder {
 type indexedPage struct {
 	dict        Dictionary
 	values      []int32
-	columnIndex int8
+	columnIndex int16
 }
 
 func (page *indexedPage) Column() int { return int(^page.columnIndex) }
@@ -778,12 +778,12 @@ type indexedColumnBuffer struct {
 	typ Type
 }
 
-func newIndexedColumnBuffer(dict Dictionary, typ Type, columnIndex, bufferSize int) *indexedColumnBuffer {
+func newIndexedColumnBuffer(dict Dictionary, typ Type, columnIndex int16, bufferSize int) *indexedColumnBuffer {
 	return &indexedColumnBuffer{
 		indexedPage: indexedPage{
 			dict:        dict,
 			values:      make([]int32, 0, bufferSize/4),
-			columnIndex: ^int8(columnIndex),
+			columnIndex: ^columnIndex,
 		},
 		typ: typ,
 	}

--- a/file.go
+++ b/file.go
@@ -813,7 +813,7 @@ func (p *filePage) Buffer() BufferedPage {
 	bufferedPage := p.column.Type().NewColumnBuffer(p.Column(), int(p.Size()))
 	_, err := CopyValues(bufferedPage, p.Values())
 	if err != nil {
-		return &errorPage{err: err, columnIndex: p.Column()}
+		return &errorPage{err: err, columnIndex: int16(p.Column())}
 	}
 	return bufferedPage.Page()
 }
@@ -926,9 +926,9 @@ func (s *filePageValueReaderState) init(columnType Type, column *Column, codec f
 	if s.reader == nil {
 		s.reader = newDataPageReader(
 			columnType,
-			column.MaxRepetitionLevel(),
-			column.MaxDefinitionLevel(),
-			column.Index(),
+			column.maxRepetitionLevel,
+			column.maxDefinitionLevel,
+			column.index,
 			defaultReadBufferSize,
 		)
 	}

--- a/limits.go
+++ b/limits.go
@@ -1,13 +1,16 @@
 package parquet
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
 const (
 	// MaxColumnDepth is the maximum column depth supported by this package.
 	MaxColumnDepth = math.MaxInt8
 
 	// MaxColumnIndex is the maximum column index supported by this package.
-	MaxColumnIndex = math.MaxInt8
+	MaxColumnIndex = math.MaxInt16
 
 	// MaxRepetitionLevel is the maximum repetition level supported by this package.
 	MaxRepetitionLevel = math.MaxInt8
@@ -15,3 +18,28 @@ const (
 	// MaxDefinitionLevel is the maximum definition level supported by this package.
 	MaxDefinitionLevel = math.MaxInt8
 )
+
+func makeRepetitionLevel(i int) int8 {
+	checkIndexRange("repetition level", i, 0, MaxRepetitionLevel)
+	return int8(i)
+}
+
+func makeDefinitionLevel(i int) int8 {
+	checkIndexRange("definition level", i, 0, MaxDefinitionLevel)
+	return int8(i)
+}
+
+func makeColumnIndex(i int) int16 {
+	checkIndexRange("column index", i, 0, MaxColumnIndex)
+	return int16(i)
+}
+
+func checkIndexRange(typ string, i, min, max int) {
+	if i < min || i > max {
+		panic(errIndexOutOfRange(typ, i, min, max))
+	}
+}
+
+func errIndexOutOfRange(typ string, i, min, max int) error {
+	return fmt.Errorf("%s out of range: %d not in [%d:%d]", typ, i, min, max)
+}

--- a/node.go
+++ b/node.go
@@ -443,22 +443,22 @@ func isMap(node Node) bool {
 	return logicalType != nil && logicalType.Map != nil
 }
 
-func numColumnsOf(node Node) int {
-	return maxColumnIndexOf(node, 0)
+func numLeafColumnsOf(node Node) int16 {
+	return makeColumnIndex(numLeafColumns(node, 0))
 }
 
-func maxColumnIndexOf(node Node, columnIndex int) int {
+func numLeafColumns(node Node, columnIndex int) int {
 	if isLeaf(node) {
 		return columnIndex + 1
 	}
 
 	if indexedNode, ok := unwrap(node).(IndexedNode); ok {
 		for i, n := 0, indexedNode.NumChildren(); i < n; i++ {
-			columnIndex = maxColumnIndexOf(indexedNode.ChildByIndex(i), columnIndex)
+			columnIndex = numLeafColumns(indexedNode.ChildByIndex(i), columnIndex)
 		}
 	} else {
 		for _, name := range node.ChildNames() {
-			columnIndex = maxColumnIndexOf(node.ChildByName(name), columnIndex)
+			columnIndex = numLeafColumns(node.ChildByName(name), columnIndex)
 		}
 	}
 

--- a/page.go
+++ b/page.go
@@ -199,17 +199,17 @@ func forEachPageSlice(page BufferedPage, wantSize int64, do func(BufferedPage) e
 
 type errorPage struct {
 	err         error
-	columnIndex int
+	columnIndex int16
 }
 
-func newErrorPage(columnIndex int, msg string, args ...interface{}) *errorPage {
+func newErrorPage(columnIndex int16, msg string, args ...interface{}) *errorPage {
 	return &errorPage{
 		err:         fmt.Errorf(msg, args...),
 		columnIndex: columnIndex,
 	}
 }
 
-func (page *errorPage) Column() int                    { return page.columnIndex }
+func (page *errorPage) Column() int                    { return int(page.columnIndex) }
 func (page *errorPage) Dictionary() Dictionary         { return nil }
 func (page *errorPage) NumRows() int64                 { return 0 }
 func (page *errorPage) NumValues() int64               { return 0 }
@@ -549,7 +549,7 @@ func (r *repeatedPageReader) ReadValues(values []Value) (n int, err error) {
 
 type booleanPage struct {
 	values      []bool
-	columnIndex int8
+	columnIndex int16
 }
 
 func (page *booleanPage) Column() int { return int(^page.columnIndex) }
@@ -671,7 +671,7 @@ func (r *booleanPageReader) ReadValues(values []Value) (n int, err error) {
 
 type int32Page struct {
 	values      []int32
-	columnIndex int8
+	columnIndex int16
 }
 
 func (page *int32Page) Column() int { return int(^page.columnIndex) }
@@ -759,7 +759,7 @@ func (r *int32PageReader) ReadValues(values []Value) (n int, err error) {
 
 type int64Page struct {
 	values      []int64
-	columnIndex int8
+	columnIndex int16
 }
 
 func (page *int64Page) Column() int { return int(^page.columnIndex) }
@@ -847,7 +847,7 @@ func (r *int64PageReader) ReadValues(values []Value) (n int, err error) {
 
 type int96Page struct {
 	values      []deprecated.Int96
-	columnIndex int8
+	columnIndex int16
 }
 
 func (page *int96Page) Column() int { return int(^page.columnIndex) }
@@ -937,7 +937,7 @@ func (r *int96PageReader) ReadValues(values []Value) (n int, err error) {
 
 type floatPage struct {
 	values      []float32
-	columnIndex int8
+	columnIndex int16
 }
 
 func (page *floatPage) Column() int { return int(^page.columnIndex) }
@@ -1025,7 +1025,7 @@ func (r *floatPageReader) ReadValues(values []Value) (n int, err error) {
 
 type doublePage struct {
 	values      []float64
-	columnIndex int8
+	columnIndex int16
 }
 
 func (page *doublePage) Column() int { return int(^page.columnIndex) }
@@ -1113,7 +1113,7 @@ func (r *doublePageReader) ReadValues(values []Value) (n int, err error) {
 
 type byteArrayPage struct {
 	values      encoding.ByteArrayList
-	columnIndex int8
+	columnIndex int16
 }
 
 func (page *byteArrayPage) Column() int { return int(^page.columnIndex) }
@@ -1257,7 +1257,7 @@ func (r *byteArrayPageReader) ReadValues(values []Value) (n int, err error) {
 type fixedLenByteArrayPage struct {
 	size        int
 	data        []byte
-	columnIndex int8
+	columnIndex int16
 }
 
 func (page *fixedLenByteArrayPage) Column() int { return int(^page.columnIndex) }

--- a/page_reader.go
+++ b/page_reader.go
@@ -19,13 +19,13 @@ type dataPageReader struct {
 	numValues          int
 	maxRepetitionLevel int8
 	maxDefinitionLevel int8
-	columnIndex        int8
+	columnIndex        int16
 	repetitions        levelReader
 	definitions        levelReader
 	values             ValueDecoder
 }
 
-func newDataPageReader(typ Type, maxRepetitionLevel, maxDefinitionLevel, columnIndex int8, bufferSize int) *dataPageReader {
+func newDataPageReader(typ Type, maxRepetitionLevel, maxDefinitionLevel int8, columnIndex int16, bufferSize int) *dataPageReader {
 	bufferSize /= 2
 	repetitionBufferSize := 0
 	definitionBufferSize := 0

--- a/row_group.go
+++ b/row_group.go
@@ -391,7 +391,7 @@ type emptyRowGroup struct {
 func newEmptyRowGroup(schema *Schema) *emptyRowGroup {
 	g := &emptyRowGroup{
 		schema:  schema,
-		columns: make([]emptyColumnChunk, numColumnsOf(schema)),
+		columns: make([]emptyColumnChunk, numLeafColumnsOf(schema)),
 	}
 	forEachLeafColumnOf(schema, func(leaf leafColumn) {
 		g.columns[leaf.columnIndex].typ = leaf.node.Type()
@@ -409,11 +409,11 @@ func (g *emptyRowGroup) Rows() Rows                      { return emptyRowReader
 
 type emptyColumnChunk struct {
 	typ    Type
-	column int
+	column int16
 }
 
 func (c *emptyColumnChunk) Type() Type               { return c.typ }
-func (c *emptyColumnChunk) Column() int              { return c.column }
+func (c *emptyColumnChunk) Column() int              { return int(c.column) }
 func (c *emptyColumnChunk) Pages() Pages             { return emptyPages{} }
 func (c *emptyColumnChunk) ColumnIndex() ColumnIndex { return &emptyColumnIndex }
 func (c *emptyColumnChunk) OffsetIndex() OffsetIndex { return &emptyOffsetIndex }

--- a/schema.go
+++ b/schema.go
@@ -88,7 +88,11 @@ func schemaOf(model reflect.Type) *Schema {
 }
 
 // NewSchema constructs a new Schema object with the given name and root node.
+//
+// The function panics if Node contains more leaf columns than supported by the
+// package (see parquet.MaxColumnIndex).
 func NewSchema(name string, root Node) *Schema {
+	_ = numLeafColumnsOf(root)
 	return &Schema{
 		name:        name,
 		root:        root,

--- a/type.go
+++ b/type.go
@@ -14,7 +14,7 @@ import (
 
 // Kind is an enumeration type representing the physical types supported by the
 // parquet type system.
-type Kind int16
+type Kind int8
 
 const (
 	Boolean           Kind = Kind(format.Boolean)
@@ -209,7 +209,7 @@ func (t booleanType) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t booleanType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newBooleanColumnBuffer(t, columnIndex, bufferSize)
+	return newBooleanColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t booleanType) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -241,7 +241,7 @@ func (t int32Type) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t int32Type) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newInt32ColumnBuffer(t, columnIndex, bufferSize)
+	return newInt32ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t int32Type) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -273,7 +273,7 @@ func (t int64Type) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t int64Type) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newInt64ColumnBuffer(t, columnIndex, bufferSize)
+	return newInt64ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t int64Type) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -305,7 +305,7 @@ func (t int96Type) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t int96Type) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newInt96ColumnBuffer(t, columnIndex, bufferSize)
+	return newInt96ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t int96Type) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -337,7 +337,7 @@ func (t floatType) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t floatType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newFloatColumnBuffer(t, columnIndex, bufferSize)
+	return newFloatColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t floatType) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -367,7 +367,7 @@ func (t doubleType) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t doubleType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newDoubleColumnBuffer(t, columnIndex, bufferSize)
+	return newDoubleColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t doubleType) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -399,7 +399,7 @@ func (t byteArrayType) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t byteArrayType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newByteArrayColumnBuffer(t, columnIndex, bufferSize)
+	return newByteArrayColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t byteArrayType) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -436,7 +436,7 @@ func (t *fixedLenByteArrayType) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t *fixedLenByteArrayType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newFixedLenByteArrayColumnBuffer(t, columnIndex, bufferSize)
+	return newFixedLenByteArrayColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t *fixedLenByteArrayType) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -591,15 +591,15 @@ func (t *intType) NewDictionary(bufferSize int) Dictionary {
 func (t *intType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
 	if t.IsSigned {
 		if t.BitWidth == 64 {
-			return newInt64ColumnBuffer(t, columnIndex, bufferSize)
+			return newInt64ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 		} else {
-			return newInt32ColumnBuffer(t, columnIndex, bufferSize)
+			return newInt32ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 		}
 	} else {
 		if t.BitWidth == 64 {
-			return newUint64ColumnBuffer(t, columnIndex, bufferSize)
+			return newUint64ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 		} else {
-			return newUint32ColumnBuffer(t, columnIndex, bufferSize)
+			return newUint32ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 		}
 	}
 }
@@ -688,7 +688,7 @@ func (t *stringType) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t *stringType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newByteArrayColumnBuffer(t, columnIndex, bufferSize)
+	return newByteArrayColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t *stringType) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -739,7 +739,7 @@ func (t *uuidType) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t *uuidType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newFixedLenByteArrayColumnBuffer(t, columnIndex, bufferSize)
+	return newFixedLenByteArrayColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t *uuidType) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -792,7 +792,7 @@ func (t *enumType) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t *enumType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newByteArrayColumnBuffer(t, columnIndex, bufferSize)
+	return newByteArrayColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t *enumType) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -845,7 +845,7 @@ func (t *jsonType) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t *jsonType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newByteArrayColumnBuffer(t, columnIndex, bufferSize)
+	return newByteArrayColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t *jsonType) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -894,7 +894,7 @@ func (t *bsonType) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t *bsonType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newByteArrayColumnBuffer(t, columnIndex, bufferSize)
+	return newByteArrayColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t *bsonType) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -939,7 +939,7 @@ func (t *dateType) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t *dateType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newInt32ColumnBuffer(t, columnIndex, bufferSize)
+	return newInt32ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t *dateType) NewValueDecoder(bufferSize int) ValueDecoder {
@@ -1064,9 +1064,9 @@ func (t *timeType) NewDictionary(bufferSize int) Dictionary {
 
 func (t *timeType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
 	if t.Unit.Millis != nil {
-		return newInt32ColumnBuffer(t, columnIndex, bufferSize)
+		return newInt32ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 	} else {
-		return newInt64ColumnBuffer(t, columnIndex, bufferSize)
+		return newInt64ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 	}
 }
 
@@ -1123,7 +1123,7 @@ func (t *timestampType) NewDictionary(bufferSize int) Dictionary {
 }
 
 func (t *timestampType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newInt64ColumnBuffer(t, columnIndex, bufferSize)
+	return newInt64ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t *timestampType) NewValueDecoder(bufferSize int) ValueDecoder {

--- a/value.go
+++ b/value.go
@@ -36,7 +36,7 @@ type Value struct {
 	// levels
 	definitionLevel int8
 	repetitionLevel int8
-	columnIndex     int8 // XOR so the zero-value is -1
+	columnIndex     int16 // XOR so the zero-value is -1
 }
 
 // ValueReader is an interface implemented by types that support reading
@@ -541,15 +541,15 @@ func (v Value) Double() float64 { return math.Float64frombits(v.u64) }
 func (v Value) ByteArray() []byte { return unsafe.Slice(v.ptr, int(v.u64)) }
 
 // RepetitionLevel returns the repetition level of v.
-func (v Value) RepetitionLevel() int8 { return v.repetitionLevel }
+func (v Value) RepetitionLevel() int { return int(v.repetitionLevel) }
 
 // DefinitionLevel returns the definition level of v.
-func (v Value) DefinitionLevel() int8 { return v.definitionLevel }
+func (v Value) DefinitionLevel() int { return int(v.definitionLevel) }
 
 // Column returns the column index within the row that v was created from.
 //
 // Returns -1 if the value does not carry a column index.
-func (v Value) Column() int8 { return ^v.columnIndex }
+func (v Value) Column() int { return int(^v.columnIndex) }
 
 // Bytes returns the binary representation of v.
 //
@@ -700,16 +700,10 @@ func (v Value) GoString() string {
 // set to the values passed as arguments.
 //
 // The method panics if either argument is negative.
-func (v Value) Level(repetitionLevel, definitionLevel, columnIndex int8) Value {
-	if repetitionLevel < 0 {
-		panic("cannot create a value with a negative repetition level")
-	}
-	if definitionLevel < 0 {
-		panic("cannot create a value with a negative definition level")
-	}
-	v.repetitionLevel = repetitionLevel
-	v.definitionLevel = definitionLevel
-	v.columnIndex = ^columnIndex
+func (v Value) Level(repetitionLevel, definitionLevel, columnIndex int) Value {
+	v.repetitionLevel = makeRepetitionLevel(repetitionLevel)
+	v.definitionLevel = makeDefinitionLevel(definitionLevel)
+	v.columnIndex = ^makeColumnIndex(columnIndex)
 	return v
 }
 


### PR DESCRIPTION
Following up from our discussion with the Tempo and Parca folks, the limit on 127 columns appeared to be a bit too low for some use cases.

This PR modifies the package to support parquet schemas with up to 32K columns, which should be plenty for any practical use case of parquet.

I also made changes to the public API to always accept and return `int` values for repetition levels, definition levels, and column indexes, to give us the liberty to modify internal limits in the future without breaking code that depend on parquet-go. Finally, I added checks at API boundaries to ensure that conversions from `int` to smaller types do not cause overflows, and trigger panics with descriptive error messages if they do.

Let me know if you have any questions!