### PR TITLE
Fix trailing null values in optional column pages

### DIFF
--- a/page.go
+++ b/page.go
@@ -368,7 +368,8 @@ func (r *optionalPageReader) ReadValues(values []Value) (n int, err error) {
 				r.offset++
 				n++
 			}
-			if err != nil {
+			// Do not return on an io.EOF here as we may still have null values to read.
+			if err != nil && err != io.EOF {
 				return n, err
 			}
 		}


### PR DESCRIPTION
Fixes #73 

Once again, it's entirely possible that I completely misunderstood everything that's happening, but this appears to fix what I observed in #73.