### PR TITLE
change parquet.BloomFilter.Check to accept a parquet.Value

### DIFF
--- a/bloom/hash.go
+++ b/bloom/hash.go
@@ -8,6 +8,14 @@ import "github.com/segmentio/parquet-go/bloom/xxhash"
 type Hash interface {
 	// Returns the 64 bit hash of the value passed as argument.
 	Sum64(value []byte) uint64
+
+	// Compute hashes of individual values of primitive types.
+	Sum64Uint8(value uint8) uint64
+	Sum64Uint16(value uint16) uint64
+	Sum64Uint32(value uint32) uint64
+	Sum64Uint64(value uint64) uint64
+	Sum64Uint128(value [16]byte) uint64
+
 	// Compute hashes of the array of fixed size values passed as arguments,
 	// returning the number of hashes written to the destination buffer.
 	MultiSum64Uint8(dst []uint64, src []uint8) int
@@ -22,6 +30,26 @@ type XXH64 struct{}
 
 func (XXH64) Sum64(b []byte) uint64 {
 	return xxhash.Sum64(b)
+}
+
+func (XXH64) Sum64Uint8(v uint8) uint64 {
+	return xxhash.Sum64Uint8(v)
+}
+
+func (XXH64) Sum64Uint16(v uint16) uint64 {
+	return xxhash.Sum64Uint16(v)
+}
+
+func (XXH64) Sum64Uint32(v uint32) uint64 {
+	return xxhash.Sum64Uint32(v)
+}
+
+func (XXH64) Sum64Uint64(v uint64) uint64 {
+	return xxhash.Sum64Uint64(v)
+}
+
+func (XXH64) Sum64Uint128(v [16]byte) uint64 {
+	return xxhash.Sum64Uint128(v)
 }
 
 func (XXH64) MultiSum64Uint8(h []uint64, v []uint8) int {

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -2,7 +2,6 @@ package parquet_test
 
 import (
 	"bytes"
-	"encoding/binary"
 	"io"
 	"math"
 	"sort"
@@ -399,9 +398,7 @@ func TestBufferGenerateBloomFilters(t *testing.T) {
 		fz := z.BloomFilter()
 
 		test := func(f parquet.BloomFilter, v float64) bool {
-			b := [8]byte{}
-			binary.LittleEndian.PutUint64(b[:], math.Float64bits(v))
-			if ok, err := f.Check(b[:]); err != nil {
+			if ok, err := f.Check(parquet.ValueOf(v)); err != nil {
 				t.Errorf("unexpected error checking bloom filter: %v", err)
 				return false
 			} else if !ok {

--- a/concat.go
+++ b/concat.go
@@ -145,10 +145,10 @@ func (f concatenatedBloomFilter) Size() int64 {
 	return size
 }
 
-func (f concatenatedBloomFilter) Check(key []byte) (bool, error) {
+func (f concatenatedBloomFilter) Check(v Value) (bool, error) {
 	for _, c := range f.chunks {
 		if b := c.BloomFilter(); b != nil {
-			if ok, err := b.Check(key); ok || err != nil {
+			if ok, err := b.Check(v); ok || err != nil {
 				return ok, err
 			}
 		}

--- a/convert.go
+++ b/convert.go
@@ -497,7 +497,7 @@ type missingBloomFilter struct{}
 
 func (missingBloomFilter) ReadAt([]byte, int64) (int, error) { return 0, io.EOF }
 func (missingBloomFilter) Size() int64                       { return 0 }
-func (missingBloomFilter) Check([]byte) (bool, error)        { return false, nil }
+func (missingBloomFilter) Check(Value) (bool, error)         { return false, nil }
 
 type missingPage struct{ *missingColumnChunk }
 

--- a/row_group.go
+++ b/row_group.go
@@ -438,7 +438,7 @@ type emptyBloomFilter struct{}
 
 func (emptyBloomFilter) ReadAt([]byte, int64) (int, error) { return 0, io.EOF }
 func (emptyBloomFilter) Size() int64                       { return 0 }
-func (emptyBloomFilter) Check([]byte) (bool, error)        { return false, nil }
+func (emptyBloomFilter) Check(Value) (bool, error)         { return false, nil }
 
 type emptyRowReader struct{ schema *Schema }
 

--- a/value.go
+++ b/value.go
@@ -326,6 +326,8 @@ func ValueOf(v interface{}) Value {
 		return Value{}
 	case uuid.UUID:
 		return makeValueBytes(FixedLenByteArray, value[:])
+	case deprecated.Int96:
+		return makeValueInt96(value)
 	}
 
 	k := Kind(-1)

--- a/writer_test.go
+++ b/writer_test.go
@@ -511,7 +511,7 @@ func TestWriterGenerateBloomFilters(t *testing.T) {
 		}
 
 		for i, row := range rows {
-			if ok, err := bloomFilter.Check([]byte(row.LastName)); err != nil {
+			if ok, err := bloomFilter.Check(parquet.ValueOf(row.LastName)); err != nil {
 				t.Errorf("unexpected error checking bloom filter: %v", err)
 				return false
 			} else if !ok {


### PR DESCRIPTION
This PR modifies the `parquet.BloomFilter` interface to accept a `parquet.Value` instead of a `[]byte`. The intent is to reduce reliance on a particular encoding, which results in more readable code in general in my opinion. It also creates better compile and runtime type checking, since the API does not accept any arbitrary byte slice anymore.

**Before**
```go
b := [8]byte{}
binary.LittleEndian.PutUint64(b[:], v)

if ok, err := bloomFilter.Check(b[:]); err != nil {
    ...
} else if ok {
    ...
}
```

**After**
```go
x := parquet.ValueOf(v)

if ok, err := bloomFilter.Check(x); err != nil {
    ...
} else if ok {
    ...
}
```