### PR TITLE
Expose rowGroupRowReader to be used by custom RowGroup implementations

### DIFF
--- a/row_group.go
+++ b/row_group.go
@@ -222,6 +222,10 @@ func (r *rowGroup) SortingColumns() []SortingColumn { return r.sorting }
 func (r *rowGroup) Schema() *Schema                 { return r.schema }
 func (r *rowGroup) Rows() Rows                      { return &rowGroupRowReader{rowGroup: r} }
 
+func NewRowGroupRowReader(rowGroup RowGroup) Rows {
+	return &rowGroupRowReader{rowGroup: rowGroup}
+}
+
 type rowGroupRowReader struct {
 	rowGroup RowGroup
 	schema   *Schema


### PR DESCRIPTION
I have a custom implementation of the `RowGroup` interface and am just missing a reader, and the standard reader here works just fine. I do wonder if we should introduce a separate interface that has everything except the `Rows` method for this as it feels like an incorrect abstraction when we pass something that according to the interface can already build a row reader. Happy to introduce an interface for that is identical to `RowGroup` except that it doesn't have the `Rows` method, but unsure about the name. Maybe `RawRowGroup`?

@achille-roussel 