### PR TITLE
Set columnIndex when reading back a value from a dictionary

### DIFF
--- a/dictionary.go
+++ b/dictionary.go
@@ -762,14 +762,18 @@ type indexedPageReader struct {
 }
 
 func (r *indexedPageReader) ReadValues(values []Value) (n int, err error) {
+	var v Value
 	for n < len(values) && r.offset < len(r.page.values) {
-		values[n] = r.page.dict.Index(int(r.page.values[r.offset]))
+		v = r.page.dict.Index(int(r.page.values[r.offset]))
+		v.columnIndex = r.page.columnIndex
+		values[n] = v
 		r.offset++
 		n++
 	}
 	if r.offset == len(r.page.values) {
 		err = io.EOF
 	}
+
 	return n, err
 }
 


### PR DESCRIPTION
Fixes #77 

I'm not 100% sure if this makes sense nor do I like very much that this is setting the unexported struct value `columnIndex` of the `Value` struct, but this appears to fix what I was observing in #77.