### PR TITLE
Optional dict column buffer page panic

### DIFF
--- a/column_buffer_test.go
+++ b/column_buffer_test.go
@@ -1,0 +1,42 @@
+package parquet_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/segmentio/parquet-go"
+)
+
+type TestStruct struct {
+	A *string `parquet:"a,optional,dict"`
+}
+
+func TestOptionalDictWriteRowGroup(t *testing.T) {
+	s := parquet.SchemaOf(&TestStruct{})
+
+	str1 := "test1"
+	str2 := "test2"
+	records := []*TestStruct{
+		{A: nil},
+		{A: &str1},
+		{A: nil},
+		{A: &str2},
+		{A: nil},
+	}
+
+	buf := parquet.NewBuffer(s)
+	for _, rec := range records {
+		row := s.Deconstruct(nil, rec)
+		err := buf.WriteRow(row)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	b := bytes.NewBuffer(nil)
+	w := parquet.NewWriter(b)
+	_, err := w.WriteRowGroup(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
I don't have a fix for this yet, but I noticed that when a column is both optional and a dictionary, after writing it in-memory into a buffer and then attempting to write it into a persistent parquet file (here simulated using a `bytes.Buffer`) then it panics.

This PR so far adds a test that panics, but I haven't found a fix yet, but in case it is obvious I wanted to open the PR already.

// edit

I believe I have found the culprit, and also why it only happens sometimes, it looks like the `WriteRow` and `WriteValues` functions did not produce identical buffers. I believe the patch now fixes that.