### PR TITLE
Fix UUID physical type

### DIFF
--- a/type.go
+++ b/type.go
@@ -721,7 +721,7 @@ func (t *uuidType) ColumnOrder() *format.ColumnOrder {
 }
 
 func (t *uuidType) PhyiscalType() *format.Type {
-	return &physicalTypes[ByteArray]
+	return &physicalTypes[FixedLenByteArray]
 }
 
 func (t *uuidType) LogicalType() *format.LogicalType {


### PR DESCRIPTION
The UUID type is well defined within the parquet spec, and only fixed
length byte arrays of length 16 are allowed to be annotated with the
UUID type.

Fixes #81 