### PR TITLE
Preserve correct column index in null values

### DIFF
--- a/page.go
+++ b/page.go
@@ -353,10 +353,14 @@ func (r *optionalPageReader) ReadValues(values []Value) (n int, err error) {
 		r.values = r.page.base.Values()
 	}
 	maxDefinitionLevel := r.page.maxDefinitionLevel
+	columnIndex := ^int16(r.page.Column())
 
 	for n < len(values) && r.offset < len(r.page.definitionLevels) {
 		for n < len(values) && r.offset < len(r.page.definitionLevels) && r.page.definitionLevels[r.offset] != maxDefinitionLevel {
-			values[n] = Value{definitionLevel: r.page.definitionLevels[r.offset]}
+			values[n] = Value{
+				definitionLevel: r.page.definitionLevels[r.offset],
+				columnIndex:     columnIndex,
+			}
 			r.offset++
 			n++
 		}

--- a/page_test.go
+++ b/page_test.go
@@ -431,3 +431,21 @@ func TestOptionalPageTrailingNulls(t *testing.T) {
 		t.Errorf("wrong number of rows read: got=%d want=%d", len(resultRows), len(rows))
 	}
 }
+
+func TestOptionalPagePreserveIndex(t *testing.T) {
+	schema := parquet.SchemaOf(&testStruct{})
+	buffer := parquet.NewBuffer(schema)
+
+	if err := buffer.WriteRow(schema.Deconstruct(nil, &testStruct{Value: nil})); err != nil {
+		t.Fatal("writing row:", err)
+	}
+
+	row, err := buffer.Rows().ReadRow(nil)
+	if err != nil {
+		t.Fatal("reading rows:", err)
+	}
+
+	if row[0].Column() != 0 {
+		t.Errorf("wrong index: got=%d want=%d", row[0].Column(), 0)
+	}
+}


### PR DESCRIPTION
Before this patch, all null values read from an optional column had the `-1` column index, while non-null values had their correct, expected index.