### PR TITLE
change parquet.ColumnIndex interface to return parquet.Value instead of []byte

### DIFF
--- a/column_index_default.go
+++ b/column_index_default.go
@@ -14,8 +14,8 @@ type booleanColumnIndex struct{ page *booleanPage }
 func (i booleanColumnIndex) NumPages() int       { return 1 }
 func (i booleanColumnIndex) NullCount(int) int64 { return 0 }
 func (i booleanColumnIndex) NullPage(int) bool   { return false }
-func (i booleanColumnIndex) MinValue(int) []byte { return plain.Boolean(i.page.min()) }
-func (i booleanColumnIndex) MaxValue(int) []byte { return plain.Boolean(i.page.max()) }
+func (i booleanColumnIndex) MinValue(int) Value  { return makeValueBoolean(i.page.min()) }
+func (i booleanColumnIndex) MaxValue(int) Value  { return makeValueBoolean(i.page.max()) }
 func (i booleanColumnIndex) IsAscending() bool   { return compareBool(i.page.bounds()) < 0 }
 func (i booleanColumnIndex) IsDescending() bool  { return compareBool(i.page.bounds()) > 0 }
 
@@ -24,8 +24,8 @@ type int32ColumnIndex struct{ page *int32Page }
 func (i int32ColumnIndex) NumPages() int       { return 1 }
 func (i int32ColumnIndex) NullCount(int) int64 { return 0 }
 func (i int32ColumnIndex) NullPage(int) bool   { return false }
-func (i int32ColumnIndex) MinValue(int) []byte { return plain.Int32(i.page.min()) }
-func (i int32ColumnIndex) MaxValue(int) []byte { return plain.Int32(i.page.max()) }
+func (i int32ColumnIndex) MinValue(int) Value  { return makeValueInt32(i.page.min()) }
+func (i int32ColumnIndex) MaxValue(int) Value  { return makeValueInt32(i.page.max()) }
 func (i int32ColumnIndex) IsAscending() bool   { return compareInt32(i.page.bounds()) < 0 }
 func (i int32ColumnIndex) IsDescending() bool  { return compareInt32(i.page.bounds()) > 0 }
 
@@ -34,8 +34,8 @@ type int64ColumnIndex struct{ page *int64Page }
 func (i int64ColumnIndex) NumPages() int       { return 1 }
 func (i int64ColumnIndex) NullCount(int) int64 { return 0 }
 func (i int64ColumnIndex) NullPage(int) bool   { return false }
-func (i int64ColumnIndex) MinValue(int) []byte { return plain.Int64(i.page.min()) }
-func (i int64ColumnIndex) MaxValue(int) []byte { return plain.Int64(i.page.max()) }
+func (i int64ColumnIndex) MinValue(int) Value  { return makeValueInt64(i.page.min()) }
+func (i int64ColumnIndex) MaxValue(int) Value  { return makeValueInt64(i.page.max()) }
 func (i int64ColumnIndex) IsAscending() bool   { return compareInt64(i.page.bounds()) < 0 }
 func (i int64ColumnIndex) IsDescending() bool  { return compareInt64(i.page.bounds()) > 0 }
 
@@ -44,8 +44,8 @@ type int96ColumnIndex struct{ page *int96Page }
 func (i int96ColumnIndex) NumPages() int       { return 1 }
 func (i int96ColumnIndex) NullCount(int) int64 { return 0 }
 func (i int96ColumnIndex) NullPage(int) bool   { return false }
-func (i int96ColumnIndex) MinValue(int) []byte { return plain.Int96(i.page.min()) }
-func (i int96ColumnIndex) MaxValue(int) []byte { return plain.Int96(i.page.max()) }
+func (i int96ColumnIndex) MinValue(int) Value  { return plain.Int96(i.page.min()) }
+func (i int96ColumnIndex) MaxValue(int) Value  { return plain.Int96(i.page.max()) }
 func (i int96ColumnIndex) IsAscending() bool   { return compareInt96(i.page.bounds()) < 0 }
 func (i int96ColumnIndex) IsDescending() bool  { return compareInt96(i.page.bounds()) > 0 }
 
@@ -54,8 +54,8 @@ type floatColumnIndex struct{ page *floatPage }
 func (i floatColumnIndex) NumPages() int       { return 1 }
 func (i floatColumnIndex) NullCount(int) int64 { return 0 }
 func (i floatColumnIndex) NullPage(int) bool   { return false }
-func (i floatColumnIndex) MinValue(int) []byte { return plain.Float(i.page.min()) }
-func (i floatColumnIndex) MaxValue(int) []byte { return plain.Float(i.page.max()) }
+func (i floatColumnIndex) MinValue(int) Value  { return makeValueFloat(i.page.min()) }
+func (i floatColumnIndex) MaxValue(int) Value  { return makeValueFloat(i.page.max()) }
 func (i floatColumnIndex) IsAscending() bool   { return compareFloat32(i.page.bounds()) < 0 }
 func (i floatColumnIndex) IsDescending() bool  { return compareFloat32(i.page.bounds()) > 0 }
 
@@ -64,8 +64,8 @@ type doubleColumnIndex struct{ page *doublePage }
 func (i doubleColumnIndex) NumPages() int       { return 1 }
 func (i doubleColumnIndex) NullCount(int) int64 { return 0 }
 func (i doubleColumnIndex) NullPage(int) bool   { return false }
-func (i doubleColumnIndex) MinValue(int) []byte { return plain.Double(i.page.min()) }
-func (i doubleColumnIndex) MaxValue(int) []byte { return plain.Double(i.page.max()) }
+func (i doubleColumnIndex) MinValue(int) Value  { return makeValueDouble(i.page.min()) }
+func (i doubleColumnIndex) MaxValue(int) Value  { return makeValueDouble(i.page.max()) }
 func (i doubleColumnIndex) IsAscending() bool   { return compareFloat64(i.page.bounds()) < 0 }
 func (i doubleColumnIndex) IsDescending() bool  { return compareFloat64(i.page.bounds()) > 0 }
 
@@ -74,8 +74,8 @@ type uint32ColumnIndex struct{ page uint32Page }
 func (i uint32ColumnIndex) NumPages() int       { return 1 }
 func (i uint32ColumnIndex) NullCount(int) int64 { return 0 }
 func (i uint32ColumnIndex) NullPage(int) bool   { return false }
-func (i uint32ColumnIndex) MinValue(int) []byte { return plain.Int32(int32(i.page.min())) }
-func (i uint32ColumnIndex) MaxValue(int) []byte { return plain.Int32(int32(i.page.max())) }
+func (i uint32ColumnIndex) MinValue(int) Value  { return makeValueInt32(int32(i.page.min())) }
+func (i uint32ColumnIndex) MaxValue(int) Value  { return makeValueInt32(int32(i.page.max())) }
 func (i uint32ColumnIndex) IsAscending() bool   { return compareUint32(i.page.bounds()) < 0 }
 func (i uint32ColumnIndex) IsDescending() bool  { return compareUint32(i.page.bounds()) > 0 }
 
@@ -84,8 +84,8 @@ type uint64ColumnIndex struct{ page uint64Page }
 func (i uint64ColumnIndex) NumPages() int       { return 1 }
 func (i uint64ColumnIndex) NullCount(int) int64 { return 0 }
 func (i uint64ColumnIndex) NullPage(int) bool   { return false }
-func (i uint64ColumnIndex) MinValue(int) []byte { return plain.Int64(int64(i.page.min())) }
-func (i uint64ColumnIndex) MaxValue(int) []byte { return plain.Int64(int64(i.page.max())) }
+func (i uint64ColumnIndex) MinValue(int) Value  { return makeValueInt64(int64(i.page.min())) }
+func (i uint64ColumnIndex) MaxValue(int) Value  { return makeValueInt64(int64(i.page.max())) }
 func (i uint64ColumnIndex) IsAscending() bool   { return compareUint64(i.page.bounds()) < 0 }
 func (i uint64ColumnIndex) IsDescending() bool  { return compareUint64(i.page.bounds()) > 0 }
 

--- a/column_index_default.go
+++ b/column_index_default.go
@@ -4,7 +4,6 @@ package parquet
 
 import (
 	"github.com/segmentio/parquet-go/deprecated"
-	"github.com/segmentio/parquet-go/encoding/plain"
 	"github.com/segmentio/parquet-go/format"
 	"github.com/segmentio/parquet-go/internal/bits"
 )
@@ -44,8 +43,8 @@ type int96ColumnIndex struct{ page *int96Page }
 func (i int96ColumnIndex) NumPages() int       { return 1 }
 func (i int96ColumnIndex) NullCount(int) int64 { return 0 }
 func (i int96ColumnIndex) NullPage(int) bool   { return false }
-func (i int96ColumnIndex) MinValue(int) Value  { return plain.Int96(i.page.min()) }
-func (i int96ColumnIndex) MaxValue(int) Value  { return plain.Int96(i.page.max()) }
+func (i int96ColumnIndex) MinValue(int) Value  { return makeValueInt96(i.page.min()) }
+func (i int96ColumnIndex) MaxValue(int) Value  { return makeValueInt96(i.page.max()) }
 func (i int96ColumnIndex) IsAscending() bool   { return compareInt96(i.page.bounds()) < 0 }
 func (i int96ColumnIndex) IsDescending() bool  { return compareInt96(i.page.bounds()) > 0 }
 

--- a/column_index_go18.go
+++ b/column_index_go18.go
@@ -13,8 +13,8 @@ type columnIndex[T primitive] struct{ page *page[T] }
 func (i columnIndex[T]) NumPages() int       { return 1 }
 func (i columnIndex[T]) NullCount(int) int64 { return 0 }
 func (i columnIndex[T]) NullPage(int) bool   { return false }
-func (i columnIndex[T]) MinValue(int) []byte { return i.page.class.plain(i.page.min()) }
-func (i columnIndex[T]) MaxValue(int) []byte { return i.page.class.plain(i.page.max()) }
+func (i columnIndex[T]) MinValue(int) Value  { return i.page.class.makeValue(i.page.min()) }
+func (i columnIndex[T]) MaxValue(int) Value  { return i.page.class.makeValue(i.page.max()) }
 func (i columnIndex[T]) IsAscending() bool   { return i.page.class.compare(i.page.bounds()) < 0 }
 func (i columnIndex[T]) IsDescending() bool  { return i.page.class.compare(i.page.bounds()) > 0 }
 

--- a/convert.go
+++ b/convert.go
@@ -481,8 +481,8 @@ type missingColumnIndex struct{ *missingColumnChunk }
 func (i missingColumnIndex) NumPages() int       { return 1 }
 func (i missingColumnIndex) NullCount(int) int64 { return i.numNulls }
 func (i missingColumnIndex) NullPage(int) bool   { return true }
-func (i missingColumnIndex) MinValue(int) []byte { return nil }
-func (i missingColumnIndex) MaxValue(int) []byte { return nil }
+func (i missingColumnIndex) MinValue(int) Value  { return Value{} }
+func (i missingColumnIndex) MaxValue(int) Value  { return Value{} }
 func (i missingColumnIndex) IsAscending() bool   { return true }
 func (i missingColumnIndex) IsDescending() bool  { return false }
 

--- a/dictionary.go
+++ b/dictionary.go
@@ -943,13 +943,13 @@ type indexedColumnIndex struct{ col *indexedColumnBuffer }
 func (index indexedColumnIndex) NumPages() int       { return 1 }
 func (index indexedColumnIndex) NullCount(int) int64 { return 0 }
 func (index indexedColumnIndex) NullPage(int) bool   { return false }
-func (index indexedColumnIndex) MinValue(int) []byte {
+func (index indexedColumnIndex) MinValue(int) Value {
 	min, _ := index.col.Bounds()
-	return min.Bytes()
+	return min
 }
-func (index indexedColumnIndex) MaxValue(int) []byte {
+func (index indexedColumnIndex) MaxValue(int) Value {
 	_, max := index.col.Bounds()
-	return max.Bytes()
+	return max
 }
 func (index indexedColumnIndex) IsAscending() bool {
 	return index.col.typ.Compare(index.col.Bounds()) < 0

--- a/file.go
+++ b/file.go
@@ -423,7 +423,7 @@ func (c *fileColumnChunk) ColumnIndex() ColumnIndex {
 	if c.columnIndex == nil {
 		return nil
 	}
-	return (*fileColumnIndex)(c.columnIndex)
+	return fileColumnIndex{c}
 }
 
 func (c *fileColumnChunk) OffsetIndex() OffsetIndex {

--- a/type.go
+++ b/type.go
@@ -30,6 +30,18 @@ const (
 // String returns a human-readable representation of the physical type.
 func (k Kind) String() string { return format.Type(k).String() }
 
+// Value constructs a value form k and v.
+//
+// The method panics if the data is not a valid representation of the value
+// kind; for example, if the kind is Int32 but the data is not 4 bytes long.
+func (k Kind) Value(v []byte) Value {
+	x, err := parseValue(k, v)
+	if err != nil {
+		panic(err)
+	}
+	return x
+}
+
 // The Type interface represents logical types of the parquet type system.
 //
 // Types are immutable and therefore safe to access from multiple goroutines.


### PR DESCRIPTION
Based on #101, this PR modifies the `parquet.ColumnIndex` interface to return `parquet.Value` instead of `[]byte` on the `MinValue` and `MaxValue` methods.

This changes was discussed in #80, it also aligns with #75, and will help implement generic versions of predicate pushdown by allowing values to be compared. Prior to this change, we had no way of knowing the underlying type of the `[]byte` returned by the index.
