### PR TITLE
Add failing test for checking bloomfilter of a dict encoded column

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -762,6 +762,12 @@ func (c *writerColumn) flushFilterPages() error {
 		if c.page.filter == nil {
 			c.page.filter = c.newBloomFilterEncoder(numValues)
 		}
+
+		// If there is a dictionary, we need to only write the dictionary.
+		if dict := c.dictionary; dict != nil {
+			return dict.WriteTo(c.page.filter)
+		}
+
 		for _, page := range c.filter {
 			if err := page.WriteTo(c.page.filter); err != nil {
 				return err


### PR DESCRIPTION
I don't have a fix yet, but I noticed that bloomfilter checks don't seem to work as expected on dictionary encoded columns. This adds a test to show the unexpected behavior.