### PR TITLE
Optimize looking up min/max values of pages with dictionaries

### DIFF
--- a/dictionary.go
+++ b/dictionary.go
@@ -28,11 +28,14 @@ type Dictionary interface {
 	Len() int
 
 	// Returns the dictionary value at the given index.
-	Index(int) Value
+	Index(index int32) Value
 
-	// Inserts a value to the dictionary, returning the index at which it was
-	// recorded.
-	Insert(Value) int
+	// Inserts values from the second slice to the dictionary and writes the
+	// indexes at which each value was inserted to the first slice.
+	//
+	// The method panics if the length of the indexes slice is smaller than the
+	// length of the values slice.
+	Insert(indexes []int32, values []Value)
 
 	// Given an array of dictionary indexes, lookup the values into the array
 	// of values passed as second argument.
@@ -79,27 +82,41 @@ func (d *byteArrayDictionary) Type() Type { return newIndexedType(d.typ, d) }
 
 func (d *byteArrayDictionary) Len() int { return d.values.Len() }
 
-func (d *byteArrayDictionary) Index(i int) Value { return makeValueBytes(ByteArray, d.values.Index(i)) }
+func (d *byteArrayDictionary) Index(i int32) Value {
+	return makeValueBytes(ByteArray, d.values.Index(int(i)))
+}
 
-func (d *byteArrayDictionary) Insert(v Value) int { return d.insert(v.ByteArray()) }
+func (d *byteArrayDictionary) Insert(indexes []int32, values []Value) {
+	_ = indexes[:len(values)]
 
-func (d *byteArrayDictionary) insert(value []byte) int {
-	if index, exists := d.index[string(value)]; exists {
-		return int(index)
-	}
-	d.values.Push(value)
-	index := d.values.Len() - 1
-	stringValue := bits.BytesToString(d.values.Index(index))
 	if d.index == nil {
+		index := int32(0)
 		d.index = make(map[string]int32, d.values.Cap())
+		d.values.Range(func(v []byte) bool {
+			d.index[bits.BytesToString(v)] = index
+			index++
+			return true
+		})
 	}
-	d.index[stringValue] = int32(index)
-	return index
+
+	for i, v := range values {
+		value := v.ByteArray()
+
+		index, exists := d.index[string(value)]
+		if !exists {
+			d.values.Push(value)
+			index = int32(d.values.Len() - 1)
+			stringValue := bits.BytesToString(d.values.Index(int(index)))
+			d.index[stringValue] = index
+		}
+
+		indexes[i] = index
+	}
 }
 
 func (d *byteArrayDictionary) Lookup(indexes []int32, values []Value) {
 	for i, j := range indexes {
-		values[i] = d.Index(int(j))
+		values[i] = d.Index(j)
 	}
 }
 
@@ -172,45 +189,53 @@ func (d *fixedLenByteArrayDictionary) Type() Type { return newIndexedType(d.typ,
 
 func (d *fixedLenByteArrayDictionary) Len() int { return len(d.values) / d.size }
 
-func (d *fixedLenByteArrayDictionary) Index(i int) Value {
+func (d *fixedLenByteArrayDictionary) Index(i int32) Value {
 	return makeValueBytes(FixedLenByteArray, d.value(i))
 }
 
-func (d *fixedLenByteArrayDictionary) value(i int) []byte {
-	return d.values[i*d.size : (i+1)*d.size]
+func (d *fixedLenByteArrayDictionary) value(i int32) []byte {
+	return d.values[int(i)*d.size : int(i+1)*d.size]
 }
 
-func (d *fixedLenByteArrayDictionary) Insert(v Value) int {
-	return d.insert(v.ByteArray())
-}
+func (d *fixedLenByteArrayDictionary) Insert(indexes []int32, values []Value) {
+	_ = indexes[:len(values)]
 
-func (d *fixedLenByteArrayDictionary) insert(value []byte) int {
-	if index, exists := d.index[string(value)]; exists {
-		return int(index)
-	}
 	if d.index == nil {
 		d.index = make(map[string]int32, cap(d.values)/d.size)
+		for i, j := 0, int32(0); i < len(d.values); i += d.size {
+			d.index[bits.BytesToString(d.values[i:i+d.size])] = j
+			j++
+		}
 	}
-	i := d.Len()
-	n := len(d.values)
-	d.values = append(d.values, value...)
-	d.index[bits.BytesToString(d.values[n:])] = int32(i)
-	return i
+
+	for i, v := range values {
+		value := v.ByteArray()
+
+		index, exists := d.index[string(value)]
+		if !exists {
+			index = int32(d.Len())
+			start := len(d.values)
+			d.values = append(d.values, value...)
+			d.index[bits.BytesToString(d.values[start:])] = index
+		}
+
+		indexes[i] = index
+	}
 }
 
 func (d *fixedLenByteArrayDictionary) Lookup(indexes []int32, values []Value) {
 	for i, j := range indexes {
-		values[i] = d.Index(int(j))
+		values[i] = d.Index(j)
 	}
 }
 
 func (d *fixedLenByteArrayDictionary) Bounds(indexes []int32) (min, max Value) {
 	if len(indexes) > 0 {
-		minValue := d.value(int(indexes[0]))
+		minValue := d.value(indexes[0])
 		maxValue := minValue
 
 		for _, i := range indexes[1:] {
-			value := d.value(int(i))
+			value := d.value(i)
 			switch {
 			case bytes.Compare(value, minValue) < 0:
 				minValue = value
@@ -338,7 +363,7 @@ type indexedPageReader struct {
 func (r *indexedPageReader) ReadValues(values []Value) (n int, err error) {
 	var v Value
 	for n < len(values) && r.offset < len(r.page.values) {
-		v = r.page.dict.Index(int(r.page.values[r.offset]))
+		v = r.page.dict.Index(r.page.values[r.offset])
 		v.columnIndex = r.page.columnIndex
 		values[n] = v
 		r.offset++
@@ -399,8 +424,8 @@ func (col *indexedColumnBuffer) Cap() int { return cap(col.values) }
 func (col *indexedColumnBuffer) Len() int { return len(col.values) }
 
 func (col *indexedColumnBuffer) Less(i, j int) bool {
-	u := col.dict.Index(int(col.values[i]))
-	v := col.dict.Index(int(col.values[j]))
+	u := col.dict.Index(col.values[i])
+	v := col.dict.Index(col.values[j])
 	return col.typ.Compare(u, v) < 0
 }
 
@@ -409,9 +434,18 @@ func (col *indexedColumnBuffer) Swap(i, j int) {
 }
 
 func (col *indexedColumnBuffer) WriteValues(values []Value) (int, error) {
-	for _, v := range values {
-		col.values = append(col.values, int32(col.dict.Insert(v)))
+	i := len(col.values)
+	j := len(col.values) + len(values)
+
+	if j <= cap(col.values) {
+		col.values = col.values[:j]
+	} else {
+		colValues := make([]int32, j)
+		copy(colValues, col.values)
+		col.values = colValues
 	}
+
+	col.dict.Insert(col.values[i:], values)
 	return len(values), nil
 }
 
@@ -422,8 +456,8 @@ func (col *indexedColumnBuffer) WriteRow(row Row) error {
 	if len(row) > 1 {
 		return errRowHasTooManyValues(int64(len(row)))
 	}
-	col.values = append(col.values, int32(col.dict.Insert(row[0])))
-	return nil
+	_, err := col.WriteValues(row[:1])
+	return err
 }
 
 func (col *indexedColumnBuffer) ReadRowAt(row Row, index int64) (Row, error) {
@@ -433,7 +467,7 @@ func (col *indexedColumnBuffer) ReadRowAt(row Row, index int64) (Row, error) {
 	case index >= int64(len(col.values)):
 		return row, io.EOF
 	default:
-		v := col.dict.Index(int(col.values[index]))
+		v := col.dict.Index(col.values[index])
 		v.columnIndex = col.columnIndex
 		return append(row, v), nil
 	}

--- a/dictionary_default.go
+++ b/dictionary_default.go
@@ -27,19 +27,23 @@ func (d *booleanDictionary) Type() Type { return newIndexedType(d.typ, d) }
 
 func (d *booleanDictionary) Len() int { return 2 }
 
-func (d *booleanDictionary) Index(i int) Value { return makeValueBoolean(d.values[i]) }
+func (d *booleanDictionary) Index(i int32) Value { return makeValueBoolean(d.values[i]) }
 
-func (d *booleanDictionary) Insert(v Value) int {
-	if v.Boolean() {
-		return 1
-	} else {
-		return 0
+func (d *booleanDictionary) Insert(indexes []int32, values []Value) {
+	_ = indexes[:len(values)]
+
+	for i, v := range values {
+		if v.Boolean() {
+			indexes[i] = 1
+		} else {
+			indexes[i] = 0
+		}
 	}
 }
 
 func (d *booleanDictionary) Lookup(indexes []int32, values []Value) {
 	for i, j := range indexes {
-		values[i] = d.Index(int(j))
+		values[i] = d.Index(j)
 	}
 }
 
@@ -105,29 +109,35 @@ func (d *int32Dictionary) Type() Type { return newIndexedType(d.typ, d) }
 
 func (d *int32Dictionary) Len() int { return len(d.values) }
 
-func (d *int32Dictionary) Index(i int) Value { return makeValueInt32(d.values[i]) }
+func (d *int32Dictionary) Index(i int32) Value { return makeValueInt32(d.values[i]) }
 
-func (d *int32Dictionary) Insert(v Value) int { return d.insert(v.Int32()) }
+func (d *int32Dictionary) Insert(indexes []int32, values []Value) {
+	_ = indexes[:len(values)]
 
-func (d *int32Dictionary) insert(value int32) int {
-	if index, exists := d.index[value]; exists {
-		return int(index)
-	}
 	if d.index == nil {
 		d.index = make(map[int32]int32, cap(d.values))
 		for i, v := range d.values {
 			d.index[v] = int32(i)
 		}
 	}
-	index := len(d.values)
-	d.index[value] = int32(index)
-	d.values = append(d.values, value)
-	return index
+
+	for i, v := range values {
+		value := v.Int32()
+
+		index, exists := d.index[value]
+		if !exists {
+			index = int32(len(d.values))
+			d.values = append(d.values, value)
+			d.index[value] = index
+		}
+
+		indexes[i] = index
+	}
 }
 
 func (d *int32Dictionary) Lookup(indexes []int32, values []Value) {
 	for i, j := range indexes {
-		values[i] = d.Index(int(j))
+		values[i] = d.Index(j)
 	}
 }
 
@@ -206,29 +216,35 @@ func (d *int64Dictionary) Type() Type { return newIndexedType(d.typ, d) }
 
 func (d *int64Dictionary) Len() int { return len(d.values) }
 
-func (d *int64Dictionary) Index(i int) Value { return makeValueInt64(d.values[i]) }
+func (d *int64Dictionary) Index(i int32) Value { return makeValueInt64(d.values[i]) }
 
-func (d *int64Dictionary) Insert(v Value) int { return d.insert(v.Int64()) }
+func (d *int64Dictionary) Insert(indexes []int32, values []Value) {
+	_ = indexes[:len(values)]
 
-func (d *int64Dictionary) insert(value int64) int {
-	if index, exists := d.index[value]; exists {
-		return int(index)
-	}
 	if d.index == nil {
 		d.index = make(map[int64]int32, cap(d.values))
 		for i, v := range d.values {
 			d.index[v] = int32(i)
 		}
 	}
-	index := len(d.values)
-	d.index[value] = int32(index)
-	d.values = append(d.values, value)
-	return index
+
+	for i, v := range values {
+		value := v.Int64()
+
+		index, exists := d.index[value]
+		if !exists {
+			index = int32(len(d.values))
+			d.values = append(d.values, value)
+			d.index[value] = index
+		}
+
+		indexes[i] = index
+	}
 }
 
 func (d *int64Dictionary) Lookup(indexes []int32, values []Value) {
 	for i, j := range indexes {
-		values[i] = d.Index(int(j))
+		values[i] = d.Index(j)
 	}
 }
 
@@ -307,29 +323,35 @@ func (d *int96Dictionary) Type() Type { return newIndexedType(d.typ, d) }
 
 func (d *int96Dictionary) Len() int { return len(d.values) }
 
-func (d *int96Dictionary) Index(i int) Value { return makeValueInt96(d.values[i]) }
+func (d *int96Dictionary) Index(i int32) Value { return makeValueInt96(d.values[i]) }
 
-func (d *int96Dictionary) Insert(v Value) int { return d.insert(v.Int96()) }
+func (d *int96Dictionary) Insert(indexes []int32, values []Value) {
+	_ = indexes[:len(values)]
 
-func (d *int96Dictionary) insert(value deprecated.Int96) int {
-	if index, exists := d.index[value]; exists {
-		return int(index)
-	}
 	if d.index == nil {
 		d.index = make(map[deprecated.Int96]int32, cap(d.values))
 		for i, v := range d.values {
 			d.index[v] = int32(i)
 		}
 	}
-	index := len(d.values)
-	d.index[value] = int32(index)
-	d.values = append(d.values, value)
-	return index
+
+	for i, v := range values {
+		value := v.Int96()
+
+		index, exists := d.index[value]
+		if !exists {
+			index = int32(len(d.values))
+			d.values = append(d.values, value)
+			d.index[value] = index
+		}
+
+		indexes[i] = index
+	}
 }
 
 func (d *int96Dictionary) Lookup(indexes []int32, values []Value) {
 	for i, j := range indexes {
-		values[i] = d.Index(int(j))
+		values[i] = d.Index(j)
 	}
 }
 
@@ -408,29 +430,35 @@ func (d *floatDictionary) Type() Type { return newIndexedType(d.typ, d) }
 
 func (d *floatDictionary) Len() int { return len(d.values) }
 
-func (d *floatDictionary) Index(i int) Value { return makeValueFloat(d.values[i]) }
+func (d *floatDictionary) Index(i int32) Value { return makeValueFloat(d.values[i]) }
 
-func (d *floatDictionary) Insert(v Value) int { return d.insert(v.Float()) }
+func (d *floatDictionary) Insert(indexes []int32, values []Value) {
+	_ = indexes[:len(values)]
 
-func (d *floatDictionary) insert(value float32) int {
-	if index, exists := d.index[value]; exists {
-		return int(index)
-	}
 	if d.index == nil {
 		d.index = make(map[float32]int32, cap(d.values))
 		for i, v := range d.values {
 			d.index[v] = int32(i)
 		}
 	}
-	index := len(d.values)
-	d.index[value] = int32(index)
-	d.values = append(d.values, value)
-	return index
+
+	for i, v := range values {
+		value := v.Float()
+
+		index, exists := d.index[value]
+		if !exists {
+			index = int32(len(d.values))
+			d.values = append(d.values, value)
+			d.index[value] = index
+		}
+
+		indexes[i] = index
+	}
 }
 
 func (d *floatDictionary) Lookup(indexes []int32, values []Value) {
 	for i, j := range indexes {
-		values[i] = d.Index(int(j))
+		values[i] = d.Index(j)
 	}
 }
 
@@ -509,29 +537,35 @@ func (d *doubleDictionary) Type() Type { return newIndexedType(d.typ, d) }
 
 func (d *doubleDictionary) Len() int { return len(d.values) }
 
-func (d *doubleDictionary) Index(i int) Value { return makeValueDouble(d.values[i]) }
+func (d *doubleDictionary) Index(i int32) Value { return makeValueDouble(d.values[i]) }
 
-func (d *doubleDictionary) Insert(v Value) int { return d.insert(v.Double()) }
+func (d *doubleDictionary) Insert(indexes []int32, values []Value) {
+	_ = indexes[:len(values)]
 
-func (d *doubleDictionary) insert(value float64) int {
-	if index, exists := d.index[value]; exists {
-		return int(index)
-	}
 	if d.index == nil {
 		d.index = make(map[float64]int32, cap(d.values))
 		for i, v := range d.values {
 			d.index[v] = int32(i)
 		}
 	}
-	index := len(d.values)
-	d.index[value] = int32(index)
-	d.values = append(d.values, value)
-	return index
+
+	for i, v := range values {
+		value := v.Double()
+
+		index, exists := d.index[value]
+		if !exists {
+			index = int32(len(d.values))
+			d.values = append(d.values, value)
+			d.index[value] = index
+		}
+
+		indexes[i] = index
+	}
 }
 
 func (d *doubleDictionary) Lookup(indexes []int32, values []Value) {
 	for i, j := range indexes {
-		values[i] = d.Index(int(j))
+		values[i] = d.Index(j)
 	}
 }
 

--- a/dictionary_default.go
+++ b/dictionary_default.go
@@ -341,9 +341,9 @@ func (d *int96Dictionary) Bounds(indexes []int32) (min, max Value) {
 		for _, i := range indexes[1:] {
 			value := d.values[i]
 			switch {
-			case value < minValue:
+			case value.Less(minValue):
 				minValue = value
-			case value > maxValue:
+			case maxValue.Less(value):
 				maxValue = value
 			}
 		}

--- a/dictionary_default.go
+++ b/dictionary_default.go
@@ -599,6 +599,8 @@ func newUint32Dictionary(typ Type, bufferSize int) uint32Dictionary {
 	return uint32Dictionary{newInt32Dictionary(typ, bufferSize)}
 }
 
+func (d uint32Dictionary) Type() Type { return newIndexedType(d.typ, d) }
+
 func (d uint32Dictionary) Bounds(indexes []int32) (min, max Value) {
 	if len(indexes) > 0 {
 		minValue := uint32(d.values[indexes[0]])
@@ -625,6 +627,8 @@ type uint64Dictionary struct{ *int64Dictionary }
 func newUint64Dictionary(typ Type, bufferSize int) uint64Dictionary {
 	return uint64Dictionary{newInt64Dictionary(typ, bufferSize)}
 }
+
+func (d uint64Dictionary) Type() Type { return newIndexedType(d.typ, d) }
 
 func (d uint64Dictionary) Bounds(indexes []int32) (min, max Value) {
 	if len(indexes) > 0 {

--- a/dictionary_default.go
+++ b/dictionary_default.go
@@ -43,6 +43,27 @@ func (d *booleanDictionary) Lookup(indexes []int32, values []Value) {
 	}
 }
 
+func (d *booleanDictionary) Bounds(indexes []int32) (min, max Value) {
+	if len(indexes) > 0 {
+		minValue := d.values[indexes[0]]
+		maxValue := minValue
+
+		for _, i := range indexes[1:] {
+			value := d.values[i]
+			switch {
+			case compareBool(value, minValue) < 0:
+				minValue = value
+			case compareBool(value, maxValue) > 0:
+				maxValue = value
+			}
+		}
+
+		min = makeValueBoolean(minValue)
+		max = makeValueBoolean(maxValue)
+	}
+	return min, max
+}
+
 func (d *booleanDictionary) ReadFrom(decoder encoding.Decoder) error {
 	_, err := decoder.DecodeBoolean(d.values[:])
 	d.Reset()
@@ -108,6 +129,27 @@ func (d *int32Dictionary) Lookup(indexes []int32, values []Value) {
 	for i, j := range indexes {
 		values[i] = d.Index(int(j))
 	}
+}
+
+func (d *int32Dictionary) Bounds(indexes []int32) (min, max Value) {
+	if len(indexes) > 0 {
+		minValue := d.values[indexes[0]]
+		maxValue := minValue
+
+		for _, i := range indexes[1:] {
+			value := d.values[i]
+			switch {
+			case value < minValue:
+				minValue = value
+			case value > maxValue:
+				maxValue = value
+			}
+		}
+
+		min = makeValueInt32(minValue)
+		max = makeValueInt32(maxValue)
+	}
+	return min, max
 }
 
 func (d *int32Dictionary) ReadFrom(decoder encoding.Decoder) error {
@@ -190,6 +232,27 @@ func (d *int64Dictionary) Lookup(indexes []int32, values []Value) {
 	}
 }
 
+func (d *int64Dictionary) Bounds(indexes []int32) (min, max Value) {
+	if len(indexes) > 0 {
+		minValue := d.values[indexes[0]]
+		maxValue := minValue
+
+		for _, i := range indexes[1:] {
+			value := d.values[i]
+			switch {
+			case value < minValue:
+				minValue = value
+			case value > maxValue:
+				maxValue = value
+			}
+		}
+
+		min = makeValueInt64(minValue)
+		max = makeValueInt64(maxValue)
+	}
+	return min, max
+}
+
 func (d *int64Dictionary) ReadFrom(decoder encoding.Decoder) error {
 	d.Reset()
 	for {
@@ -268,6 +331,27 @@ func (d *int96Dictionary) Lookup(indexes []int32, values []Value) {
 	for i, j := range indexes {
 		values[i] = d.Index(int(j))
 	}
+}
+
+func (d *int96Dictionary) Bounds(indexes []int32) (min, max Value) {
+	if len(indexes) > 0 {
+		minValue := d.values[indexes[0]]
+		maxValue := minValue
+
+		for _, i := range indexes[1:] {
+			value := d.values[i]
+			switch {
+			case value < minValue:
+				minValue = value
+			case value > maxValue:
+				maxValue = value
+			}
+		}
+
+		min = makeValueInt96(minValue)
+		max = makeValueInt96(maxValue)
+	}
+	return min, max
 }
 
 func (d *int96Dictionary) ReadFrom(decoder encoding.Decoder) error {
@@ -350,6 +434,27 @@ func (d *floatDictionary) Lookup(indexes []int32, values []Value) {
 	}
 }
 
+func (d *floatDictionary) Bounds(indexes []int32) (min, max Value) {
+	if len(indexes) > 0 {
+		minValue := d.values[indexes[0]]
+		maxValue := minValue
+
+		for _, i := range indexes[1:] {
+			value := d.values[i]
+			switch {
+			case value < minValue:
+				minValue = value
+			case value > maxValue:
+				maxValue = value
+			}
+		}
+
+		min = makeValueFloat(minValue)
+		max = makeValueFloat(maxValue)
+	}
+	return min, max
+}
+
 func (d *floatDictionary) ReadFrom(decoder encoding.Decoder) error {
 	d.Reset()
 	for {
@@ -430,6 +535,27 @@ func (d *doubleDictionary) Lookup(indexes []int32, values []Value) {
 	}
 }
 
+func (d *doubleDictionary) Bounds(indexes []int32) (min, max Value) {
+	if len(indexes) > 0 {
+		minValue := d.values[indexes[0]]
+		maxValue := minValue
+
+		for _, i := range indexes[1:] {
+			value := d.values[i]
+			switch {
+			case value < minValue:
+				minValue = value
+			case value > maxValue:
+				maxValue = value
+			}
+		}
+
+		min = makeValueDouble(minValue)
+		max = makeValueDouble(maxValue)
+	}
+	return min, max
+}
+
 func (d *doubleDictionary) ReadFrom(decoder encoding.Decoder) error {
 	d.Reset()
 	for {
@@ -465,4 +591,58 @@ func (d *doubleDictionary) WriteTo(encoder encoding.Encoder) error {
 func (d *doubleDictionary) Reset() {
 	d.values = d.values[:0]
 	d.index = nil
+}
+
+type uint32Dictionary struct{ *int32Dictionary }
+
+func newUint32Dictionary(typ Type, bufferSize int) uint32Dictionary {
+	return uint32Dictionary{newInt32Dictionary(typ, bufferSize)}
+}
+
+func (d uint32Dictionary) Bounds(indexes []int32) (min, max Value) {
+	if len(indexes) > 0 {
+		minValue := uint32(d.values[indexes[0]])
+		maxValue := minValue
+
+		for _, i := range indexes[1:] {
+			value := uint32(d.values[i])
+			switch {
+			case value < minValue:
+				minValue = value
+			case value > maxValue:
+				maxValue = value
+			}
+		}
+
+		min = makeValueInt32(int32(minValue))
+		max = makeValueInt32(int32(maxValue))
+	}
+	return min, max
+}
+
+type uint64Dictionary struct{ *int64Dictionary }
+
+func newUint64Dictionary(typ Type, bufferSize int) uint64Dictionary {
+	return uint64Dictionary{newInt64Dictionary(typ, bufferSize)}
+}
+
+func (d uint64Dictionary) Bounds(indexes []int32) (min, max Value) {
+	if len(indexes) > 0 {
+		minValue := uint64(d.values[indexes[0]])
+		maxValue := minValue
+
+		for _, i := range indexes[1:] {
+			value := uint64(d.values[i])
+			switch {
+			case value < minValue:
+				minValue = value
+			case value > maxValue:
+				maxValue = value
+			}
+		}
+
+		min = makeValueInt64(int64(minValue))
+		max = makeValueInt64(int64(maxValue))
+	}
+	return min, max
 }

--- a/dictionary_go18.go
+++ b/dictionary_go18.go
@@ -28,29 +28,37 @@ func (d *dictionary[T]) Type() Type { return newIndexedType(d.typ, d) }
 
 func (d *dictionary[T]) Len() int { return len(d.values) }
 
-func (d *dictionary[T]) Index(i int) Value { return d.class.makeValue(d.values[i]) }
+func (d *dictionary[T]) Index(index int32) Value {
+	return d.class.makeValue(d.values[index])
+}
 
-func (d *dictionary[T]) Insert(v Value) int { return d.insert(d.class.value(v)) }
+func (d *dictionary[T]) Insert(indexes []int32, values []Value) {
+	_ = indexes[:len(values)]
 
-func (d *dictionary[T]) insert(value T) int {
-	if index, exists := d.index[value]; exists {
-		return int(index)
-	}
 	if d.index == nil {
 		d.index = make(map[T]int32, cap(d.values))
 		for i, v := range d.values {
 			d.index[v] = int32(i)
 		}
 	}
-	index := len(d.values)
-	d.index[value] = int32(index)
-	d.values = append(d.values, value)
-	return index
+
+	for i, v := range values {
+		value := d.class.value(v)
+
+		index, exists := d.index[value]
+		if !exists {
+			index = int32(len(d.values))
+			d.values = append(d.values, value)
+			d.index[value] = index
+		}
+
+		indexes[i] = index
+	}
 }
 
 func (d *dictionary[T]) Lookup(indexes []int32, values []Value) {
 	for i, j := range indexes {
-		values[i] = d.Index(int(j))
+		values[i] = d.Index(j)
 	}
 }
 

--- a/dictionary_go18.go
+++ b/dictionary_go18.go
@@ -54,6 +54,29 @@ func (d *dictionary[T]) Lookup(indexes []int32, values []Value) {
 	}
 }
 
+func (d *dictionary[T]) Bounds(indexes []int32) (min, max Value) {
+	if len(indexes) > 0 {
+		minValue := d.values[indexes[0]]
+		maxValue := minValue
+		less := d.class.less
+
+		for _, i := range indexes[1:] {
+			value := d.values[i]
+			switch {
+			case less(value, minValue):
+				minValue = value
+			case less(maxValue, value):
+				maxValue = value
+			}
+		}
+
+		makeValue := d.class.makeValue
+		min = makeValue(minValue)
+		max = makeValue(maxValue)
+	}
+	return min, max
+}
+
 func (d *dictionary[T]) ReadFrom(decoder encoding.Decoder) error {
 	d.Reset()
 	for {

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -1,0 +1,49 @@
+package parquet_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/segmentio/parquet-go"
+)
+
+func BenchmarkDictionaryPageBounds(b *testing.B) {
+	benchmarkDictionary(b, func(b *testing.B, typ parquet.Type) {
+		values := make([]parquet.Value, 1e3)
+		f := randValueFuncOf(typ)
+		r := rand.New(rand.NewSource(0))
+
+		for i := range values {
+			values[i] = f(r)
+		}
+
+		for i := 0; i < b.N; i++ {
+			page := randDictionaryPage(typ, values)
+			page.Bounds()
+		}
+	})
+}
+
+func benchmarkDictionary(b *testing.B, do func(*testing.B, parquet.Type)) {
+	types := []parquet.Type{
+		parquet.BooleanType,
+		parquet.Int32Type,
+		parquet.Int64Type,
+		parquet.Int96Type,
+		parquet.FloatType,
+		parquet.DoubleType,
+		parquet.ByteArrayType,
+	}
+
+	for _, typ := range types {
+		b.Run(typ.String(), func(b *testing.B) { do(b, typ) })
+	}
+}
+
+func randDictionaryPage(typ parquet.Type, values []parquet.Value) parquet.BufferedPage {
+	const bufferSize = 64 * 1024
+	dict := typ.NewDictionary(4 * bufferSize)
+	buf := dict.Type().NewColumnBuffer(0, bufferSize)
+	buf.WriteValues(values)
+	return buf.Page()
+}

--- a/type_default.go
+++ b/type_default.go
@@ -310,10 +310,18 @@ func (t *intType) NewColumnIndexer(sizeLimit int) ColumnIndexer {
 }
 
 func (t *intType) NewDictionary(bufferSize int) Dictionary {
-	if t.BitWidth == 64 {
-		return newInt64Dictionary(t, bufferSize)
+	if t.IsSigned {
+		if t.BitWidth == 64 {
+			return newInt64Dictionary(t, bufferSize)
+		} else {
+			return newInt32Dictionary(t, bufferSize)
+		}
 	} else {
-		return newInt32Dictionary(t, bufferSize)
+		if t.BitWidth == 64 {
+			return newUint64Dictionary(t, bufferSize)
+		} else {
+			return newUint32Dictionary(t, bufferSize)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds a benchmark to highlight a performance bottleneck that was reported when computing the min/max bounds of pages with dictionaries, and proposes introducing a new `parquet.Dictionary.Bounds` method optimizing the operation.

After analyzing CPU profiles, it appeared that the excessive compute footprint was mostly driven by the cost of abstractions: multiple indirect method calls through interface and deep call stacks in a tight loop over large data sets add up quickly.

To amortize the cost of abstractions, I am adding a `Bounds(indexes []int32) (min, max Value)` method to the `parquet.Dictionary` interface, that the indexed pages delegate the computation of min/max values to, passing the list of dictionary indexes that belong to the page as argument. With this model, we cross abstraction boundaries only once per bound lookup, instead of once for each comparison, which amortizes the compute cost.

Here is a comparison of the benchmark I added highlighting the impact of the change:
```
name                             old time/op    new time/op    delta
DictionaryPageBounds/BOOLEAN       58.9µs ± 1%    27.6µs ± 1%  -53.22%  (p=0.000 n=10+9)
DictionaryPageBounds/INT32         65.6µs ± 0%    38.4µs ± 1%  -41.49%  (p=0.000 n=10+10)
DictionaryPageBounds/INT64         69.9µs ± 1%    42.0µs ± 1%  -39.89%  (p=0.000 n=9+10)
DictionaryPageBounds/INT96          127µs ± 1%      64µs ± 1%  -49.41%  (p=0.000 n=8+10)
DictionaryPageBounds/FLOAT         73.0µs ± 1%    46.0µs ± 1%  -37.02%  (p=0.000 n=10+10)
DictionaryPageBounds/DOUBLE        74.9µs ± 0%    47.7µs ± 0%  -36.38%  (p=0.000 n=10+6)
DictionaryPageBounds/BYTE_ARRAY    70.1µs ± 1%    41.0µs ± 1%  -41.51%  (p=0.000 n=10+10)

name                             old alloc/op   new alloc/op   delta
DictionaryPageBounds/BOOLEAN        331kB ± 0%     331kB ± 0%   -0.01%  (p=0.000 n=10+10)
DictionaryPageBounds/INT32          303kB ± 0%     303kB ± 0%   -0.01%  (p=0.000 n=10+10)
DictionaryPageBounds/INT64          393kB ± 0%     393kB ± 0%   -0.01%  (p=0.000 n=10+10)
DictionaryPageBounds/INT96          491kB ± 0%     475kB ± 0%   -3.26%  (p=0.000 n=10+10)
DictionaryPageBounds/FLOAT          303kB ± 0%     303kB ± 0%   -0.01%  (p=0.000 n=10+10)
DictionaryPageBounds/DOUBLE         393kB ± 0%     393kB ± 0%   -0.01%  (p=0.000 n=10+10)
DictionaryPageBounds/BYTE_ARRAY     361kB ± 0%     361kB ± 0%   -0.01%  (p=0.000 n=10+10)

name                             old allocs/op  new allocs/op  delta
DictionaryPageBounds/BOOLEAN         9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.000 n=10+10)
DictionaryPageBounds/INT32           9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.000 n=10+10)
DictionaryPageBounds/INT64           9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.000 n=10+10)
DictionaryPageBounds/INT96          1.01k ± 0%     0.01k ± 0%  -99.01%  (p=0.000 n=10+10)
DictionaryPageBounds/FLOAT           9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.000 n=10+10)
DictionaryPageBounds/DOUBLE          9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.000 n=10+10)
DictionaryPageBounds/BYTE_ARRAY      10.0 ± 0%       9.0 ± 0%  -10.00%  (p=0.000 n=10+10)
```

Another interesting quality of this approach is that it opens-up the door to further optimizations using SIMD operations and AVX gather instructions since we are working on two arrays of contiguous values (the indexes and the dictionary values).

I based the PR on #103 since I had made changes to the dictionary types. I gotta say I'm looking forward to not have to maintain 1.17 anymore :D 