### PR TITLE
fix github annotations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       matrix:
         go:
-        - 1.17
-        - 1.18
+        - '1.17.x'
+        - '1.18.x'
         tags:
         - ''
         - purego
@@ -26,8 +26,19 @@ jobs:
     - name: Download Dependencies
       run: go mod download
 
-    - name: Validate Formatting
-      run: test -z $(find . -name '*.go' | xargs gofmt -l)
-
     - name: Run Tests
       run: go test -race -tags=${{ matrix.tags }} ./...
+
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Go ${{ matrix.go }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.18.x'
+
+    - name: Validate formatting
+      run: make format

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+.PHONY: format
+
 AUTHORS.txt: .mailmap
 	go install github.com/kevinburke/write_mailmap@latest
 	write_mailmap > AUTHORS.txt
+
+format:
+	go install github.com/kevinburke/differ@latest
+	differ gofmt -w .


### PR DESCRIPTION
    Previously Github would complain about the syntax when you ran the
    formatter using go 1.17, because the formatter doesn't know to ignore
    go 1.18 files.

    Instead only run the formatter on go 1.18 files.