### PR TITLE
Add new decimal primitive type

### DIFF
--- a/node.go
+++ b/node.go
@@ -504,7 +504,7 @@ func encodingAndCompressionOf(node Node) (encoding.Encoding, compress.Codec) {
 	// the opportunity to override this behavior if needed.
 	//
 	// https://github.com/apache/parquet-format/blob/master/Encodings.md#delta-length-byte-array-delta_length_byte_array--6
-	if node.Type().Kind() == ByteArray {
+	if node.Type().Kind() == ByteArray && len(node.Encoding()) == 0 {
 		encoding = &DeltaLengthByteArray
 	}
 

--- a/node.go
+++ b/node.go
@@ -496,6 +496,7 @@ func encodingAndCompressionOf(node Node) (encoding.Encoding, compress.Codec) {
 	// representations of the pages, picking the one with the smallest space
 	// footprint; keep it simple for now.
 	encoding := encoding.Encoding(&Plain)
+	nodeEncoding := node.Encoding()
 	compression := compress.Codec(&Uncompressed)
 	// The parquet-format documentation states that the
 	// DELTA_LENGTH_BYTE_ARRAY is always preferred to PLAIN when
@@ -504,11 +505,11 @@ func encodingAndCompressionOf(node Node) (encoding.Encoding, compress.Codec) {
 	// the opportunity to override this behavior if needed.
 	//
 	// https://github.com/apache/parquet-format/blob/master/Encodings.md#delta-length-byte-array-delta_length_byte_array--6
-	if node.Type().Kind() == ByteArray && len(node.Encoding()) == 0 {
+	if node.Type().Kind() == ByteArray && len(nodeEncoding) == 0 {
 		encoding = &DeltaLengthByteArray
 	}
 
-	for _, e := range node.Encoding() {
+	for _, e := range nodeEncoding {
 		encoding = e
 		break
 	}

--- a/schema.go
+++ b/schema.go
@@ -2,7 +2,6 @@ package parquet
 
 import (
 	"fmt"
-	"math"
 	"reflect"
 	"sort"
 	"strconv"
@@ -558,8 +557,7 @@ func makeStructField(f reflect.StructField) structField {
 				case reflect.Int64:
 					baseType = Int64Type
 				case reflect.Array:
-					length := int(math.Ceil((math.Log10(2) + float64(precision)) / math.Log10(256)))
-					baseType = FixedLenByteArrayType(length)
+					baseType = FixedLenByteArrayType(CalcDecimalFixedLenByteArraySize(precision))
 				default:
 					throwInvalidFieldTag(f, option)
 				}

--- a/schema.go
+++ b/schema.go
@@ -557,7 +557,7 @@ func makeStructField(f reflect.StructField) structField {
 				case reflect.Int64:
 					baseType = Int64Type
 				case reflect.Array:
-					baseType = FixedLenByteArrayType(CalcDecimalFixedLenByteArraySize(precision))
+					baseType = FixedLenByteArrayType(calcDecimalFixedLenByteArraySize(precision))
 				default:
 					throwInvalidFieldTag(f, option)
 				}

--- a/type.go
+++ b/type.go
@@ -305,16 +305,21 @@ func (t *intType) ConvertedType() *deprecated.ConvertedType {
 	return &convertedTypes[convertedType]
 }
 
+// FixedLenByteArray decimals are sized based on precision
+// this function calculates the necessary byte array size
+func CalcDecimalFixedLenByteArraySize(precision int) int {
+	return int(math.Ceil((math.Log10(2) + float64(precision)) / math.Log10(256)))
+}
+
 // Decimal constructs a leaf node of decimal logical type with the given
 // scale, precision, and underlying type.
 //
 // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal
 func Decimal(scale, precision int, typ Type) Node {
-	length := int(math.Ceil((math.Log10(2) + float64(precision)) / math.Log10(256)))
 	switch typ.Kind() {
-	case Int32Type.Kind(), Int64Type.Kind(), FixedLenByteArrayType(length).Kind():
+	case Int32, Int64, FixedLenByteArray:
 	default:
-		panic("DECIMAL node must annotate the INT32, INT64 or FixedLenByteArrayType kinds but got " + typ.String())
+		panic("DECIMAL node must annotate Int32, Int64 or FixedLenByteArray but got " + typ.String())
 	}
 	return Leaf(&decimalType{
 		decimal: format.DecimalType{

--- a/type.go
+++ b/type.go
@@ -307,7 +307,7 @@ func (t *intType) ConvertedType() *deprecated.ConvertedType {
 
 // FixedLenByteArray decimals are sized based on precision
 // this function calculates the necessary byte array size
-func CalcDecimalFixedLenByteArraySize(precision int) int {
+func calcDecimalFixedLenByteArraySize(precision int) int {
 	return int(math.Ceil((math.Log10(2) + float64(precision)) / math.Log10(256)))
 }
 

--- a/type.go
+++ b/type.go
@@ -3,6 +3,7 @@ package parquet
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"reflect"
 	"time"
 
@@ -309,10 +310,11 @@ func (t *intType) ConvertedType() *deprecated.ConvertedType {
 //
 // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal
 func Decimal(scale, precision int, typ Type) Node {
-	switch typ {
-	case Int32Type, Int64Type:
+	length := int(math.Ceil((math.Log10(2) + float64(precision)) / math.Log10(256)))
+	switch typ.Kind() {
+	case Int32Type.Kind(), Int64Type.Kind(), FixedLenByteArrayType(length).Kind():
 	default:
-		panic("DECIMAL node must annotate the INT32 or INT64 types but got " + typ.String())
+		panic("DECIMAL node must annotate the INT32, INT64 or FixedLenByteArrayType kinds but got " + typ.String())
 	}
 	return Leaf(&decimalType{
 		decimal: format.DecimalType{


### PR DESCRIPTION
Added fixed_len_byte_array decimal option
Added timestamp and date to struct tags. 
Changed it so byte arrays are not always delta encoded if plain is set as a struct tag. Some readers such as spark vectorized reader do not support this encoding.

Would appreciate some feedback on this PR. Thanks

Also want to say thanks for this project! This performance is great