### PR TITLE
Fix performance degradation when writing to Buffer

### DIFF
--- a/dictionary.go
+++ b/dictionary.go
@@ -454,7 +454,7 @@ func (col *indexedColumnBuffer) WriteValues(values []Value) (int, error) {
 	if j <= cap(col.values) {
 		col.values = col.values[:j]
 	} else {
-		colValues := make([]int32, j)
+		colValues := make([]int32, j, 2*j)
 		copy(colValues, col.values)
 		col.values = colValues
 	}


### PR DESCRIPTION
When the configured size of an `indexedColumnBuffer` is exceeded then `indexedColumnBuffer.WriteValues` degrades significantly, because it only increases the buffer size for necessary row and copies the slice again.  This proposes a simple 2x alloc to maintain efficiency.  The default buffer size is 1MB, and with dictionary encoding and the /4 in `newIndexedColumnBuffer`, the default cutoff is 128K values.

Benchmark numbers pasted here, but the benchmark itself is not committed because it is quite awkward, `indexedColumnBuffer` is not exported.  This benchmark appends a single `parquet.Value` to a buffer that has already exceeded the starting size.

```
old:
BenchmarkIndexedColumnBufferWriteValues-12    	    2415	     51526 ns/op	  408458 B/op	       1 allocs/op

new:
BenchmarkIndexedColumnBufferWriteValues-12    	 6640164	        15.45 ns/op	       9 B/op	       0 allocs/op
```

