### PR TITLE
expose number of rows on parquet files

### DIFF
--- a/file.go
+++ b/file.go
@@ -207,7 +207,7 @@ func (f *File) readPageIndex(section *bufferedSectionReader, decoder *thrift.Dec
 }
 
 // NumRows returns the number of rows in the file.
-func (f *File) NumRows() int64 { return f.metadata.numRows }
+func (f *File) NumRows() int64 { return f.metadata.NumRows }
 
 // NumRowGroups returns the number of row groups in f.
 func (f *File) NumRowGroups() int { return len(f.rowGroups) }

--- a/file.go
+++ b/file.go
@@ -206,6 +206,9 @@ func (f *File) readPageIndex(section *bufferedSectionReader, decoder *thrift.Dec
 	return columnIndexes, offsetIndexes, nil
 }
 
+// NumRows returns the number of rows in the file.
+func (f *File) NumRows() int64 { return f.metadata.numRows }
+
 // NumRowGroups returns the number of row groups in f.
 func (f *File) NumRowGroups() int { return len(f.rowGroups) }
 


### PR DESCRIPTION
This PR adds a `NumRows() int64` method to the `parquet.File` type to offer a simple way to get the total number of rows in a parquet file.