### PR TITLE
Support column indexes over multiple pages

### DIFF
--- a/column_index_default.go
+++ b/column_index_default.go
@@ -15,7 +15,7 @@ func (i booleanColumnIndex) NullCount(int) int64 { return 0 }
 func (i booleanColumnIndex) NullPage(int) bool   { return false }
 func (i booleanColumnIndex) MinValue(int) Value  { return makeValueBoolean(i.page.min()) }
 func (i booleanColumnIndex) MaxValue(int) Value  { return makeValueBoolean(i.page.max()) }
-func (i booleanColumnIndex) IsAscending() bool   { return compareBool(i.page.bounds()) < 0 }
+func (i booleanColumnIndex) IsAscending() bool   { return compareBool(i.page.bounds()) <= 0 }
 func (i booleanColumnIndex) IsDescending() bool  { return compareBool(i.page.bounds()) > 0 }
 
 type int32ColumnIndex struct{ page *int32Page }
@@ -25,7 +25,7 @@ func (i int32ColumnIndex) NullCount(int) int64 { return 0 }
 func (i int32ColumnIndex) NullPage(int) bool   { return false }
 func (i int32ColumnIndex) MinValue(int) Value  { return makeValueInt32(i.page.min()) }
 func (i int32ColumnIndex) MaxValue(int) Value  { return makeValueInt32(i.page.max()) }
-func (i int32ColumnIndex) IsAscending() bool   { return compareInt32(i.page.bounds()) < 0 }
+func (i int32ColumnIndex) IsAscending() bool   { return compareInt32(i.page.bounds()) <= 0 }
 func (i int32ColumnIndex) IsDescending() bool  { return compareInt32(i.page.bounds()) > 0 }
 
 type int64ColumnIndex struct{ page *int64Page }
@@ -35,7 +35,7 @@ func (i int64ColumnIndex) NullCount(int) int64 { return 0 }
 func (i int64ColumnIndex) NullPage(int) bool   { return false }
 func (i int64ColumnIndex) MinValue(int) Value  { return makeValueInt64(i.page.min()) }
 func (i int64ColumnIndex) MaxValue(int) Value  { return makeValueInt64(i.page.max()) }
-func (i int64ColumnIndex) IsAscending() bool   { return compareInt64(i.page.bounds()) < 0 }
+func (i int64ColumnIndex) IsAscending() bool   { return compareInt64(i.page.bounds()) <= 0 }
 func (i int64ColumnIndex) IsDescending() bool  { return compareInt64(i.page.bounds()) > 0 }
 
 type int96ColumnIndex struct{ page *int96Page }
@@ -45,7 +45,7 @@ func (i int96ColumnIndex) NullCount(int) int64 { return 0 }
 func (i int96ColumnIndex) NullPage(int) bool   { return false }
 func (i int96ColumnIndex) MinValue(int) Value  { return makeValueInt96(i.page.min()) }
 func (i int96ColumnIndex) MaxValue(int) Value  { return makeValueInt96(i.page.max()) }
-func (i int96ColumnIndex) IsAscending() bool   { return compareInt96(i.page.bounds()) < 0 }
+func (i int96ColumnIndex) IsAscending() bool   { return compareInt96(i.page.bounds()) <= 0 }
 func (i int96ColumnIndex) IsDescending() bool  { return compareInt96(i.page.bounds()) > 0 }
 
 type floatColumnIndex struct{ page *floatPage }
@@ -55,7 +55,7 @@ func (i floatColumnIndex) NullCount(int) int64 { return 0 }
 func (i floatColumnIndex) NullPage(int) bool   { return false }
 func (i floatColumnIndex) MinValue(int) Value  { return makeValueFloat(i.page.min()) }
 func (i floatColumnIndex) MaxValue(int) Value  { return makeValueFloat(i.page.max()) }
-func (i floatColumnIndex) IsAscending() bool   { return compareFloat32(i.page.bounds()) < 0 }
+func (i floatColumnIndex) IsAscending() bool   { return compareFloat32(i.page.bounds()) <= 0 }
 func (i floatColumnIndex) IsDescending() bool  { return compareFloat32(i.page.bounds()) > 0 }
 
 type doubleColumnIndex struct{ page *doublePage }
@@ -65,7 +65,7 @@ func (i doubleColumnIndex) NullCount(int) int64 { return 0 }
 func (i doubleColumnIndex) NullPage(int) bool   { return false }
 func (i doubleColumnIndex) MinValue(int) Value  { return makeValueDouble(i.page.min()) }
 func (i doubleColumnIndex) MaxValue(int) Value  { return makeValueDouble(i.page.max()) }
-func (i doubleColumnIndex) IsAscending() bool   { return compareFloat64(i.page.bounds()) < 0 }
+func (i doubleColumnIndex) IsAscending() bool   { return compareFloat64(i.page.bounds()) <= 0 }
 func (i doubleColumnIndex) IsDescending() bool  { return compareFloat64(i.page.bounds()) > 0 }
 
 type uint32ColumnIndex struct{ page uint32Page }
@@ -75,7 +75,7 @@ func (i uint32ColumnIndex) NullCount(int) int64 { return 0 }
 func (i uint32ColumnIndex) NullPage(int) bool   { return false }
 func (i uint32ColumnIndex) MinValue(int) Value  { return makeValueInt32(int32(i.page.min())) }
 func (i uint32ColumnIndex) MaxValue(int) Value  { return makeValueInt32(int32(i.page.max())) }
-func (i uint32ColumnIndex) IsAscending() bool   { return compareUint32(i.page.bounds()) < 0 }
+func (i uint32ColumnIndex) IsAscending() bool   { return compareUint32(i.page.bounds()) <= 0 }
 func (i uint32ColumnIndex) IsDescending() bool  { return compareUint32(i.page.bounds()) > 0 }
 
 type uint64ColumnIndex struct{ page uint64Page }
@@ -85,7 +85,7 @@ func (i uint64ColumnIndex) NullCount(int) int64 { return 0 }
 func (i uint64ColumnIndex) NullPage(int) bool   { return false }
 func (i uint64ColumnIndex) MinValue(int) Value  { return makeValueInt64(int64(i.page.min())) }
 func (i uint64ColumnIndex) MaxValue(int) Value  { return makeValueInt64(int64(i.page.max())) }
-func (i uint64ColumnIndex) IsAscending() bool   { return compareUint64(i.page.bounds()) < 0 }
+func (i uint64ColumnIndex) IsAscending() bool   { return compareUint64(i.page.bounds()) <= 0 }
 func (i uint64ColumnIndex) IsDescending() bool  { return compareUint64(i.page.bounds()) > 0 }
 
 type booleanColumnIndexer struct {

--- a/column_index_go18.go
+++ b/column_index_go18.go
@@ -14,7 +14,7 @@ func (i columnIndex[T]) NullCount(int) int64 { return 0 }
 func (i columnIndex[T]) NullPage(int) bool   { return false }
 func (i columnIndex[T]) MinValue(int) Value  { return i.page.class.makeValue(i.page.min()) }
 func (i columnIndex[T]) MaxValue(int) Value  { return i.page.class.makeValue(i.page.max()) }
-func (i columnIndex[T]) IsAscending() bool   { return i.page.class.compare(i.page.bounds()) < 0 }
+func (i columnIndex[T]) IsAscending() bool   { return i.page.class.compare(i.page.bounds()) <= 0 }
 func (i columnIndex[T]) IsDescending() bool  { return i.page.class.compare(i.page.bounds()) > 0 }
 
 type columnIndexer[T primitive] struct {

--- a/column_test.go
+++ b/column_test.go
@@ -144,6 +144,7 @@ func checkColumnChunkColumnIndex(columnChunk parquet.ColumnChunk) error {
 	columnIndex := columnChunk.ColumnIndex()
 	numPages := columnIndex.NumPages()
 	pagesRead := 0
+	stats := newColumnStats(columnType)
 	err := forEachPage(columnChunk.Pages(), func(page parquet.Page) error {
 		pageMin, pageMax := page.Bounds()
 		indexMin := columnIndex.MinValue(pagesRead)
@@ -159,6 +160,7 @@ func checkColumnChunkColumnIndex(columnChunk parquet.ColumnChunk) error {
 		numNulls := int64(0)
 		numValues := int64(0)
 		err := forEachValue(page.Values(), func(value parquet.Value) error {
+			stats.observe(value)
 			if value.IsNull() {
 				numNulls++
 			}
@@ -179,17 +181,7 @@ func checkColumnChunkColumnIndex(columnChunk parquet.ColumnChunk) error {
 			return fmt.Errorf("page only contained null values but the index did not categorize it as a null page: nulls=%d", numNulls)
 		}
 
-		switch {
-		case columnIndex.IsAscending():
-			if columnType.Compare(pageMin, pageMax) > 0 {
-				return fmt.Errorf("column index is declared to be in ascending order but %v > %v", pageMin, pageMax)
-			}
-		case columnIndex.IsDescending():
-			if columnType.Compare(pageMin, pageMax) < 0 {
-				return fmt.Errorf("column index is declared to be in desending order but %v < %v", pageMin, pageMax)
-			}
-		}
-
+		stats.pageRead()
 		pagesRead++
 		return nil
 	})
@@ -199,6 +191,23 @@ func checkColumnChunkColumnIndex(columnChunk parquet.ColumnChunk) error {
 	if pagesRead != numPages {
 		return fmt.Errorf("number of pages found in column index differs from the number of pages read: index=%d read=%d", numPages, pagesRead)
 	}
+
+	actualOrder := columnIndexOrder(columnIndex)
+	observedOrder := observedIndexOrder(columnType, stats.minValues, stats.maxValues)
+	xorAscending := (columnIndex.IsAscending() || observedOrder == ascendingIndexOrder) &&
+		!(columnIndex.IsAscending() && observedOrder == ascendingIndexOrder)
+	xorDescending := (columnIndex.IsDescending() || observedOrder == descendingIndexOrder) &&
+		!(columnIndex.IsDescending() && observedOrder == descendingIndexOrder)
+
+	if xorAscending || xorDescending {
+		return fmt.Errorf("column index is declared to be %s while observed values %s (min values %s, max values %s)",
+			actualOrder,
+			observedOrder,
+			valueOrder(columnType, stats.minValues),
+			valueOrder(columnType, stats.maxValues),
+		)
+	}
+
 	return nil
 }
 
@@ -401,3 +410,114 @@ func (i *fileOffsetIndex) CompressedPageSize(j int) int64 {
 	return int64(i.PageLocations[j].CompressedPageSize)
 }
 func (i *fileOffsetIndex) FirstRowIndex(j int) int64 { return i.PageLocations[j].FirstRowIndex }
+
+type columnStats struct {
+	page       int
+	columnType parquet.Type
+	minValues  []parquet.Value
+	maxValues  []parquet.Value
+}
+
+func newColumnStats(columnType parquet.Type) *columnStats {
+	return &columnStats{columnType: columnType}
+}
+
+func (c *columnStats) observe(value parquet.Value) {
+	if c.page >= len(c.minValues) {
+		c.minValues = append(c.minValues, value)
+	} else if c.columnType.Compare(c.minValues[c.page], value) > 0 {
+		c.minValues[c.page] = value
+	}
+
+	if c.page >= len(c.maxValues) {
+		c.maxValues = append(c.maxValues, value)
+	} else if c.columnType.Compare(c.maxValues[c.page], value) < 0 {
+		c.maxValues[c.page] = value
+	}
+}
+
+func (c *columnStats) pageRead() {
+	c.page++
+}
+
+type indexOrder int
+
+const (
+	invalidIndexOrder indexOrder = iota
+	unorderedIndexOrder
+	ascendingIndexOrder
+	descendingIndexOrder
+	equalIndexOrder
+)
+
+func (o indexOrder) String() string {
+	switch o {
+	case unorderedIndexOrder:
+		return "unordered"
+	case ascendingIndexOrder:
+		return "ascending"
+	case descendingIndexOrder:
+		return "descending"
+	case equalIndexOrder:
+		return "equal"
+	default:
+		return "invalid"
+	}
+}
+
+func columnIndexOrder(index parquet.ColumnIndex) indexOrder {
+	switch {
+	case index.IsAscending() && index.IsDescending():
+		return invalidIndexOrder
+	case index.IsAscending():
+		return ascendingIndexOrder
+	case index.IsDescending():
+		return descendingIndexOrder
+	default:
+		return unorderedIndexOrder
+	}
+}
+
+func observedIndexOrder(columnType parquet.Type, minValues []parquet.Value, maxValues []parquet.Value) indexOrder {
+	a := valueOrder(columnType, minValues)
+	b := valueOrder(columnType, maxValues)
+
+	switch {
+	case (a == equalIndexOrder || a == ascendingIndexOrder) && (b == equalIndexOrder || b == ascendingIndexOrder):
+		return ascendingIndexOrder
+	case (a == equalIndexOrder || a == descendingIndexOrder) && (b == equalIndexOrder || b == descendingIndexOrder):
+		return descendingIndexOrder
+	default:
+		return unorderedIndexOrder
+	}
+}
+
+func valueOrder(columnType parquet.Type, values []parquet.Value) indexOrder {
+	if len(values) == 0 {
+		return unorderedIndexOrder
+	}
+
+	var order int
+	for i := 1; i < len(values); i++ {
+		next := columnType.Compare(values[i], values[i-1])
+		if next == 0 {
+			continue
+		}
+		if order == 0 {
+			order = next
+			continue
+		}
+		if order != next {
+			return unorderedIndexOrder
+		}
+	}
+
+	switch order {
+	case 1:
+		return ascendingIndexOrder
+	case -1:
+		return descendingIndexOrder
+	default:
+		return equalIndexOrder
+	}
+}

--- a/column_test.go
+++ b/column_test.go
@@ -2,8 +2,10 @@ package parquet_test
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 	"testing/quick"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/segmentio/parquet-go"
@@ -236,7 +238,9 @@ func checkColumnChunkOffsetIndex(columnChunk parquet.ColumnChunk) error {
 
 func testColumnPageIndexWithFile(t *testing.T, rows rows) bool {
 	if len(rows) > 0 {
-		f, err := createParquetFile(rows)
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		size := parquet.PageBufferSize(r.Intn(49) + 1)
+		f, err := createParquetFile(rows, size)
 		if err != nil {
 			t.Error(err)
 			return false

--- a/internal/bits/order.go
+++ b/internal/bits/order.go
@@ -18,13 +18,15 @@ func OrderOfBool(data []bool) int {
 			k = -1
 			i = streakOfTrue(data)
 			if i == len(data) {
-				k = +1
-			} else {
-				i += streakOfFalse(data[i:])
+				return 2
 			}
+			i += streakOfFalse(data[i:])
 		} else { // false => true: ascending
 			k = +1
 			i = streakOfFalse(data)
+			if i == len(data) {
+				return 2
+			}
 			i += streakOfTrue(data[i:])
 		}
 
@@ -122,17 +124,18 @@ func OrderOfBytes(data [][]byte) int {
 	if len(data) == 1 {
 		return 1
 	}
+
 	data = skipBytesStreak(data)
-	if len(data) < 2 {
-		return 1
+	if len(data) == 1 {
+		return 2
 	}
 	ordering := bytes.Compare(data[0], data[1])
 	switch {
-	case ordering > 0:
+	case ordering < 0:
 		if bytesAreInAscendingOrder(data[1:]) {
 			return +1
 		}
-	case ordering < 0:
+	case ordering > 0:
 		if bytesAreInDescendingOrder(data[1:]) {
 			return -1
 		}

--- a/internal/bits/order_go18.go
+++ b/internal/bits/order_go18.go
@@ -15,8 +15,8 @@ func orderOfFloat32(data []float32) int { return orderOfValues(data) }
 func orderOfFloat64(data []float64) int { return orderOfValues(data) }
 
 func orderOfValues[T ordered](data []T) int {
-	if valuesAreInAscendingOrder(data) {
-		return +1
+	if order := valuesAreInAscendingOrder(data); order > 0 {
+		return order
 	}
 	if valuesAreInDescendingOrder(data) {
 		return -1
@@ -24,13 +24,20 @@ func orderOfValues[T ordered](data []T) int {
 	return 0
 }
 
-func valuesAreInAscendingOrder[T ordered](data []T) bool {
+func valuesAreInAscendingOrder[T ordered](data []T) int {
+	order := 2
 	for i := len(data) - 1; i > 0; i-- {
-		if data[i-1] > data[i] {
-			return false
+		next := data[i]
+		prev := data[i-1]
+		if prev > next {
+			return 0
+		}
+
+		if order == 2 && prev != next {
+			order = +1
 		}
 	}
-	return true
+	return order
 }
 
 func valuesAreInDescendingOrder[T ordered](data []T) bool {

--- a/internal/bits/order_test.go
+++ b/internal/bits/order_test.go
@@ -60,6 +60,7 @@ const (
 	ascending  = "ascending"
 	descending = "descending"
 	undefined  = "undefined"
+	equal      = "equal"
 )
 
 func orderingName(ordering int) string {
@@ -74,11 +75,15 @@ func orderingName(ordering int) string {
 }
 
 func isAscending(ordering int) bool {
-	return ordering > 0
+	return ordering == 1
 }
 
 func isDescending(ordering int) bool {
-	return ordering < 0
+	return ordering == -1
+}
+
+func isEqual(ordering int) bool {
+	return ordering == 2
 }
 
 func isUndefined(ordering int) bool {
@@ -89,13 +94,20 @@ func isSorted(set sort.Interface) bool {
 	return set.Len() > 0 && sort.IsSorted(set)
 }
 
-func checkOrdering(t *testing.T, set sort.Interface, ordering int) bool {
+func checkOrdering(t *testing.T, set sort.Interface, ordering int, firstLastEqual bool) bool {
 	t.Helper()
 	switch {
 	case isSorted(set):
-		if !isAscending(ordering) {
-			t.Errorf("got=%s want=%s", orderingName(ordering), ascending)
-			return false
+		if firstLastEqual {
+			if !isEqual(ordering) {
+				t.Errorf("got=%s want=%s", orderingName(ordering), equal)
+				return false
+			}
+		} else {
+			if !isAscending(ordering) {
+				t.Errorf("got=%s want=%s", orderingName(ordering), ascending)
+				return false
+			}
 		}
 	case isSorted(sort.Reverse(set)):
 		if !isDescending(ordering) {
@@ -113,8 +125,20 @@ func checkOrdering(t *testing.T, set sort.Interface, ordering int) bool {
 
 func TestOrderOfBool(t *testing.T) {
 	check := func(values []bool) bool {
-		return checkOrdering(t, boolOrder(values), bits.OrderOfBool(values))
+		var firstLastEqual bool
+		if len(values) > 1 {
+			firstLastEqual = values[0] == values[len(values)-1]
+		}
+		return checkOrdering(t, boolOrder(values), bits.OrderOfBool(values), firstLastEqual)
 	}
+
+	t.Run("detects set of equal values", func(t *testing.T) {
+		values := []bool{true, true}
+		order := bits.OrderOfBool(values)
+		if order != 2 {
+			t.Errorf("got=%s want=equal", orderingName(order))
+		}
+	})
 
 	t.Run("quick check", func(t *testing.T) {
 		err := quickCheck(func(values []bool) bool {
@@ -139,8 +163,20 @@ func TestOrderOfBool(t *testing.T) {
 
 func TestOrderOfInt32(t *testing.T) {
 	check := func(values []int32) bool {
-		return checkOrdering(t, int32Order(values), bits.OrderOfInt32(values))
+		var firstLastEqual bool
+		if len(values) > 1 {
+			firstLastEqual = values[0] == values[len(values)-1]
+		}
+		return checkOrdering(t, int32Order(values), bits.OrderOfInt32(values), firstLastEqual)
 	}
+
+	t.Run("detects set of equal values", func(t *testing.T) {
+		values := []int32{1, 1}
+		order := bits.OrderOfInt32(values)
+		if order != 2 {
+			t.Errorf("got=%s want=equal", orderingName(order))
+		}
+	})
 
 	// Tests corner case of the vectorized code path which works on 64 bytes per
 	// loop iteration.
@@ -181,8 +217,20 @@ func TestOrderOfInt32(t *testing.T) {
 
 func TestOrderOfInt64(t *testing.T) {
 	check := func(values []int64) bool {
-		return checkOrdering(t, int64Order(values), bits.OrderOfInt64(values))
+		var firstLastEqual bool
+		if len(values) > 1 {
+			firstLastEqual = values[0] == values[len(values)-1]
+		}
+		return checkOrdering(t, int64Order(values), bits.OrderOfInt64(values), firstLastEqual)
 	}
+
+	t.Run("detects set of equal values", func(t *testing.T) {
+		values := []int64{1, 1}
+		order := bits.OrderOfInt64(values)
+		if order != 2 {
+			t.Errorf("got=%s want=equal", orderingName(order))
+		}
+	})
 
 	// Tests corner case of the vectorized code path which works on 64 bytes per
 	// loop iteration.
@@ -222,8 +270,20 @@ func TestOrderOfInt64(t *testing.T) {
 
 func TestOrderOfUint32(t *testing.T) {
 	check := func(values []uint32) bool {
-		return checkOrdering(t, uint32Order(values), bits.OrderOfUint32(values))
+		var firstLastEqual bool
+		if len(values) > 1 {
+			firstLastEqual = values[0] == values[len(values)-1]
+		}
+		return checkOrdering(t, uint32Order(values), bits.OrderOfUint32(values), firstLastEqual)
 	}
+
+	t.Run("detects set of equal values", func(t *testing.T) {
+		values := []uint32{1, 1}
+		order := bits.OrderOfUint32(values)
+		if order != 2 {
+			t.Errorf("got=%s want=equal", orderingName(order))
+		}
+	})
 
 	// Tests corner case of the vectorized code path which works on 64 bytes per
 	// loop iteration.
@@ -263,8 +323,20 @@ func TestOrderOfUint32(t *testing.T) {
 
 func TestOrderOfUint64(t *testing.T) {
 	check := func(values []uint64) bool {
-		return checkOrdering(t, uint64Order(values), bits.OrderOfUint64(values))
+		var firstLastEqual bool
+		if len(values) > 1 {
+			firstLastEqual = values[0] == values[len(values)-1]
+		}
+		return checkOrdering(t, uint64Order(values), bits.OrderOfUint64(values), firstLastEqual)
 	}
+
+	t.Run("detects set of equal values", func(t *testing.T) {
+		values := []uint64{1, 1}
+		order := bits.OrderOfUint64(values)
+		if order != 2 {
+			t.Errorf("got=%s want=equal", orderingName(order))
+		}
+	})
 
 	// Tests corner case of the vectorized code path which works on 64 bytes per
 	// loop iteration.
@@ -304,8 +376,20 @@ func TestOrderOfUint64(t *testing.T) {
 
 func TestOrderOfFloat32(t *testing.T) {
 	check := func(values []float32) bool {
-		return checkOrdering(t, float32Order(values), bits.OrderOfFloat32(values))
+		var firstLastEqual bool
+		if len(values) > 1 {
+			firstLastEqual = values[0] == values[len(values)-1]
+		}
+		return checkOrdering(t, float32Order(values), bits.OrderOfFloat32(values), firstLastEqual)
 	}
+
+	t.Run("detects set of equal values", func(t *testing.T) {
+		values := []float32{1, 1}
+		order := bits.OrderOfFloat32(values)
+		if order != 2 {
+			t.Errorf("got=%s want=equal", orderingName(order))
+		}
+	})
 
 	// Tests corner case of the vectorized code path which works on 64 bytes per
 	// loop iteration.
@@ -345,8 +429,20 @@ func TestOrderOfFloat32(t *testing.T) {
 
 func TestOrderOfFloat64(t *testing.T) {
 	check := func(values []float64) bool {
-		return checkOrdering(t, float64Order(values), bits.OrderOfFloat64(values))
+		var firstLastEqual bool
+		if len(values) > 1 {
+			firstLastEqual = values[0] == values[len(values)-1]
+		}
+		return checkOrdering(t, float64Order(values), bits.OrderOfFloat64(values), firstLastEqual)
 	}
+
+	t.Run("detects set of equal values", func(t *testing.T) {
+		values := []float64{1, 1}
+		order := bits.OrderOfFloat64(values)
+		if order != 2 {
+			t.Errorf("got=%s want=equal", orderingName(order))
+		}
+	})
 
 	// Tests corner case of the vectorized code path which works on 64 bytes per
 	// loop iteration.
@@ -386,8 +482,20 @@ func TestOrderOfFloat64(t *testing.T) {
 
 func TestOrderOfBytes(t *testing.T) {
 	check := func(values [][]byte) bool {
-		return checkOrdering(t, bytesOrder(values), bits.OrderOfBytes(values))
+		var firstLastEqual bool
+		if len(values) > 1 {
+			firstLastEqual = bytes.Compare(values[0], values[len(values)-1]) == 0
+		}
+		return checkOrdering(t, bytesOrder(values), bits.OrderOfBytes(values), firstLastEqual)
 	}
+
+	t.Run("detects set of equal values", func(t *testing.T) {
+		values := [][]byte{{1}, {1}}
+		order := bits.OrderOfBytes(values)
+		if order != 2 {
+			t.Errorf("got=%s want=equal", orderingName(order))
+		}
+	})
 
 	t.Run("quick check", func(t *testing.T) {
 		err := quickCheck(func(values [][16]byte) bool {

--- a/internal/bits/order_test.go
+++ b/internal/bits/order_test.go
@@ -115,258 +115,304 @@ func TestOrderOfBool(t *testing.T) {
 	check := func(values []bool) bool {
 		return checkOrdering(t, boolOrder(values), bits.OrderOfBool(values))
 	}
-	err := quickCheck(func(values []bool) bool {
-		if !check(values) {
-			return false
+
+	t.Run("quick check", func(t *testing.T) {
+		err := quickCheck(func(values []bool) bool {
+			if !check(values) {
+				return false
+			}
+			sort.Sort(boolOrder(values))
+			if !check(values) {
+				return false
+			}
+			sort.Sort(sort.Reverse(boolOrder(values)))
+			if !check(values) {
+				return false
+			}
+			return true
+		})
+		if err != nil {
+			t.Error(err)
 		}
-		sort.Sort(boolOrder(values))
-		if !check(values) {
-			return false
-		}
-		sort.Sort(sort.Reverse(boolOrder(values)))
-		if !check(values) {
-			return false
-		}
-		return true
 	})
-	if err != nil {
-		t.Error(err)
-	}
 }
 
 func TestOrderOfInt32(t *testing.T) {
 	check := func(values []int32) bool {
 		return checkOrdering(t, int32Order(values), bits.OrderOfInt32(values))
 	}
-	err := quickCheck(func(values []int32) bool {
-		if !check(values) {
-			return false
+
+	// Tests corner case of the vectorized code path which works on 64 bytes per
+	// loop iteration.
+	t.Run("detects out-of-order values at 64 byte boundaries", func(t *testing.T) {
+		values := []int32{
+			0, 1, 2, 3, 4, 5, 6, 7,
+			8, 9, 10, 11, 12, 13, 14, 15,
+			// 15 > 14, the algorithm must detect that the values are not ordered.
+			14, 17, 18, 19, 20, 21, 22, 23,
+			24, 25, 26, 27, 28, 29, 30, 31,
 		}
-		sort.Sort(int32Order(values))
+
 		if !check(values) {
-			return false
+			t.Error("failed due to not checking the connection between sequences of 16 elements")
 		}
-		sort.Sort(sort.Reverse(int32Order(values)))
-		if !check(values) {
-			return false
-		}
-		return true
 	})
-	if err != nil {
-		t.Error(err)
-	}
 
-	// This extra test validates that out-of-order values at 64 byte boundaries
-	// are properly detected; it tests corner cases of the vectorized code path
-	// which works on 64 bytes per loop iteration.
-	values := []int32{
-		0, 1, 2, 3, 4, 5, 6, 7,
-		8, 9, 10, 11, 12, 13, 14, 15,
-		// 15 > 14, the algorithm must detect that the values are not ordered.
-		14, 17, 18, 19, 20, 21, 22, 23,
-		24, 25, 26, 27, 28, 29, 30, 31,
-	}
-
-	if !check(values) {
-		t.Error("failed due to not checking the connection between sequences of 16 elements")
-	}
+	t.Run("quick check", func(t *testing.T) {
+		err := quickCheck(func(values []int32) bool {
+			if !check(values) {
+				return false
+			}
+			sort.Sort(int32Order(values))
+			if !check(values) {
+				return false
+			}
+			sort.Sort(sort.Reverse(int32Order(values)))
+			if !check(values) {
+				return false
+			}
+			return true
+		})
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }
 
 func TestOrderOfInt64(t *testing.T) {
 	check := func(values []int64) bool {
 		return checkOrdering(t, int64Order(values), bits.OrderOfInt64(values))
 	}
-	err := quickCheck(func(values []int64) bool {
-		if !check(values) {
-			return false
+
+	// Tests corner case of the vectorized code path which works on 64 bytes per
+	// loop iteration.
+	t.Run("detects out-of-order values at 64 byte boundaries", func(t *testing.T) {
+		values := []int64{
+			0, 1, 2, 3, 4, 5, 6, 7,
+			6, 9, 10, 11, 12, 13, 14, 15,
+			14, 17, 18, 19, 20, 21, 22, 23,
+			24, 25, 26, 27, 28, 29, 30, 31,
 		}
-		sort.Sort(int64Order(values))
+
 		if !check(values) {
-			return false
+			t.Error("failed due to not checking the connection between sequences of 8 elements")
 		}
-		sort.Sort(sort.Reverse(int64Order(values)))
-		if !check(values) {
-			return false
-		}
-		return true
 	})
-	if err != nil {
-		t.Error(err)
-	}
 
-	values := []int64{
-		0, 1, 2, 3, 4, 5, 6, 7,
-		6, 9, 10, 11, 12, 13, 14, 15,
-		14, 17, 18, 19, 20, 21, 22, 23,
-		24, 25, 26, 27, 28, 29, 30, 31,
-	}
-
-	if !check(values) {
-		t.Error("failed due to not checking the connection between sequences of 8 elements")
-	}
+	t.Run("quick check", func(t *testing.T) {
+		err := quickCheck(func(values []int64) bool {
+			if !check(values) {
+				return false
+			}
+			sort.Sort(int64Order(values))
+			if !check(values) {
+				return false
+			}
+			sort.Sort(sort.Reverse(int64Order(values)))
+			if !check(values) {
+				return false
+			}
+			return true
+		})
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }
 
 func TestOrderOfUint32(t *testing.T) {
 	check := func(values []uint32) bool {
 		return checkOrdering(t, uint32Order(values), bits.OrderOfUint32(values))
 	}
-	err := quickCheck(func(values []uint32) bool {
-		if !check(values) {
-			return false
+
+	// Tests corner case of the vectorized code path which works on 64 bytes per
+	// loop iteration.
+	t.Run("detects out-of-order values at 64 byte boundaries", func(t *testing.T) {
+		values := []uint32{
+			0, 1, 2, 3, 4, 5, 6, 7,
+			8, 9, 10, 11, 12, 13, 14, 15,
+			14, 17, 18, 19, 20, 21, 22, 23,
+			24, 25, 26, 27, 28, 29, 30, 31,
 		}
-		sort.Sort(uint32Order(values))
+
 		if !check(values) {
-			return false
+			t.Error("failed due to not checking the connection between sequences of 16 elements")
 		}
-		sort.Sort(sort.Reverse(uint32Order(values)))
-		if !check(values) {
-			return false
-		}
-		return true
 	})
-	if err != nil {
-		t.Error(err)
-	}
 
-	values := []uint32{
-		0, 1, 2, 3, 4, 5, 6, 7,
-		8, 9, 10, 11, 12, 13, 14, 15,
-		14, 17, 18, 19, 20, 21, 22, 23,
-		24, 25, 26, 27, 28, 29, 30, 31,
-	}
-
-	if !check(values) {
-		t.Error("failed due to not checking the connection between sequences of 16 elements")
-	}
+	t.Run("quick check", func(t *testing.T) {
+		err := quickCheck(func(values []uint32) bool {
+			if !check(values) {
+				return false
+			}
+			sort.Sort(uint32Order(values))
+			if !check(values) {
+				return false
+			}
+			sort.Sort(sort.Reverse(uint32Order(values)))
+			if !check(values) {
+				return false
+			}
+			return true
+		})
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }
 
 func TestOrderOfUint64(t *testing.T) {
 	check := func(values []uint64) bool {
 		return checkOrdering(t, uint64Order(values), bits.OrderOfUint64(values))
 	}
-	err := quickCheck(func(values []uint64) bool {
-		if !check(values) {
-			return false
+
+	// Tests corner case of the vectorized code path which works on 64 bytes per
+	// loop iteration.
+	t.Run("detects out-of-order values at 64 byte boundaries", func(t *testing.T) {
+		values := []uint64{
+			0, 1, 2, 3, 4, 5, 6, 7,
+			6, 9, 10, 11, 12, 13, 14, 15,
+			14, 17, 18, 19, 20, 21, 22, 23,
+			24, 25, 26, 27, 28, 29, 30, 31,
 		}
-		sort.Sort(uint64Order(values))
+
 		if !check(values) {
-			return false
+			t.Error("failed due to not checking the connection between sequences of 8 elements")
 		}
-		sort.Sort(sort.Reverse(uint64Order(values)))
-		if !check(values) {
-			return false
-		}
-		return true
 	})
-	if err != nil {
-		t.Error(err)
-	}
 
-	values := []uint64{
-		0, 1, 2, 3, 4, 5, 6, 7,
-		6, 9, 10, 11, 12, 13, 14, 15,
-		14, 17, 18, 19, 20, 21, 22, 23,
-		24, 25, 26, 27, 28, 29, 30, 31,
-	}
-
-	if !check(values) {
-		t.Error("failed due to not checking the connection between sequences of 8 elements")
-	}
+	t.Run("quick check", func(t *testing.T) {
+		err := quickCheck(func(values []uint64) bool {
+			if !check(values) {
+				return false
+			}
+			sort.Sort(uint64Order(values))
+			if !check(values) {
+				return false
+			}
+			sort.Sort(sort.Reverse(uint64Order(values)))
+			if !check(values) {
+				return false
+			}
+			return true
+		})
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }
 
 func TestOrderOfFloat32(t *testing.T) {
 	check := func(values []float32) bool {
 		return checkOrdering(t, float32Order(values), bits.OrderOfFloat32(values))
 	}
-	err := quickCheck(func(values []float32) bool {
-		if !check(values) {
-			return false
+
+	// Tests corner case of the vectorized code path which works on 64 bytes per
+	// loop iteration.
+	t.Run("detects out-of-order values at 64 byte boundaries", func(t *testing.T) {
+		values := []float32{
+			0, 1, 2, 3, 4, 5, 6, 7,
+			8, 9, 10, 11, 12, 13, 14, 15,
+			14, 17, 18, 19, 20, 21, 22, 23,
+			24, 25, 26, 27, 28, 29, 30, 31,
 		}
-		sort.Sort(float32Order(values))
+
 		if !check(values) {
-			return false
+			t.Error("failed due to not checking the connection between sequences of 16 elements")
 		}
-		sort.Sort(sort.Reverse(float32Order(values)))
-		if !check(values) {
-			return false
-		}
-		return true
 	})
-	if err != nil {
-		t.Error(err)
-	}
 
-	values := []float32{
-		0, 1, 2, 3, 4, 5, 6, 7,
-		8, 9, 10, 11, 12, 13, 14, 15,
-		14, 17, 18, 19, 20, 21, 22, 23,
-		24, 25, 26, 27, 28, 29, 30, 31,
-	}
-
-	if !check(values) {
-		t.Error("failed due to not checking the connection between sequences of 16 elements")
-	}
+	t.Run("quick check", func(t *testing.T) {
+		err := quickCheck(func(values []float32) bool {
+			if !check(values) {
+				return false
+			}
+			sort.Sort(float32Order(values))
+			if !check(values) {
+				return false
+			}
+			sort.Sort(sort.Reverse(float32Order(values)))
+			if !check(values) {
+				return false
+			}
+			return true
+		})
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }
 
 func TestOrderOfFloat64(t *testing.T) {
 	check := func(values []float64) bool {
 		return checkOrdering(t, float64Order(values), bits.OrderOfFloat64(values))
 	}
-	err := quickCheck(func(values []float64) bool {
-		if !check(values) {
-			return false
+
+	// Tests corner case of the vectorized code path which works on 64 bytes per
+	// loop iteration.
+	t.Run("detects out-of-order values at 64 byte boundaries", func(t *testing.T) {
+		values := []float64{
+			0, 1, 2, 3, 4, 5, 6, 7,
+			6, 9, 10, 11, 12, 13, 14, 15,
+			14, 17, 18, 19, 20, 21, 22, 23,
+			24, 25, 26, 27, 28, 29, 30, 31,
 		}
-		sort.Sort(float64Order(values))
+
 		if !check(values) {
-			return false
+			t.Error("failed due to not checking the connection between sequences of 8 elements")
 		}
-		sort.Sort(sort.Reverse(float64Order(values)))
-		if !check(values) {
-			return false
-		}
-		return true
 	})
-	if err != nil {
-		t.Error(err)
-	}
 
-	values := []float64{
-		0, 1, 2, 3, 4, 5, 6, 7,
-		6, 9, 10, 11, 12, 13, 14, 15,
-		14, 17, 18, 19, 20, 21, 22, 23,
-		24, 25, 26, 27, 28, 29, 30, 31,
-	}
-
-	if !check(values) {
-		t.Error("failed due to not checking the connection between sequences of 8 elements")
-	}
+	t.Run("quick check", func(t *testing.T) {
+		err := quickCheck(func(values []float64) bool {
+			if !check(values) {
+				return false
+			}
+			sort.Sort(float64Order(values))
+			if !check(values) {
+				return false
+			}
+			sort.Sort(sort.Reverse(float64Order(values)))
+			if !check(values) {
+				return false
+			}
+			return true
+		})
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }
 
 func TestOrderOfBytes(t *testing.T) {
 	check := func(values [][]byte) bool {
 		return checkOrdering(t, bytesOrder(values), bits.OrderOfBytes(values))
 	}
-	err := quickCheck(func(values [][16]byte) bool {
-		slices := make([][]byte, len(values))
-		for i, v := range values {
-			slices[i] = v[:]
+
+	t.Run("quick check", func(t *testing.T) {
+		err := quickCheck(func(values [][16]byte) bool {
+			slices := make([][]byte, len(values))
+			for i, v := range values {
+				cpy := v
+				slices[i] = cpy[:]
+			}
+			if !check(slices) {
+				return false
+			}
+			sort.Sort(bytesOrder(slices))
+			if !check(slices) {
+				return false
+			}
+			sort.Sort(sort.Reverse(bytesOrder(slices)))
+			if !check(slices) {
+				return false
+			}
+			return true
+		})
+		if err != nil {
+			t.Error(err)
 		}
-		if !check(slices) {
-			return false
-		}
-		sort.Sort(bytesOrder(slices))
-		if !check(slices) {
-			return false
-		}
-		sort.Sort(sort.Reverse(bytesOrder(slices)))
-		if !check(slices) {
-			return false
-		}
-		return true
 	})
-	if err != nil {
-		t.Error(err)
-	}
 }
 
 func BenchmarkOrderOfBool(b *testing.B) {

--- a/writer.go
+++ b/writer.go
@@ -620,7 +620,7 @@ func (w *writer) WriteRow(row Row) error {
 }
 
 // The WriteValues method is intended to work in pair with WritePage to allow
-// programs to target writing values to specific columns of of the writer.
+// programs to target writing values to specific columns of the writer.
 func (w *writer) WriteValues(values []Value) (numValues int, err error) {
 	return w.columns[values[0].Column()].WriteValues(values)
 }


### PR DESCRIPTION
This PR started when noticing a small bug in the column index implementation and exploring how to exercise it in a test case. That resulted in noticing that some behavior wasn't covered by tests because the tests only created single page columns.

The big change is to update the tests to create multipage columns. That exposes a few small bugs in the implementation which are fixed in subsequent commits.

The fundamental change in behavior that this PR introduces is that `internal/bits/order` should return `2` when the input slice contains all equal values. This is necessary so that a column index can report an accurate order when one of the sets of values is ordered and the other is all equal value. For example, a column index with the metadata `min=[0,0,0] max=[6,5,4]` should report descending. I think this is likely to come up when a column can contain null values. The min index will probably be a set of all nulls so it should defer to the ordering of the max index.

I highly suggest reviewing this PR a commit at a time. Each commit is a focused change with a commit message describing it. Various assembly implementations will need to be updated. I'm hoping that CI will expose those paths and expose them as failures.