### PR TITLE
Fix column index null count

### DIFF
--- a/column_index.go
+++ b/column_index.go
@@ -54,7 +54,7 @@ func (f *formatColumnIndex) NumPages() int {
 
 func (f *formatColumnIndex) NullCount(i int) int64 {
 	if len(f.index.NullCounts) > 0 {
-		return f.index.NullCounts[0]
+		return f.index.NullCounts[i]
 	}
 	return 0
 }


### PR DESCRIPTION
Fixes a simple typo in `NullCount()`. There is no test change in this PR because no tests exercise this code path. Expanding test coverage is a larger change started in #134