### PR TITLE
Add self-hosted arm64 runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,11 @@ jobs:
         tags:
         - ''
         - purego
+        label:
+        - [self-hosted, linux, arm64, segment]
+        - ubuntu-latest
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.label }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR enable the Segment self-hosted runner, hosted on AWS Graviton instances, to test parquet-go against arm64 cpu.