### PR TITLE
support configuring default compression codec

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -63,7 +63,7 @@ func (buf *Buffer) configure(schema *Schema) {
 		columnType := leaf.node.Type()
 		bufferSize := buf.config.ColumnBufferSize
 		dictionary := (Dictionary)(nil)
-		encoding, _ := encodingAndCompressionOf(leaf.node)
+		encoding := encodingOf(leaf.node)
 
 		if isDictionaryEncoding(encoding) {
 			bufferSize /= 2

--- a/column.go
+++ b/column.go
@@ -306,7 +306,7 @@ func (cl *columnLoader) open(file *File, path []string) (*Column, error) {
 		if len(c.chunks) > 0 {
 			// Pick the encoding and compression codec of the first chunk.
 			//
-			// Techically each column chunk may use a different compression
+			// Technically each column chunk may use a different compression
 			// codec, and each page of the columm chunk might have a different
 			// encoding. Exposing these details does not provide a lot of value
 			// to the end user.

--- a/column.go
+++ b/column.go
@@ -27,8 +27,8 @@ type Column struct {
 	chunks      []*format.ColumnChunk
 	columnIndex []*format.ColumnIndex
 	offsetIndex []*format.OffsetIndex
-	encoding    []encoding.Encoding
-	compression []compress.Codec
+	encoding    encoding.Encoding
+	compression compress.Codec
 
 	depth              int8
 	maxRepetitionLevel int8
@@ -63,10 +63,10 @@ func (c *Column) Fields() []Field {
 }
 
 // Encoding returns the encodings used by this column.
-func (c *Column) Encoding() []encoding.Encoding { return c.encoding }
+func (c *Column) Encoding() encoding.Encoding { return c.encoding }
 
 // Compression returns the compression codecs used by this column.
-func (c *Column) Compression() []compress.Codec { return c.compression }
+func (c *Column) Compression() compress.Codec { return c.compression }
 
 // Path of the column in the parquet schema.
 func (c *Column) Path() []string { return c.path }
@@ -303,21 +303,25 @@ func (cl *columnLoader) open(file *File, path []string) (*Column, error) {
 			}
 		}
 
-		c.encoding = make([]encoding.Encoding, 0, len(c.chunks))
-		for _, chunk := range c.chunks {
-			for _, encoding := range chunk.MetaData.Encoding {
-				c.encoding = append(c.encoding, LookupEncoding(encoding))
+		if len(c.chunks) > 0 {
+			// Pick the encoding and compression codec of the first chunk.
+			//
+			// Techically each column chunk may use a different compression
+			// codec, and each page of the columm chunk might have a different
+			// encoding. Exposing these details does not provide a lot of value
+			// to the end user.
+			//
+			// Programs that which to determine the encoding and compression of
+			// each page of the column should iterate through the pages and read
+			// the page headers to determine which compression and encodings are
+			// applied.
+			for _, encoding := range c.chunks[0].MetaData.Encoding {
+				c.encoding = LookupEncoding(encoding)
+				break
 			}
+			c.compression = LookupCompressionCodec(c.chunks[0].MetaData.Codec)
 		}
-		sortEncodings(c.encoding)
-		c.encoding = dedupeSortedEncodings(c.encoding)
 
-		c.compression = make([]compress.Codec, len(c.chunks))
-		for i, chunk := range c.chunks {
-			c.compression[i] = LookupCompressionCodec(chunk.MetaData.Codec)
-		}
-		sortCodecs(c.compression)
-		c.compression = dedupeSortedCodecs(c.compression)
 		return c, nil
 	}
 

--- a/column.go
+++ b/column.go
@@ -311,7 +311,7 @@ func (cl *columnLoader) open(file *File, path []string) (*Column, error) {
 			// encoding. Exposing these details does not provide a lot of value
 			// to the end user.
 			//
-			// Programs that which to determine the encoding and compression of
+			// Programs that wish to determine the encoding and compression of
 			// each page of the column should iterate through the pages and read
 			// the page headers to determine which compression and encodings are
 			// applied.

--- a/node.go
+++ b/node.go
@@ -49,23 +49,18 @@ type Node interface {
 	// This method returns an empty mapping when called on leaf nodes.
 	Fields() []Field
 
-	// Returns the list of encodings used by the node.
+	// Returns the encoding used by the node.
 	//
-	// The method may return an empty slice to indicate that only the plain
-	// encoding is used.
-	//
-	// As an optimization, the returned slice may be the same across calls to
-	// this method. Applications should treat the return value as immutable.
-	Encoding() []encoding.Encoding
+	// The method may return nil to indicate that no specific encoding was
+	// configured on the node, in which case a default encoding might be used.
+	Encoding() encoding.Encoding
 
-	// Returns the list of compression codecs used by the node.
+	// Returns compression codec used by the node.
 	//
-	// The method may return an empty slice to indicate that no compression was
-	// configured on the node.
-	//
-	// As an optimization, the returned slice may be the same across calls to
-	// this method. Applications should treat the return value as immutable.
-	Compression() []compress.Codec
+	// The method may return nil to indicate that no specific compression codec
+	// was configured on the node, in which case a default compression might be
+	// used.
+	Compression() compress.Codec
 
 	// Returns the Go type that best represents the parquet node.
 	//
@@ -97,130 +92,89 @@ type Field interface {
 	Value(base reflect.Value) reflect.Value
 }
 
-// WrappedNode is an extension of the Node interface implemented by types which
-// wrap another underlying node.
-type WrappedNode interface {
-	Node
-	// Unwrap returns the underlying base node.
-	//
-	// Note that Unwrap is not intended to recursively unwrap multiple layers of
-	// wrappers, it returns the immediate next layer.
-	Unwrap() Node
-}
-
-type wrappedNode struct{ Node }
-
-func (w wrappedNode) Unwrap() Node { return w.Node }
-
-func wrap(node Node) wrappedNode { return wrappedNode{node} }
-
-func unwrap(node Node) Node {
-	for {
-		if w, ok := node.(WrappedNode); ok {
-			node = w.Unwrap()
-		} else {
-			break
-		}
-	}
-	return node
-}
-
-// Encoded wraps the node passed as argument to add the given list of encodings.
+// Encoded wraps the node passed as argument to use the given encoding.
 //
-// The function panics if it is called on a non-leaf node, or if one of the
-// encodings is not able to encode the node type.
-func Encoded(node Node, encodings ...encoding.Encoding) Node {
-	if len(encodings) == 0 {
-		return node
-	}
+// The function panics if it is called on a non-leaf node, or if the
+// encoding does not support the node type.
+func Encoded(node Node, encoding encoding.Encoding) Node {
 	if !node.Leaf() {
-		panic("cannot add encodings to a non-leaf node")
+		panic("cannot add encoding to a non-leaf node")
 	}
-	kind := node.Type().Kind()
-	for _, e := range encodings {
-		if !e.CanEncode(format.Type(kind)) {
-			panic("cannot apply " + e.Encoding().String() + " to node of type " + kind.String())
+	if encoding != nil {
+		kind := node.Type().Kind()
+		if !encoding.CanEncode(format.Type(kind)) {
+			panic("cannot apply " + encoding.Encoding().String() + " to node of type " + kind.String())
 		}
 	}
-	encodings = append([]encoding.Encoding{}, encodings...)
-	encodings = append(encodings, node.Encoding()...)
-	sortEncodings(encodings)
-	encodings = dedupeSortedEncodings(encodings)
 	return &encodedNode{
-		wrappedNode: wrap(node),
-		encodings:   encodings[:len(encodings):len(encodings)],
+		Node:     node,
+		encoding: encoding,
 	}
 }
 
 type encodedNode struct {
-	wrappedNode
-	encodings []encoding.Encoding
+	Node
+	encoding encoding.Encoding
 }
 
-func (n *encodedNode) Encoding() []encoding.Encoding {
-	return n.encodings
+func (n *encodedNode) Encoding() encoding.Encoding {
+	return n.encoding
 }
 
-// Compressed wraps the node passed as argument to add the given list of
-// compression codecs.
+// Compressed wraps the node passed as argument to use the given compression
+// codec.
+//
+// If the codec is nil, the node's compression is left unchanged.
 //
 // The function panics if it is called on a non-leaf node.
-func Compressed(node Node, codecs ...compress.Codec) Node {
-	if len(codecs) == 0 {
-		return node
-	}
+func Compressed(node Node, codec compress.Codec) Node {
 	if !node.Leaf() {
-		panic("cannot add compression codecs to a non-leaf node")
+		panic("cannot add compression codec to a non-leaf node")
 	}
-	codecs = append([]compress.Codec{}, codecs...)
-	codecs = append(codecs, node.Compression()...)
-	codecs = codecs[:len(codecs):len(codecs)]
-	sortCodecs(codecs)
-	codecs = dedupeSortedCodecs(codecs)
 	return &compressedNode{
-		wrappedNode: wrap(node),
-		codecs:      codecs[:len(codecs):len(codecs)],
+		Node:  node,
+		codec: codec,
 	}
 }
 
 type compressedNode struct {
-	wrappedNode
-	codecs []compress.Codec
+	Node
+	codec compress.Codec
 }
 
-func (n *compressedNode) Compression() []compress.Codec {
-	return n.codecs
+func (n *compressedNode) Compression() compress.Codec {
+	return n.codec
 }
 
 // Optional wraps the given node to make it optional.
-func Optional(node Node) Node { return &optionalNode{wrap(node)} }
+func Optional(node Node) Node { return &optionalNode{node} }
 
-type optionalNode struct{ wrappedNode }
+type optionalNode struct{ Node }
 
 func (opt *optionalNode) Optional() bool       { return true }
 func (opt *optionalNode) Repeated() bool       { return false }
 func (opt *optionalNode) Required() bool       { return false }
-func (opt *optionalNode) GoType() reflect.Type { return reflect.PtrTo(unwrap(opt).GoType()) }
+func (opt *optionalNode) GoType() reflect.Type { return reflect.PtrTo(opt.Node.GoType()) }
 
 // Repeated wraps the given node to make it repeated.
-func Repeated(node Node) Node { return &repeatedNode{wrap(node)} }
+func Repeated(node Node) Node { return &repeatedNode{node} }
 
-type repeatedNode struct{ wrappedNode }
+type repeatedNode struct{ Node }
 
 func (rep *repeatedNode) Optional() bool       { return false }
 func (rep *repeatedNode) Repeated() bool       { return true }
 func (rep *repeatedNode) Required() bool       { return false }
-func (rep *repeatedNode) GoType() reflect.Type { return reflect.SliceOf(unwrap(rep).GoType()) }
+func (rep *repeatedNode) GoType() reflect.Type { return reflect.SliceOf(rep.Node.GoType()) }
 
 // Required wraps the given node to make it required.
-func Required(node Node) Node { return &requiredNode{wrap(node)} }
+func Required(node Node) Node { return &requiredNode{node} }
 
-type requiredNode struct{ wrappedNode }
+type requiredNode struct{ Node }
 
 func (req *requiredNode) Optional() bool       { return false }
 func (req *requiredNode) Repeated() bool       { return false }
 func (req *requiredNode) Required() bool       { return true }
-func (req *requiredNode) GoType() reflect.Type { return unwrap(req).GoType() }
+func (req *requiredNode) GoType() reflect.Type { return req.Node.GoType() }
 
 type node struct{}
 
@@ -245,9 +199,9 @@ func (n *leafNode) Leaf() bool { return true }
 
 func (n *leafNode) Fields() []Field { return nil }
 
-func (n *leafNode) Encoding() []encoding.Encoding { return nil }
+func (n *leafNode) Encoding() encoding.Encoding { return nil }
 
-func (n *leafNode) Compression() []compress.Codec { return nil }
+func (n *leafNode) Compression() compress.Codec { return nil }
 
 func (n *leafNode) GoType() reflect.Type { return goTypeOfLeaf(n) }
 
@@ -299,8 +253,8 @@ func (g Group) Fields() []Field {
 	groupFields := make([]groupField, 0, len(g))
 	for name, node := range g {
 		groupFields = append(groupFields, groupField{
-			wrappedNode: wrap(node),
-			name:        name,
+			Node: node,
+			name: name,
 		})
 	}
 	sort.Slice(groupFields, func(i, j int) bool {
@@ -313,14 +267,14 @@ func (g Group) Fields() []Field {
 	return fields
 }
 
-func (g Group) Encoding() []encoding.Encoding { return nil }
+func (g Group) Encoding() encoding.Encoding { return nil }
 
-func (g Group) Compression() []compress.Codec { return nil }
+func (g Group) Compression() compress.Codec { return nil }
 
 func (g Group) GoType() reflect.Type { return goTypeOfGroup(g) }
 
 type groupField struct {
-	wrappedNode
+	Node
 	name string
 }
 
@@ -449,15 +403,8 @@ func mapKeyValueOf(node Node) Node {
 	panic("node with logical type MAP is not composed of a repeated .key_value group with key and value fields")
 }
 
-func encodingAndCompressionOf(node Node) (encoding.Encoding, compress.Codec) {
-	// TODO: we pick the first encoding and compression algorithm configured
-	// on the node. An amelioration we could bring to this model is to
-	// generate a matrix of encoding x codec and generate multiple
-	// representations of the pages, picking the one with the smallest space
-	// footprint; keep it simple for now.
-	encoding := encoding.Encoding(&Plain)
-	nodeEncoding := node.Encoding()
-	compression := compress.Codec(&Uncompressed)
+func encodingOf(node Node) encoding.Encoding {
+	encoding := node.Encoding()
 	// The parquet-format documentation states that the
 	// DELTA_LENGTH_BYTE_ARRAY is always preferred to PLAIN when
 	// encoding BYTE_ARRAY values. We apply it as a default if
@@ -465,21 +412,13 @@ func encodingAndCompressionOf(node Node) (encoding.Encoding, compress.Codec) {
 	// the opportunity to override this behavior if needed.
 	//
 	// https://github.com/apache/parquet-format/blob/master/Encodings.md#delta-length-byte-array-delta_length_byte_array--6
-	if node.Type().Kind() == ByteArray && len(nodeEncoding) == 0 {
+	if node.Type().Kind() == ByteArray && encoding == nil {
 		encoding = &DeltaLengthByteArray
 	}
-
-	for _, e := range nodeEncoding {
-		encoding = e
-		break
+	if encoding == nil {
+		encoding = &Plain
 	}
-
-	for _, c := range node.Compression() {
-		compression = c
-		break
-	}
-
-	return encoding, compression
+	return encoding
 }
 
 func forEachNodeOf(name string, node Node, do func(string, Node)) {

--- a/writer.go
+++ b/writer.go
@@ -270,11 +270,21 @@ func newWriter(output io.Writer, config *WriterConfig) *writer {
 		dataPageType = format.DataPageV2
 	}
 
+	defaultCompression := config.Compression
+	if defaultCompression == nil {
+		defaultCompression = &Uncompressed
+	}
+
 	forEachLeafColumnOf(config.Schema, func(leaf leafColumn) {
-		encoding, compression := encodingAndCompressionOf(leaf.node)
+		encoding := encodingOf(leaf.node)
 		dictionary := Dictionary(nil)
 		columnType := leaf.node.Type()
 		columnIndex := int(leaf.columnIndex)
+		compression := leaf.node.Compression()
+
+		if compression == nil {
+			compression = defaultCompression
+		}
 
 		if isDictionaryEncoding(encoding) {
 			dictionary = columnType.NewDictionary(columnIndex, defaultDictBufferSize)


### PR DESCRIPTION
Based on #140, this PR addresses #124 by adding a new writer option to configure the default compression codec to use when none are specified on the schema.

As part of this work, I am suggesting to simplify further the `parquet.Node` interface to support having a single encoding and compression codec per node. Prior to this change, it was possible to configure multiple encodings and compression codecs on a column; however, we never made use of this feature, nor did it provide applications with information they couldn't other access more precisely with different mechanism (see the comment I left in `column.go` for details).