### PR TITLE
improve error handling of invalid arguments in encodings

### DIFF
--- a/encoding/delta/byte_array_decoder.go
+++ b/encoding/delta/byte_array_decoder.go
@@ -41,7 +41,7 @@ func (d *ByteArrayDecoder) DecodeByteArray(data *encoding.ByteArrayList) (int, e
 
 func (d *ByteArrayDecoder) DecodeFixedLenByteArray(size int, data []byte) (int, error) {
 	if size <= 0 {
-		return 0, fmt.Errorf("%w: size can't be < 1", encoding.ErrInvalidArguments)
+		return 0, fmt.Errorf("DELTA_BYTE_ARRAY: %w: size of decoded FIXED_LEN_BYTE_ARRAY must be positive", encoding.ErrInvalidArgument)
 	}
 
 	i := 0

--- a/encoding/delta/byte_array_encoder.go
+++ b/encoding/delta/byte_array_encoder.go
@@ -36,7 +36,7 @@ func (e *ByteArrayEncoder) EncodeByteArray(data encoding.ByteArrayList) error {
 
 func (e *ByteArrayEncoder) EncodeFixedLenByteArray(size int, data []byte) error {
 	if size <= 0 {
-		return fmt.Errorf("%w: size can't be zero", encoding.ErrInvalidArguments)
+		return fmt.Errorf("DELTA_BYTE_ARRAY: %w: size of encoded FIXED_LEN_BYTE_ARRAY must be positive", encoding.ErrInvalidArgument)
 	}
 	return e.encode(len(data)/size, func(i int) []byte { return data[i*size : (i+1)*size] })
 }

--- a/encoding/notsupported.go
+++ b/encoding/notsupported.go
@@ -18,13 +18,13 @@ var (
 	// returned by encoders and decoders.
 	ErrNotSupported = errors.New("encoding not supported")
 
-	// ErrInvalidArguments is an error returned when arguments passed to the
-	// encoding functions are incorrect and will lead to an expected failure.
+	// ErrInvalidArgument is an error returned one or more arguments passed to
+	// the encoding functions are incorrect.
 	//
 	// As with ErrNotSupported, this error may be wrapped with specific
 	// information about the problem and applications are expected to use
 	// errors.Is for comparisons.
-	ErrInvalidArguments = errors.New("invalid encoding arguments")
+	ErrInvalidArgument = errors.New("invalid argument")
 )
 
 // NotSupported is a type satisfying the Encoding interface which does not

--- a/encoding/plain/decoder.go
+++ b/encoding/plain/decoder.go
@@ -78,9 +78,14 @@ func (d *Decoder) DecodeByteArray(data *encoding.ByteArrayList) (n int, err erro
 }
 
 func (d *Decoder) DecodeFixedLenByteArray(size int, data []byte) (int, error) {
-	if size == 0 || (len(data)%size) != 0 {
-		return 0, fmt.Errorf("%w: length of fixed byte array is not a multiple of its size: size=%d length=%d", encoding.ErrInvalidArguments, size, len(data))
+	if size <= 0 {
+		return 0, fmt.Errorf("PLAIN: %w: size of decoded FIXED_LEN_BYTE_ARRAY must be positive", encoding.ErrInvalidArgument)
 	}
+
+	if (len(data) % size) != 0 {
+		return 0, fmt.Errorf("PLAIN: %w: length of decoded FIXED_LEN_BYTE_ARRAY must be a multiple of its size: size=%d length=%d", encoding.ErrInvalidArgument, size, len(data))
+	}
+
 	return readFull(d.reader, size, data)
 }
 

--- a/encoding/plain/encoder.go
+++ b/encoding/plain/encoder.go
@@ -77,12 +77,12 @@ func (e *Encoder) EncodeByteArray(data encoding.ByteArrayList) (err error) {
 }
 
 func (e *Encoder) EncodeFixedLenByteArray(size int, data []byte) error {
-	if size == 0 {
-		return fmt.Errorf("%w: size can't be zero", encoding.ErrInvalidArguments)
+	if size <= 0 {
+		return fmt.Errorf("PLAIN: %w: size of encoded FIXED_LEN_BYTE_ARRAY must be positive", encoding.ErrInvalidArgument)
 	}
 
 	if (len(data) % size) != 0 {
-		return fmt.Errorf("%w: length of fixed byte array is not a multiple of its size: size=%d length=%d", encoding.ErrInvalidArguments, size, len(data))
+		return fmt.Errorf("PLAIN: %w: length of encoded FIXED_LEN_BYTE_ARRAY must be a multiple of its size: size=%d length=%d", encoding.ErrInvalidArgument, size, len(data))
 	}
 
 	_, err := e.writer.Write(data)


### PR DESCRIPTION
Fixes #112 

I'm taking the suggested approach of making the error messages more descriptive of the conditions that triggered the issues rather than using distinct error values for input validation errors that occur while encoding or decoding.

Let me know if you have any feedback.