### PR TITLE
Optimize file reader memory footprint

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -240,7 +240,7 @@ func (buf *Buffer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 //
 // The buffer and the returned reader share memory. Mutating the buffer
 // concurrently to reading rows may result in non-deterministic behavior.
-func (buf *Buffer) Rows() Rows { return &rowGroupRowReader{rowGroup: buf} }
+func (buf *Buffer) Rows() Rows { return &rowGroupRows{rowGroup: buf} }
 
 // bufferWriter is an adapter for Buffer which implements both RowWriter and
 // PageWriter to enable optimizations in CopyRows for types that support writing

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -371,7 +371,9 @@ func TestBufferGenerateBloomFilters(t *testing.T) {
 		for i := range rows {
 			buffer.Write(&rows[i])
 		}
-		_, err := parquet.CopyRows(writer, buffer.Rows())
+		bufferRows := buffer.Rows()
+		_, err := parquet.CopyRows(writer, bufferRows)
+		bufferRows.Close()
 		if err != nil {
 			t.Error(err)
 			return false

--- a/class_go18.go
+++ b/class_go18.go
@@ -57,6 +57,18 @@ type class[T primitive] struct {
 	decode    func(encoding.Decoder, []T) (int, error)
 }
 
+func (c *class[T]) getBuffer() []T {
+	b := getBuffer()
+	return unsafe.Slice((*T)(unsafe.Pointer(&b[0])), bufferSize/sizeof[T]())
+}
+
+func (c *class[T]) putBuffer(b []T) {
+	if cap(b) == (bufferSize / sizeof[T]()) {
+		b = b[:1]
+		putBuffer((*[bufferSize]byte)(unsafe.Pointer(&b[0])))
+	}
+}
+
 var boolClass = class[bool]{
 	name:      "BOOLEAN",
 	bits:      1,

--- a/column.go
+++ b/column.go
@@ -109,6 +109,12 @@ type columnPages struct {
 	index int
 }
 
+func (r *columnPages) Close() error {
+	r.pages = nil
+	r.index = 0
+	return nil
+}
+
 func (r *columnPages) ReadPage() (Page, error) {
 	for {
 		if r.index >= len(r.pages) {

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -344,8 +344,8 @@ func (col *optionalColumnBuffer) ReadValuesAt(values []Value, offset int64) (int
 	return int(length), nil
 }
 
-func (col *optionalColumnBuffer) Values() ValueReader {
-	return &optionalPageReader{page: col.Page().(*optionalPage)}
+func (col *optionalColumnBuffer) Values() PageValues {
+	return &optionalValues{page: col.Page().(*optionalPage)}
 }
 
 // repeatedColumnBuffer is an implementation of the ColumnBuffer interface used
@@ -622,8 +622,8 @@ func (col *repeatedColumnBuffer) ReadValuesAt(values []Value, offset int64) (int
 	panic("NOT IMPLEMENTED")
 }
 
-func (col *repeatedColumnBuffer) Values() ValueReader {
-	return &repeatedPageReader{page: col.Page().(*repeatedPage)}
+func (col *repeatedColumnBuffer) Values() PageValues {
+	return &repeatedValues{page: col.Page().(*repeatedPage)}
 }
 
 func optionalRowsHaveBeenReordered(rows []int32) bool {

--- a/column_reader_go18.go
+++ b/column_reader_go18.go
@@ -15,7 +15,6 @@ type columnReader[T primitive] struct {
 	buffer      []T
 	offset      int
 	remain      int
-	bufferSize  int
 	columnIndex int16
 }
 
@@ -23,7 +22,7 @@ func newColumnReader[T primitive](typ Type, columnIndex int16, bufferSize int, c
 	return &columnReader[T]{
 		class:       class,
 		typ:         typ,
-		bufferSize:  bufferSize,
+		buffer:      make([]T, 0, atLeastOne(bufferSize/sizeof[T]())),
 		columnIndex: ^columnIndex,
 	}
 }
@@ -51,10 +50,6 @@ func (r *columnReader[T]) ReadRequired(values []T) (n int, err error) {
 }
 
 func (r *columnReader[T]) ReadValues(values []Value) (n int, err error) {
-	if cap(r.buffer) == 0 {
-		r.buffer = make([]T, 0, atLeastOne(r.bufferSize))
-	}
-
 	makeValue := r.class.makeValue
 	columnIndex := r.columnIndex
 	for {

--- a/convert.go
+++ b/convert.go
@@ -332,7 +332,7 @@ func (p missingPage) NumValues() int64                  { return p.numValues }
 func (p missingPage) NumNulls() int64                   { return p.numNulls }
 func (p missingPage) Bounds() (min, max Value, ok bool) { return }
 func (p missingPage) Size() int64                       { return 0 }
-func (p missingPage) Values() ValueReader               { return &missingValues{page: p} }
+func (p missingPage) Values() PageValues                { return &missingValues{page: p} }
 func (p missingPage) Buffer() BufferedPage {
 	return newErrorPage(p.Column(), "cannot buffer missing page")
 }
@@ -340,6 +340,11 @@ func (p missingPage) Buffer() BufferedPage {
 type missingValues struct {
 	page missingPage
 	read int64
+}
+
+func (r *missingValues) Close() error {
+	r.read = r.page.numValues
+	return nil
 }
 
 func (r *missingValues) ReadValues(values []Value) (int, error) {

--- a/file.go
+++ b/file.go
@@ -850,19 +850,19 @@ func (p *filePage) Size() int64 {
 	return int64(p.header.UncompressedPageSize)
 }
 
-func (p *filePage) Values() ValueReader {
+func (p *filePage) Values() PageValues {
 	if p.values == nil {
 		p.values = new(filePageValueReaderState)
 	}
 	if err := p.values.init(p.columnType, p.column, p.codec, p.PageHeader(), &p.data, p.dictionary); err != nil {
-		return &errorValueReader{err: err}
+		return &errorValues{err: err}
 	}
 	return p.values.reader
 }
 
 func (p *filePage) Buffer() BufferedPage {
 	bufferedPage := p.column.Type().NewColumnBuffer(p.Column(), int(p.Size()))
-	_, err := CopyValues(bufferedPage, p.Values())
+	_, err := copyPageValues(bufferedPage, p.Values())
 	if err != nil {
 		return &errorPage{err: err, columnIndex: p.Column()}
 	}

--- a/merge.go
+++ b/merge.go
@@ -19,10 +19,10 @@ func (m *mergedRowGroup) SortingColumns() []SortingColumn {
 func (m *mergedRowGroup) Rows() Rows {
 	// The row group needs to respect a sorting order; the merged row reader
 	// uses a heap to merge rows from the row groups.
-	return &mergedRowGroupRowReader{rowGroup: m, schema: m.schema}
+	return &mergedRows{rowGroup: m, schema: m.schema}
 }
 
-type mergedRowGroupRowReader struct {
+type mergedRows struct {
 	rowGroup *mergedRowGroup
 	schema   *Schema
 	sorting  []columnSortFunc
@@ -34,7 +34,7 @@ type mergedRowGroupRowReader struct {
 	err      error
 }
 
-func (r *mergedRowGroupRowReader) init(m *mergedRowGroup) {
+func (r *mergedRows) init(m *mergedRowGroup) {
 	if r.schema != nil {
 		numColumns := numLeafColumnsOf(r.schema)
 		cursors := make([]bufferedRowGroupCursor, len(m.rowGroups))
@@ -53,14 +53,14 @@ func (r *mergedRowGroupRowReader) init(m *mergedRowGroup) {
 			// TODO: this is a bit of a weak model, it only works with types
 			// declared in this package; we may want to define an API to allow
 			// applications to participate in it.
-			if rd, ok := cursors[i].reader.(*rowGroupRowReader); ok {
+			if rd, ok := cursors[i].reader.(*rowGroupRows); ok {
 				rd.init(rd.rowGroup)
 				rd.rowGroup = nil
 				// TODO: this optimization is disabled for now, there are
 				// remaining blockers:
 				//
 				// * The optimized merge of pages for non-overlapping ranges is
-				//   not yet implemented in the mergedRowGroupRowReader type.
+				//   not yet implemented in the mergedRows type.
 				//
 				// * Using pages min/max to determine overlapping ranges does
 				//   not work for repeated columns; sorting by repeated columns
@@ -86,7 +86,14 @@ func (r *mergedRowGroupRowReader) init(m *mergedRowGroup) {
 	}
 }
 
-func (r *mergedRowGroupRowReader) SeekToRow(rowIndex int64) error {
+func (r *mergedRows) Close() error {
+	for i := range r.cursors {
+		r.cursors[i].close()
+	}
+	return nil
+}
+
+func (r *mergedRows) SeekToRow(rowIndex int64) error {
 	if rowIndex >= r.index {
 		r.seek = rowIndex
 		return nil
@@ -94,7 +101,7 @@ func (r *mergedRowGroupRowReader) SeekToRow(rowIndex int64) error {
 	return fmt.Errorf("SeekToRow: merged row reader cannot seek backward from row %d to %d", r.index, rowIndex)
 }
 
-func (r *mergedRowGroupRowReader) ReadRow(row Row) (Row, error) {
+func (r *mergedRows) ReadRow(row Row) (Row, error) {
 	if r.rowGroup != nil {
 		r.init(r.rowGroup)
 		r.rowGroup = nil
@@ -131,7 +138,7 @@ func (r *mergedRowGroupRowReader) ReadRow(row Row) (Row, error) {
 	}
 }
 
-// func (r *mergedRowGroupRowReader) WriteRowsTo(w RowWriter) (int64, error) {
+// func (r *mergedRows) WriteRowsTo(w RowWriter) (int64, error) {
 // 	if r.rowGroup != nil {
 // 		defer func() { r.rowGroup = nil }()
 // 		switch dst := w.(type) {
@@ -145,22 +152,22 @@ func (r *mergedRowGroupRowReader) ReadRow(row Row) (Row, error) {
 // 	return CopyRows(w, struct{ RowReaderWithSchema }{r})
 // }
 
-func (r *mergedRowGroupRowReader) writeRowsTo(w pageAndValueWriter) (numRows int64, err error) {
+func (r *mergedRows) writeRowsTo(w pageAndValueWriter) (numRows int64, err error) {
 	// TODO: the intent of this method is to optimize the merge of rows by
 	// copying entire pages instead of individual rows when we detect ranges
 	// that don't overlap.
 	return
 }
 
-func (r *mergedRowGroupRowReader) Schema() *Schema {
+func (r *mergedRows) Schema() *Schema {
 	return r.schema
 }
 
-func (r *mergedRowGroupRowReader) Len() int {
+func (r *mergedRows) Len() int {
 	return len(r.cursors)
 }
 
-func (r *mergedRowGroupRowReader) Less(i, j int) bool {
+func (r *mergedRows) Less(i, j int) bool {
 	cursor1 := r.cursors[i]
 	cursor2 := r.cursors[j]
 
@@ -179,15 +186,15 @@ func (r *mergedRowGroupRowReader) Less(i, j int) bool {
 	return false
 }
 
-func (r *mergedRowGroupRowReader) Swap(i, j int) {
+func (r *mergedRows) Swap(i, j int) {
 	r.cursors[i], r.cursors[j] = r.cursors[j], r.cursors[i]
 }
 
-func (r *mergedRowGroupRowReader) Push(interface{}) {
+func (r *mergedRows) Push(interface{}) {
 	panic("BUG: unreachable")
 }
 
-func (r *mergedRowGroupRowReader) Pop() interface{} {
+func (r *mergedRows) Pop() interface{} {
 	n := len(r.cursors) - 1
 	c := r.cursors[n]
 	r.cursors = r.cursors[:n]
@@ -195,6 +202,7 @@ func (r *mergedRowGroupRowReader) Pop() interface{} {
 }
 
 type rowGroupCursor interface {
+	close() error
 	readRow(Row) (Row, error)
 	readNext() error
 	nextRowValuesOf([]Value, int16) []Value
@@ -209,6 +217,10 @@ type bufferedRowGroupCursor struct {
 	reader  Rows
 	rowbuf  Row
 	columns [][]Value
+}
+
+func (cur *bufferedRowGroupCursor) close() error {
+	return cur.reader.Close()
 }
 
 func (cur *bufferedRowGroupCursor) readRow(row Row) (Row, error) {
@@ -235,7 +247,7 @@ func (cur *bufferedRowGroupCursor) nextRowValuesOf(values []Value, columnIndex i
 }
 
 /*
-type optimizedRowGroupCursor struct{ *rowGroupRowReader }
+type optimizedRowGroupCursor struct{ *rowGroupRows }
 
 func (cur optimizedRowGroupCursor) readRow(row Row) (Row, error) { return cur.ReadRow(row) }
 
@@ -264,6 +276,6 @@ func (cur optimizedRowGroupCursor) nextRowValuesOf(values []Value, columnIndex i
 */
 
 var (
-	_ RowReaderWithSchema = (*mergedRowGroupRowReader)(nil)
-	//_ RowWriterTo         = (*mergedRowGroupRowReader)(nil)
+	_ RowReaderWithSchema = (*mergedRows)(nil)
+	//_ RowWriterTo         = (*mergedRows)(nil)
 )

--- a/page.go
+++ b/page.go
@@ -121,14 +121,22 @@ type singlePage struct {
 	seek int64
 }
 
+func (r *singlePage) Close() error {
+	r.page = nil
+	r.seek = 0
+	return nil
+}
+
 func (r *singlePage) ReadPage() (Page, error) {
-	if numRows := r.page.NumRows(); r.seek < numRows {
-		seek := r.seek
-		r.seek = numRows
-		if seek > 0 {
-			return r.page.Buffer().Slice(seek, numRows), nil
+	if r.page != nil {
+		if numRows := r.page.NumRows(); r.seek < numRows {
+			seek := r.seek
+			r.seek = numRows
+			if seek > 0 {
+				return r.page.Buffer().Slice(seek, numRows), nil
+			}
+			return r.page, nil
 		}
-		return r.page, nil
 	}
 	return nil, io.EOF
 }

--- a/page_decoder.go
+++ b/page_decoder.go
@@ -1,0 +1,399 @@
+package parquet
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"unsafe"
+
+	"github.com/segmentio/parquet-go/encoding"
+	"github.com/segmentio/parquet-go/encoding/plain"
+	"github.com/segmentio/parquet-go/internal/bits"
+)
+
+type filePageDecoder struct {
+	remain             int
+	numValues          int
+	maxRepetitionLevel int8
+	maxDefinitionLevel int8
+	columnIndex        int16
+	repetitions        levelDecoder
+	definitions        levelDecoder
+	values             PageValues
+}
+
+func newFilePageDecoder(numValues int, columnIndex int16, maxRepetitionLevel, maxDefinitionLevel int8, repetitions, definitions encoding.Decoder, values PageValues) *filePageDecoder {
+	if repetitions != nil {
+		repetitions.SetBitWidth(bits.Len8(maxRepetitionLevel))
+	}
+	if definitions != nil {
+		definitions.SetBitWidth(bits.Len8(maxDefinitionLevel))
+	}
+	return &filePageDecoder{
+		remain:             numValues,
+		numValues:          numValues,
+		maxRepetitionLevel: maxRepetitionLevel,
+		maxDefinitionLevel: maxDefinitionLevel,
+		columnIndex:        ^columnIndex,
+		repetitions:        makeLevelDecoder(repetitions),
+		definitions:        makeLevelDecoder(definitions),
+		values:             values,
+	}
+}
+
+func (r *filePageDecoder) Close() error {
+	r.remain = 0
+	r.repetitions.close()
+	r.definitions.close()
+	return r.values.Close()
+}
+
+func (r *filePageDecoder) ReadValues(values []Value) (int, error) {
+	read := 0
+
+	for r.remain > 0 && len(values) > 0 {
+		var err error
+		var repetitionLevels []int8
+		var definitionLevels []int8
+		var numValues = r.remain
+
+		if len(values) < numValues {
+			numValues = len(values)
+		}
+
+		if r.maxRepetitionLevel > 0 {
+			repetitionLevels, err = r.repetitions.peekLevels()
+			if err != nil {
+				return read, fmt.Errorf("decoding repetition level from data page of column %d: %w", ^r.columnIndex, err)
+			}
+			if len(repetitionLevels) < numValues {
+				numValues = len(repetitionLevels)
+			}
+		}
+
+		if r.maxDefinitionLevel > 0 {
+			definitionLevels, err = r.definitions.peekLevels()
+			if err != nil {
+				return read, fmt.Errorf("decoding definition level from data page of column %d: %w", ^r.columnIndex, err)
+			}
+			if len(definitionLevels) < numValues {
+				numValues = len(definitionLevels)
+			}
+		}
+
+		if len(repetitionLevels) > 0 {
+			repetitionLevels = repetitionLevels[:numValues]
+		}
+		if len(definitionLevels) > 0 {
+			definitionLevels = definitionLevels[:numValues]
+		}
+		numNulls := countLevelsNotEqual(definitionLevels, r.maxDefinitionLevel)
+		wantRead := numValues - numNulls
+		n, err := r.values.ReadValues(values[:wantRead])
+		if n < wantRead && err != nil {
+			return read, fmt.Errorf("read error after decoding %d/%d values from data page of column %d: %w", r.numValues-r.remain, r.numValues, ^r.columnIndex, err)
+		}
+
+		for i, j := n-1, len(definitionLevels)-1; j >= 0; j-- {
+			if definitionLevels[j] != r.maxDefinitionLevel {
+				values[j] = Value{columnIndex: r.columnIndex}
+			} else {
+				values[j] = values[i]
+				i--
+			}
+		}
+
+		for i, lvl := range repetitionLevels {
+			values[i].repetitionLevel = lvl
+		}
+
+		for i, lvl := range definitionLevels {
+			values[i].definitionLevel = lvl
+		}
+
+		values = values[numValues:]
+		r.repetitions.discardLevels(len(repetitionLevels))
+		r.definitions.discardLevels(len(definitionLevels))
+		r.remain -= numValues
+		read += numValues
+	}
+
+	if r.remain == 0 {
+		return read, io.EOF
+	}
+
+	return read, nil
+}
+
+type levelDecoder struct {
+	decoder encoding.Decoder
+	levels  []int8
+	offset  int
+	count   int
+}
+
+func makeLevelDecoder(decoder encoding.Decoder) levelDecoder {
+	return levelDecoder{
+		decoder: decoder,
+		levels:  getLevelBuffer(),
+	}
+}
+
+func (r *levelDecoder) close() {
+	putLevelBuffer(r.levels)
+	r.decoder = nil
+	r.levels = nil
+	r.offset = 0
+	r.count = 0
+}
+
+func (r *levelDecoder) readLevel() (int8, error) {
+	for {
+		if r.offset < len(r.levels) {
+			lvl := r.levels[r.offset]
+			r.offset++
+			return lvl, nil
+		}
+		if err := r.decodeLevels(); err != nil {
+			return -1, err
+		}
+	}
+}
+
+func (r *levelDecoder) peekLevels() ([]int8, error) {
+	if r.offset == len(r.levels) {
+		if err := r.decodeLevels(); err != nil {
+			return nil, err
+		}
+	}
+	return r.levels[r.offset:], nil
+}
+
+func (r *levelDecoder) discardLevels(n int) {
+	remain := len(r.levels) - r.offset
+	switch {
+	case n > remain:
+		panic("BUG: cannot discard more levels than buffered")
+	case n == remain:
+		r.levels = r.levels[:0]
+		r.offset = 0
+	default:
+		r.offset += n
+	}
+}
+
+func (r *levelDecoder) decodeLevels() error {
+	n, err := r.decoder.DecodeInt8(r.levels[:cap(r.levels)])
+	if n == 0 {
+		return err
+	}
+	r.levels = r.levels[:n]
+	r.offset = 0
+	r.count += n
+	return nil
+}
+
+type byteArrayPageDecoder struct {
+	decoder     encoding.Decoder
+	buffer      *encoding.ByteArrayList
+	offset      int
+	remain      int
+	columnIndex int16
+}
+
+func newByteArrayPageDecoder(typ Type, columnIndex int16, numValues int, decoder encoding.Decoder) *byteArrayPageDecoder {
+	return &byteArrayPageDecoder{
+		decoder:     decoder,
+		buffer:      getByteArrayList(),
+		remain:      numValues,
+		columnIndex: ^columnIndex,
+	}
+}
+
+func (r *byteArrayPageDecoder) Close() error {
+	putByteArrayList(r.buffer)
+	r.decoder = nil
+	r.buffer = nil
+	r.offset = 0
+	r.remain = 0
+	return nil
+}
+
+func (r *byteArrayPageDecoder) readByteArrays(do func([]byte) bool) (n int, err error) {
+	for {
+		for r.remain > 0 && r.offset < r.buffer.Len() {
+			if !do(r.buffer.Index(r.offset)) {
+				return n, nil
+			}
+			r.offset++
+			r.remain--
+			n++
+		}
+
+		if r.remain == 0 || r.decoder == nil {
+			return n, io.EOF
+		}
+
+		r.buffer.Reset()
+		r.offset = 0
+
+		d, err := r.decoder.DecodeByteArray(r.buffer)
+		if d == 0 {
+			return n, err
+		}
+	}
+}
+
+func (r *byteArrayPageDecoder) ReadRequired(values []byte) (int, error) {
+	return r.ReadByteArrays(values)
+}
+
+func (r *byteArrayPageDecoder) ReadByteArrays(values []byte) (int, error) {
+	i := 0
+	n, err := r.readByteArrays(func(b []byte) bool {
+		k := plain.ByteArrayLengthSize + len(b)
+		if k > (len(values) - i) {
+			return false
+		}
+		plain.PutByteArrayLength(values[i:], len(b))
+		copy(values[i+plain.ByteArrayLengthSize:], b)
+		i += k
+		return true
+	})
+	if i == 0 && err == nil {
+		err = io.ErrShortBuffer
+	}
+	return n, err
+}
+
+func (r *byteArrayPageDecoder) ReadValues(values []Value) (int, error) {
+	i := 0
+	return r.readByteArrays(func(b []byte) (ok bool) {
+		if ok = i < len(values); ok {
+			values[i] = makeValueBytes(ByteArray, copyBytes(b))
+			values[i].columnIndex = r.columnIndex
+			i++
+		}
+		return ok
+	})
+}
+
+type fixedLenByteArrayPageDecoder struct {
+	decoder     encoding.Decoder
+	buffer      []byte
+	offset      int
+	remain      int
+	size        int
+	columnIndex int16
+}
+
+func newFixedLenByteArrayPageDecoder(typ Type, columnIndex int16, numValues int, decoder encoding.Decoder) *fixedLenByteArrayPageDecoder {
+	return &fixedLenByteArrayPageDecoder{
+		decoder:     decoder,
+		buffer:      getBuffer()[:],
+		remain:      numValues,
+		size:        typ.Length(),
+		columnIndex: ^columnIndex,
+	}
+}
+
+func (r *fixedLenByteArrayPageDecoder) Close() error {
+	putBuffer((*[bufferSize]byte)(r.buffer))
+	r.decoder = nil
+	r.buffer = nil
+	r.offset = 0
+	r.remain = 0
+	return nil
+}
+
+func (r *fixedLenByteArrayPageDecoder) ReadRequired(values []byte) (int, error) {
+	return r.ReadFixedLenByteArrays(values)
+}
+
+func (r *fixedLenByteArrayPageDecoder) ReadFixedLenByteArrays(values []byte) (n int, err error) {
+	if (len(values) % r.size) != 0 {
+		return 0, fmt.Errorf("cannot read FIXED_LEN_BYTE_ARRAY values of size %d into buffer of size %d", r.size, len(values))
+	}
+	if r.offset < len(r.buffer) {
+		i := copy(values, r.buffer[r.offset:])
+		n = i / r.size
+		r.offset += i
+		r.remain -= i
+		values = values[i:]
+	}
+	if r.decoder == nil {
+		err = io.EOF
+	} else {
+		var d int
+		values = values[:min(r.remain, len(values))]
+		d, err = r.decoder.DecodeFixedLenByteArray(r.size, values)
+		n += d
+		r.remain -= d
+		if r.remain == 0 && err == nil {
+			err = io.EOF
+		}
+	}
+	return n, err
+}
+
+func (r *fixedLenByteArrayPageDecoder) ReadValues(values []Value) (n int, err error) {
+	for {
+		for (r.offset+r.size) <= len(r.buffer) && n < len(values) {
+			values[n] = makeValueBytes(FixedLenByteArray, copyBytes(r.buffer[r.offset:r.offset+r.size]))
+			values[n].columnIndex = r.columnIndex
+			r.offset += r.size
+			r.remain -= r.size
+			n++
+		}
+
+		if r.remain == 0 || r.decoder == nil {
+			return n, io.EOF
+		}
+		if n == len(values) {
+			return n, nil
+		}
+
+		length := min(r.remain, cap(r.buffer))
+		buffer := r.buffer[:length]
+		d, err := r.decoder.DecodeFixedLenByteArray(r.size, buffer)
+		if d == 0 {
+			return n, err
+		}
+
+		r.buffer = buffer[:d*r.size]
+		r.offset = 0
+	}
+}
+
+var (
+	byteArrayLists sync.Pool // *encoding.ByteArrayList
+)
+
+func getByteArrayList() *encoding.ByteArrayList {
+	b, _ := byteArrayLists.Get().(*encoding.ByteArrayList)
+	if b != nil {
+		b.Reset()
+	} else {
+		buffer := encoding.MakeByteArrayList(bufferSize / 16)
+		b = &buffer
+	}
+	return b
+}
+
+func putByteArrayList(b *encoding.ByteArrayList) {
+	if b != nil {
+		byteArrayLists.Put(b)
+	}
+}
+
+func getLevelBuffer() []int8 {
+	b := getBuffer()
+	return unsafe.Slice((*int8)(unsafe.Pointer(&b[0])), bufferSize)
+}
+
+func putLevelBuffer(b []int8) {
+	if cap(b) == bufferSize {
+		b = b[:cap(b)]
+		putBuffer((*[bufferSize]byte)(unsafe.Pointer(&b[0])))
+	}
+}

--- a/page_go18_test.go
+++ b/page_go18_test.go
@@ -270,6 +270,7 @@ func TestOptionalPageTrailingNulls(t *testing.T) {
 
 	resultRows := []parquet.Row{}
 	reader := buffer.Rows()
+	defer reader.Close()
 	for {
 		row, err := reader.ReadRow(nil)
 		if err != nil {
@@ -294,7 +295,10 @@ func TestOptionalPagePreserveIndex(t *testing.T) {
 		t.Fatal("writing row:", err)
 	}
 
-	row, err := buffer.Rows().ReadRow(nil)
+	reader := buffer.Rows()
+	defer reader.Close()
+
+	row, err := reader.ReadRow(nil)
 	if err != nil {
 		t.Fatal("reading rows:", err)
 	}
@@ -328,6 +332,7 @@ func TestRepeatedPageTrailingNulls(t *testing.T) {
 
 	resultRows := []parquet.Row{}
 	reader := buf.Rows()
+	defer reader.Close()
 	for {
 		row, err := reader.ReadRow(nil)
 		if err != nil {

--- a/page_test.go
+++ b/page_test.go
@@ -418,6 +418,7 @@ func TestOptionalPageTrailingNulls(t *testing.T) {
 
 	resultRows := []parquet.Row{}
 	reader := buffer.Rows()
+	defer reader.Close()
 	for {
 		row, err := reader.ReadRow(nil)
 		if err != nil {
@@ -442,7 +443,10 @@ func TestOptionalPagePreserveIndex(t *testing.T) {
 		t.Fatal("writing row:", err)
 	}
 
-	row, err := buffer.Rows().ReadRow(nil)
+	reader := buffer.Rows()
+	defer reader.Close()
+
+	row, err := reader.ReadRow(nil)
 	if err != nil {
 		t.Fatal("reading rows:", err)
 	}
@@ -476,6 +480,7 @@ func TestRepeatedPageTrailingNulls(t *testing.T) {
 
 	resultRows := []parquet.Row{}
 	reader := buf.Rows()
+	defer reader.Close()
 	for {
 		row, err := reader.ReadRow(nil)
 		if err != nil {

--- a/page_values.go
+++ b/page_values.go
@@ -1,0 +1,271 @@
+package parquet
+
+import (
+	"io"
+
+	"github.com/segmentio/parquet-go/encoding/plain"
+)
+
+type optionalValues struct {
+	page   *optionalPage
+	values PageValues
+	offset int
+}
+
+func (r *optionalValues) Close() error {
+	r.page = nil
+	return r.values.Close()
+}
+
+func (r *optionalValues) ReadValues(values []Value) (n int, err error) {
+	if r.page == nil {
+		return 0, io.EOF
+	}
+	if r.values == nil {
+		r.values = r.page.base.Values()
+	}
+	maxDefinitionLevel := r.page.maxDefinitionLevel
+	columnIndex := ^int16(r.page.Column())
+
+	for n < len(values) && r.offset < len(r.page.definitionLevels) {
+		for n < len(values) && r.offset < len(r.page.definitionLevels) && r.page.definitionLevels[r.offset] != maxDefinitionLevel {
+			values[n] = Value{
+				definitionLevel: r.page.definitionLevels[r.offset],
+				columnIndex:     columnIndex,
+			}
+			r.offset++
+			n++
+		}
+
+		i := n
+		j := r.offset
+		for i < len(values) && j < len(r.page.definitionLevels) && r.page.definitionLevels[j] == maxDefinitionLevel {
+			i++
+			j++
+		}
+
+		if n < i {
+			for j, err = r.values.ReadValues(values[n:i]); j > 0; j-- {
+				values[n].definitionLevel = maxDefinitionLevel
+				r.offset++
+				n++
+			}
+			// Do not return on an io.EOF here as we may still have null values to read.
+			if err != nil && err != io.EOF {
+				return n, err
+			}
+		}
+	}
+
+	if r.offset == len(r.page.definitionLevels) {
+		err = io.EOF
+	}
+	return n, err
+}
+
+type repeatedValues struct {
+	page   *repeatedPage
+	values PageValues
+	offset int
+}
+
+func (r *repeatedValues) Close() error {
+	r.page = nil
+	return r.values.Close()
+}
+
+func (r *repeatedValues) ReadValues(values []Value) (n int, err error) {
+	if r.page == nil {
+		return 0, io.EOF
+	}
+	if r.values == nil {
+		r.values = r.page.base.Values()
+	}
+	maxDefinitionLevel := r.page.maxDefinitionLevel
+	columnIndex := ^int16(r.page.Column())
+
+	for n < len(values) && r.offset < len(r.page.definitionLevels) {
+		for n < len(values) && r.offset < len(r.page.definitionLevels) && r.page.definitionLevels[r.offset] != maxDefinitionLevel {
+			values[n] = Value{
+				repetitionLevel: r.page.repetitionLevels[r.offset],
+				definitionLevel: r.page.definitionLevels[r.offset],
+				columnIndex:     columnIndex,
+			}
+			r.offset++
+			n++
+		}
+
+		i := n
+		j := r.offset
+		for i < len(values) && j < len(r.page.definitionLevels) && r.page.definitionLevels[j] == maxDefinitionLevel {
+			i++
+			j++
+		}
+
+		if n < i {
+			for j, err = r.values.ReadValues(values[n:i]); j > 0; j-- {
+				values[n].repetitionLevel = r.page.repetitionLevels[r.offset]
+				values[n].definitionLevel = maxDefinitionLevel
+				r.offset++
+				n++
+			}
+			if err != nil && err != io.EOF {
+				return n, err
+			}
+		}
+	}
+
+	if r.offset == len(r.page.definitionLevels) {
+		err = io.EOF
+	}
+	return n, err
+}
+
+type byteArrayValues struct {
+	page   *byteArrayPage
+	offset int
+}
+
+func (r *byteArrayValues) Close() error {
+	r.page = nil
+	return nil
+}
+
+func (r *byteArrayValues) Read(b []byte) (int, error) {
+	_, n, err := r.readByteArrays(b)
+	return n, err
+}
+
+func (r *byteArrayValues) ReadRequired(values []byte) (int, error) {
+	return r.ReadByteArrays(values)
+}
+
+func (r *byteArrayValues) ReadByteArrays(values []byte) (int, error) {
+	n, _, err := r.readByteArrays(values)
+	return n, err
+}
+
+func (r *byteArrayValues) readByteArrays(values []byte) (c, n int, err error) {
+	if r.page == nil {
+		return 0, 0, io.EOF
+	}
+	for r.offset < r.page.values.Len() {
+		b := r.page.values.Index(r.offset)
+		k := plain.ByteArrayLengthSize + len(b)
+		if k > (len(values) - n) {
+			break
+		}
+		plain.PutByteArrayLength(values[n:], len(b))
+		n += plain.ByteArrayLengthSize
+		n += copy(values[n:], b)
+		r.offset++
+		c++
+	}
+	if r.offset == r.page.values.Len() {
+		err = io.EOF
+	} else if n == 0 && len(values) > 0 {
+		err = io.ErrShortBuffer
+	}
+	return c, n, err
+}
+
+func (r *byteArrayValues) ReadValues(values []Value) (n int, err error) {
+	if r.page == nil {
+		return 0, io.EOF
+	}
+	for n < len(values) && r.offset < r.page.values.Len() {
+		values[n] = makeValueBytes(ByteArray, r.page.values.Index(r.offset))
+		values[n].columnIndex = r.page.columnIndex
+		r.offset++
+		n++
+	}
+	if r.offset == r.page.values.Len() {
+		err = io.EOF
+	}
+	return n, err
+}
+
+type fixedLenByteArrayValues struct {
+	page   *fixedLenByteArrayPage
+	offset int
+}
+
+func (r *fixedLenByteArrayValues) Close() error {
+	r.page = nil
+	return nil
+}
+
+func (r *fixedLenByteArrayValues) Read(b []byte) (n int, err error) {
+	n, err = r.ReadFixedLenByteArrays(b)
+	return n * r.page.size, err
+}
+
+func (r *fixedLenByteArrayValues) ReadRequired(values []byte) (int, error) {
+	return r.ReadFixedLenByteArrays(values)
+}
+
+func (r *fixedLenByteArrayValues) ReadFixedLenByteArrays(values []byte) (n int, err error) {
+	if r.page == nil {
+		return 0, io.EOF
+	}
+	n = copy(values, r.page.data[r.offset:]) / r.page.size
+	r.offset += n * r.page.size
+	if r.offset == len(r.page.data) {
+		err = io.EOF
+	} else if n == 0 && len(values) > 0 {
+		err = io.ErrShortBuffer
+	}
+	return n, err
+}
+
+func (r *fixedLenByteArrayValues) ReadValues(values []Value) (n int, err error) {
+	if r.page == nil {
+		return 0, io.EOF
+	}
+	for n < len(values) && r.offset < len(r.page.data) {
+		values[n] = makeValueBytes(FixedLenByteArray, r.page.data[r.offset:r.offset+r.page.size])
+		values[n].columnIndex = r.page.columnIndex
+		r.offset += r.page.size
+		n++
+	}
+	if r.offset == len(r.page.data) {
+		err = io.EOF
+	}
+	return n, err
+}
+
+type nullValues struct {
+	remain      int
+	columnIndex int16
+}
+
+func newNullValues(typ Type, columnIndex int16, numValues int) *nullValues {
+	return &nullValues{
+		remain:      numValues,
+		columnIndex: ^columnIndex,
+	}
+}
+
+func (r *nullValues) Close() error {
+	r.remain = 0
+	return nil
+}
+
+func (r *nullValues) ReadValues(values []Value) (int, error) {
+	if len(values) > r.remain {
+		values = values[:r.remain]
+	}
+	for i := range values {
+		values[i] = Value{columnIndex: r.columnIndex}
+	}
+	r.remain -= len(values)
+	if r.remain == 0 {
+		return 0, io.EOF
+	}
+	return len(values), nil
+}
+
+type errorValues struct{ err error }
+
+func (r *errorValues) Close() error                    { return nil }
+func (r *errorValues) ReadValues([]Value) (int, error) { return 0, r.err }

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -125,8 +125,11 @@ func writeParquetFileWithBuffer(w io.Writer, rows rows, options ...parquet.Write
 		}
 	}
 
+	reader := buffer.Rows()
+	defer reader.Close()
+
 	writer := parquet.NewWriter(w, options...)
-	numRows, err := parquet.CopyRows(writer, buffer.Rows())
+	numRows, err := parquet.CopyRows(writer, reader)
 	if err != nil {
 		return err
 	}

--- a/reader.go
+++ b/reader.go
@@ -157,6 +157,15 @@ func sizeOf(r io.ReaderAt) (int64, error) {
 	}
 }
 
+// Close closes the reader.
+func (r *Reader) Close() error {
+	r.file.Close()
+	r.read.Close()
+	r.rowIndex = 0
+	clearValues(r.values)
+	return nil
+}
+
 // Reset repositions the reader at the beginning of the underlying parquet file.
 func (r *Reader) Reset() {
 	r.file.Reset()
@@ -258,7 +267,19 @@ func (r *reader) init(schema *Schema, rowGroup RowGroup) {
 	r.Reset()
 }
 
+func (r *reader) Close() (err error) {
+	if r.rows != nil {
+		err = r.rows.Close()
+	}
+	r.rows = nil
+	r.rowIndex = 0
+	return err
+}
+
 func (r *reader) Reset() {
+	if r.rows != nil {
+		r.rows.Close()
+	}
 	r.rows = nil // TODO: can we make the RowReader reusable?
 	r.rowIndex = 0
 }

--- a/row_group.go
+++ b/row_group.go
@@ -346,7 +346,8 @@ func (r *rowGroupRows) WriteRowsTo(w RowWriter) (int64, error) {
 
 	case PageWriter:
 		for _, column := range rowGroup.ColumnChunks() {
-			if err := copyPages(dst, column.Pages()); err != nil {
+			_, err := copyPages(dst, column.Pages())
+			if err != nil {
 				return 0, err
 			}
 		}
@@ -369,12 +370,6 @@ func (r *rowGroupRows) writeRowsTo(w pageAndValueWriter, limit int64) (numRows i
 		}
 	}
 	return numRows, nil
-}
-
-func copyPages(w PageWriter, p Pages) error {
-	defer p.Close()
-	_, err := CopyPages(w, p)
-	return err
 }
 
 type seekRowGroup struct {

--- a/row_group.go
+++ b/row_group.go
@@ -55,6 +55,7 @@ type RowGroup interface {
 type Rows interface {
 	RowReaderWithSchema
 	RowSeeker
+	io.Closer
 }
 
 // RowGroupReader is an interface implemented by types that expose sequences of
@@ -237,20 +238,20 @@ func (r *rowGroup) NumRows() int64                  { return r.numRows }
 func (r *rowGroup) ColumnChunks() []ColumnChunk     { return r.columns }
 func (r *rowGroup) SortingColumns() []SortingColumn { return r.sorting }
 func (r *rowGroup) Schema() *Schema                 { return r.schema }
-func (r *rowGroup) Rows() Rows                      { return &rowGroupRowReader{rowGroup: r} }
+func (r *rowGroup) Rows() Rows                      { return &rowGroupRows{rowGroup: r} }
 
 func NewRowGroupRowReader(rowGroup RowGroup) Rows {
-	return &rowGroupRowReader{rowGroup: rowGroup}
+	return &rowGroupRows{rowGroup: rowGroup}
 }
 
-type rowGroupRowReader struct {
+type rowGroupRows struct {
 	rowGroup RowGroup
 	schema   *Schema
 	columns  []columnChunkReader
 	seek     int64
 }
 
-func (r *rowGroupRowReader) init(rowGroup RowGroup) error {
+func (r *rowGroupRows) init(rowGroup RowGroup) error {
 	const columnBufferSize = defaultValueBufferSize
 	columns := rowGroup.ColumnChunks()
 	buffer := make([]Value, columnBufferSize*len(columns))
@@ -270,7 +271,14 @@ func (r *rowGroupRowReader) init(rowGroup RowGroup) error {
 	return nil
 }
 
-func (r *rowGroupRowReader) Schema() *Schema {
+func (r *rowGroupRows) Close() error {
+	for i := range r.columns {
+		r.columns[i].close()
+	}
+	return nil
+}
+
+func (r *rowGroupRows) Schema() *Schema {
 	switch {
 	case r.schema != nil:
 		return r.schema
@@ -281,7 +289,7 @@ func (r *rowGroupRowReader) Schema() *Schema {
 	}
 }
 
-func (r *rowGroupRowReader) SeekToRow(rowIndex int64) error {
+func (r *rowGroupRows) SeekToRow(rowIndex int64) error {
 	for i := range r.columns {
 		if err := r.columns[i].seekToRow(rowIndex); err != nil {
 			return err
@@ -291,7 +299,7 @@ func (r *rowGroupRowReader) SeekToRow(rowIndex int64) error {
 	return nil
 }
 
-func (r *rowGroupRowReader) ReadRow(row Row) (Row, error) {
+func (r *rowGroupRows) ReadRow(row Row) (Row, error) {
 	if r.rowGroup != nil {
 		err := r.init(r.rowGroup)
 		r.rowGroup = nil
@@ -310,7 +318,7 @@ func (r *rowGroupRowReader) ReadRow(row Row) (Row, error) {
 	return row, err
 }
 
-func (r *rowGroupRowReader) WriteRowsTo(w RowWriter) (int64, error) {
+func (r *rowGroupRows) WriteRowsTo(w RowWriter) (int64, error) {
 	if r.rowGroup == nil {
 		return CopyRows(w, struct{ RowReaderWithSchema }{r})
 	}
@@ -338,8 +346,7 @@ func (r *rowGroupRowReader) WriteRowsTo(w RowWriter) (int64, error) {
 
 	case PageWriter:
 		for _, column := range rowGroup.ColumnChunks() {
-			_, err := CopyPages(dst, column.Pages())
-			if err != nil {
+			if err := copyPages(dst, column.Pages()); err != nil {
 				return 0, err
 			}
 		}
@@ -349,7 +356,7 @@ func (r *rowGroupRowReader) WriteRowsTo(w RowWriter) (int64, error) {
 	return CopyRows(w, struct{ RowReaderWithSchema }{r})
 }
 
-func (r *rowGroupRowReader) writeRowsTo(w pageAndValueWriter, limit int64) (numRows int64, err error) {
+func (r *rowGroupRows) writeRowsTo(w pageAndValueWriter, limit int64) (numRows int64, err error) {
 	for i := range r.columns {
 		n, err := r.columns[i].writeRowsTo(w, limit)
 		if err != nil {
@@ -362,6 +369,12 @@ func (r *rowGroupRowReader) writeRowsTo(w pageAndValueWriter, limit int64) (numR
 		}
 	}
 	return numRows, nil
+}
+
+func copyPages(w PageWriter, p Pages) error {
+	defer p.Close()
+	_, err := CopyPages(w, p)
+	return err
 }
 
 type seekRowGroup struct {
@@ -452,7 +465,7 @@ func (g *emptyRowGroup) NumRows() int64                  { return 0 }
 func (g *emptyRowGroup) ColumnChunks() []ColumnChunk     { return g.columns }
 func (g *emptyRowGroup) Schema() *Schema                 { return g.schema }
 func (g *emptyRowGroup) SortingColumns() []SortingColumn { return nil }
-func (g *emptyRowGroup) Rows() Rows                      { return emptyRowReader{g.schema} }
+func (g *emptyRowGroup) Rows() Rows                      { return emptyRows{g.schema} }
 
 type emptyColumnChunk struct {
 	typ    Type
@@ -473,22 +486,24 @@ func (emptyBloomFilter) ReadAt([]byte, int64) (int, error) { return 0, io.EOF }
 func (emptyBloomFilter) Size() int64                       { return 0 }
 func (emptyBloomFilter) Check(Value) (bool, error)         { return false, nil }
 
-type emptyRowReader struct{ schema *Schema }
+type emptyRows struct{ schema *Schema }
 
-func (r emptyRowReader) Schema() *Schema                      { return r.schema }
-func (r emptyRowReader) ReadRow(row Row) (Row, error)         { return row, io.EOF }
-func (r emptyRowReader) SeekToRow(int64) error                { return nil }
-func (r emptyRowReader) WriteRowsTo(RowWriter) (int64, error) { return 0, nil }
+func (r emptyRows) Close() error                         { return nil }
+func (r emptyRows) Schema() *Schema                      { return r.schema }
+func (r emptyRows) ReadRow(row Row) (Row, error)         { return row, io.EOF }
+func (r emptyRows) SeekToRow(int64) error                { return nil }
+func (r emptyRows) WriteRowsTo(RowWriter) (int64, error) { return 0, nil }
 
 type emptyPages struct{}
 
+func (emptyPages) Close() error            { return nil }
 func (emptyPages) ReadPage() (Page, error) { return nil, io.EOF }
 func (emptyPages) SeekToRow(int64) error   { return nil }
 
 var (
-	_ RowReaderWithSchema = (*rowGroupRowReader)(nil)
-	_ RowWriterTo         = (*rowGroupRowReader)(nil)
+	_ RowReaderWithSchema = (*rowGroupRows)(nil)
+	_ RowWriterTo         = (*rowGroupRows)(nil)
 
-	_ RowReaderWithSchema = emptyRowReader{}
-	_ RowWriterTo         = emptyRowReader{}
+	_ RowReaderWithSchema = emptyRows{}
+	_ RowWriterTo         = emptyRows{}
 )

--- a/type_default.go
+++ b/type_default.go
@@ -3,9 +3,6 @@
 package parquet
 
 import (
-	"bytes"
-	"fmt"
-
 	"github.com/segmentio/parquet-go/deprecated"
 	"github.com/segmentio/parquet-go/encoding"
 	"github.com/segmentio/parquet-go/format"
@@ -241,89 +238,6 @@ func (t doubleType) NewColumnReader(columnIndex, bufferSize int) ColumnReader {
 
 func (t doubleType) ReadDictionary(columnIndex, numValues int, decoder encoding.Decoder) (Dictionary, error) {
 	return readDoubleDictionary(t, makeColumnIndex(columnIndex), numValues, decoder)
-}
-
-type byteArrayType struct{ primitiveType }
-
-func (t byteArrayType) String() string { return "BYTE_ARRAY" }
-
-func (t byteArrayType) Kind() Kind { return ByteArray }
-
-func (t byteArrayType) Length() int { return 0 }
-
-func (t byteArrayType) Compare(a, b Value) int {
-	return bytes.Compare(a.ByteArray(), b.ByteArray())
-}
-
-func (t byteArrayType) PhysicalType() *format.Type {
-	return &physicalTypes[ByteArray]
-}
-
-func (t byteArrayType) NewColumnIndexer(sizeLimit int) ColumnIndexer {
-	return newByteArrayColumnIndexer(sizeLimit)
-}
-
-func (t byteArrayType) NewDictionary(columnIndex, bufferSize int) Dictionary {
-	return newByteArrayDictionary(t, makeColumnIndex(columnIndex), bufferSize)
-}
-
-func (t byteArrayType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newByteArrayColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
-}
-
-func (t byteArrayType) NewColumnReader(columnIndex, bufferSize int) ColumnReader {
-	return newByteArrayColumnReader(t, makeColumnIndex(columnIndex), bufferSize)
-}
-
-func (t byteArrayType) ReadDictionary(columnIndex, numValues int, decoder encoding.Decoder) (Dictionary, error) {
-	return readByteArrayDictionary(t, makeColumnIndex(columnIndex), numValues, decoder)
-}
-
-type fixedLenByteArrayType struct {
-	primitiveType
-	length int
-}
-
-func (t *fixedLenByteArrayType) String() string {
-	return fmt.Sprintf("FIXED_LEN_BYTE_ARRAY(%d)", t.length)
-}
-
-func (t *fixedLenByteArrayType) Kind() Kind { return FixedLenByteArray }
-
-func (t *fixedLenByteArrayType) Length() int { return t.length }
-
-func (t *fixedLenByteArrayType) Compare(a, b Value) int {
-	return bytes.Compare(a.ByteArray(), b.ByteArray())
-}
-
-func (t *fixedLenByteArrayType) PhysicalType() *format.Type {
-	return &physicalTypes[FixedLenByteArray]
-}
-
-func (t *fixedLenByteArrayType) NewColumnIndexer(sizeLimit int) ColumnIndexer {
-	return newFixedLenByteArrayColumnIndexer(t.length, sizeLimit)
-}
-
-func (t *fixedLenByteArrayType) NewDictionary(columnIndex, bufferSize int) Dictionary {
-	return newFixedLenByteArrayDictionary(t, makeColumnIndex(columnIndex), bufferSize)
-}
-
-func (t *fixedLenByteArrayType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newFixedLenByteArrayColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
-}
-
-func (t *fixedLenByteArrayType) NewColumnReader(columnIndex, bufferSize int) ColumnReader {
-	return newFixedLenByteArrayColumnReader(t, makeColumnIndex(columnIndex), bufferSize)
-}
-
-func (t *fixedLenByteArrayType) ReadDictionary(columnIndex, numValues int, decoder encoding.Decoder) (Dictionary, error) {
-	return readFixedLenByteArrayDictionary(t, makeColumnIndex(columnIndex), numValues, decoder)
-}
-
-// FixedLenByteArrayType constructs a type for fixed-length values of the given
-// size (in bytes).
-func FixedLenByteArrayType(length int) Type {
-	return &fixedLenByteArrayType{length: length}
 }
 
 func (t *intType) NewColumnIndexer(sizeLimit int) ColumnIndexer {

--- a/value.go
+++ b/value.go
@@ -775,7 +775,3 @@ func clearValues(values []Value) {
 		values[i] = Value{}
 	}
 }
-
-type errorValueReader struct{ err error }
-
-func (r *errorValueReader) ReadValues([]Value) (int, error) { return 0, r.err }

--- a/writer_test.go
+++ b/writer_test.go
@@ -603,6 +603,8 @@ func TestWriterRepeatedUUIDDict(t *testing.T) {
 	}
 
 	rows := f.RowGroups()[0].Rows()
+	defer rows.Close()
+
 	row, err := rows.ReadRow(nil)
 	if err != nil {
 		t.Fatalf("reading row from parquet file: %v", err)


### PR DESCRIPTION
This is still a work in progress but generally ready to get feedback I think.

Benchmarks were showing that reading parquet files was allocating large amounts of memory, so I spent a bit of time optimizing it.

I took the following approaches:
* Make the size of internal buffers configurable when reading files, which helps applications reduce the amount of memory they allocate if needed
* Fix a bug that was causing allocations of read buffers to be multiplied by the size of the type (e.g. 8x for a buffer of int64)
* pool the memory buffer used to read compressed pages into memory

These changes have been effective at reducing the amount of memory allocated by the program:
```
name                 old time/op    new time/op    delta
ReaderReadRow/INT64    16.7ns ± 0%    16.1ns ± 1%   -3.81%  (p=0.000 n=9+9)

name                 old speed      new speed      delta
ReaderReadRow/INT64   538MB/s ± 0%   560MB/s ± 1%   +3.96%  (p=0.000 n=9+9)

name                 old row/s      new row/s      delta
ReaderReadRow/INT64     59.8M ± 0%     62.2M ± 1%   +3.96%  (p=0.000 n=9+9)

name                 old alloc/op   new alloc/op   delta
ReaderReadRow/INT64     12.0B ± 0%      1.0B ± 0%  -91.67%  (p=0.000 n=10+10)

name                 old allocs/op  new allocs/op  delta
ReaderReadRow/INT64      0.00           0.00          ~     (all equal)
```

In order to enable pooling of memory buffers, I would like to modify some exported APIs to give the program a mechanism for controlling the lifecycle of some objects (e.g. page readers) via a call to a `Close` method when the objects are not needed anymore. This is an area where I am still experimenting, I may extend this to more APIs to support better internal memory management.