### PR TITLE
Refactor compression APIs

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -2,10 +2,6 @@ package parquet
 
 import (
 	"fmt"
-	"io"
-	"runtime"
-	"sort"
-	"sync"
 
 	"github.com/segmentio/parquet-go/compress"
 	"github.com/segmentio/parquet-go/compress/brotli"
@@ -56,11 +52,6 @@ var (
 		format.Zstd:         &Zstd,
 		format.Lz4Raw:       &Lz4Raw,
 	}
-
-	// Pools of compressed page readers used to retain compression codecs across
-	// page reads to reduce the compute and memory footprint of creating new
-	// decompressors for every new page read in a parquet file.
-	compressedPageReaders = [len(compressionCodecs)]sync.Pool{}
 )
 
 // LookupCompressionCodec returns the compression codec associated with the
@@ -77,45 +68,9 @@ func LookupCompressionCodec(codec format.CompressionCodec) compress.Codec {
 	return &unsupported{codec}
 }
 
-func acquireCompressedPageReader(codec format.CompressionCodec, page io.Reader) *compressedPageReader {
-	r, _ := compressedPageReaders[codec].Get().(*compressedPageReader)
-	if r == nil {
-		r = &compressedPageReader{codec: codec}
-		r.reader, r.err = LookupCompressionCodec(codec).NewReader(page)
-		runtime.SetFinalizer(r, func(r *compressedPageReader) { r.Close() })
-	} else {
-		r.Reset(page)
-	}
-	return r
+type unsupported struct {
+	codec format.CompressionCodec
 }
-
-func releaseCompressedPageReader(r *compressedPageReader) {
-	r.Reset(nil)
-	compressedPageReaders[r.codec].Put(r)
-}
-
-type compressedPageReader struct {
-	codec  format.CompressionCodec
-	reader compress.Reader
-	err    error
-}
-
-func (r *compressedPageReader) Close() error {
-	return r.reader.Close()
-}
-
-func (r *compressedPageReader) Read(b []byte) (int, error) {
-	if r.err != nil {
-		return 0, r.err
-	}
-	return r.reader.Read(b)
-}
-
-func (r *compressedPageReader) Reset(page io.Reader) {
-	r.err = r.reader.Reset(page)
-}
-
-type unsupported struct{ codec format.CompressionCodec }
 
 func (u *unsupported) String() string {
 	return "UNSUPPORTED"
@@ -125,56 +80,14 @@ func (u *unsupported) CompressionCodec() format.CompressionCodec {
 	return u.codec
 }
 
-func (u *unsupported) NewReader(r io.Reader) (compress.Reader, error) {
-	return unsupportedReader{u}, nil
+func (u *unsupported) Encode(dst, src []byte) ([]byte, error) {
+	return dst[:0], u.error()
 }
 
-func (u *unsupported) NewWriter(w io.Writer) (compress.Writer, error) {
-	return unsupportedWriter{u}, nil
+func (u *unsupported) Decode(dst, src []byte) ([]byte, error) {
+	return dst[:0], u.error()
 }
 
 func (u *unsupported) error() error {
 	return fmt.Errorf("unsupported compression codec: %s", u.codec)
-}
-
-type unsupportedReader struct{ *unsupported }
-
-func (r unsupportedReader) Close() error               { return nil }
-func (r unsupportedReader) Reset(io.Reader) error      { return nil }
-func (r unsupportedReader) Read(b []byte) (int, error) { return 0, r.error() }
-
-type unsupportedWriter struct{ *unsupported }
-
-func (w unsupportedWriter) Close() error                { return nil }
-func (w unsupportedWriter) Flush() error                { return nil }
-func (w unsupportedWriter) Reset(io.Writer) error       { return nil }
-func (w unsupportedWriter) Write(b []byte) (int, error) { return 0, w.error() }
-
-func sortCodecs(codecs []compress.Codec) {
-	if len(codecs) > 1 {
-		sort.Slice(codecs, func(i, j int) bool {
-			return codecs[i].CompressionCodec() < codecs[j].CompressionCodec()
-		})
-	}
-}
-
-func dedupeSortedCodecs(codecs []compress.Codec) []compress.Codec {
-	if len(codecs) > 1 {
-		i := 0
-
-		for _, c := range codecs[1:] {
-			if c.CompressionCodec() != codecs[i].CompressionCodec() {
-				i++
-				codecs[i] = c
-			}
-		}
-
-		clear := codecs[i+1:]
-		for i := range clear {
-			clear[i] = nil
-		}
-
-		codecs = codecs[:i+1]
-	}
-	return codecs
 }

--- a/compress.go
+++ b/compress.go
@@ -34,8 +34,7 @@ var (
 
 	// Zstd is the ZSTD parquet compression codec.
 	Zstd = zstd.Codec{
-		Level:       zstd.DefaultLevel,
-		Concurrency: zstd.DefaultConcurrency,
+		Level: zstd.DefaultLevel,
 	}
 
 	// Lz4Raw is the LZ4_RAW parquet compression codec.

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -2,9 +2,7 @@ package compress_test
 
 import (
 	"bytes"
-	"io"
 	"testing"
-	"testing/iotest"
 
 	"github.com/segmentio/parquet-go/compress"
 	"github.com/segmentio/parquet-go/compress/brotli"
@@ -51,53 +49,30 @@ func TestCompressionCodec(t *testing.T) {
 		},
 	}
 
-	buffer := new(bytes.Buffer)
-	output := new(bytes.Buffer)
 	random := bytes.Repeat([]byte("1234567890qwertyuiopasdfghjklzxcvbnm"), 1000)
+	buffer := make([]byte, 0, len(random))
+	output := make([]byte, 0, len(random))
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			w, err := test.codec.NewWriter(nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer w.Close()
+			const N = 10
+			// Run the test multiple times to exercise codecs that maintain
+			// state across compression/decompression.
+			for i := 0; i < N; i++ {
+				var err error
 
-			r, err := test.codec.NewReader(nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer r.Close()
-
-			for i := 0; i < 10; i++ {
-				buffer.Reset()
-				output.Reset()
-
-				if err := w.Reset(buffer); err != nil {
-					t.Fatal(err)
-				}
-				if _, err := io.Copy(w, iotest.OneByteReader(bytes.NewReader(random))); err != nil {
-					t.Fatal(err)
-				}
-				if err := w.Close(); err != nil {
+				buffer, err = test.codec.Encode(buffer[:0], random)
+				if err != nil {
 					t.Fatal(err)
 				}
 
-				if err := r.Reset(buffer); err != nil {
+				output, err = test.codec.Decode(output[:0], buffer)
+				if err != nil {
 					t.Fatal(err)
-				}
-				if _, err := io.Copy(output, iotest.OneByteReader(r)); err != nil {
-					t.Fatal(err)
-				}
-				if !bytes.Equal(random, output.Bytes()) {
-					t.Errorf("content mismatch after compressing and decompressing:\n%q\n%q", random, output.Bytes())
 				}
 
-				if err := w.Reset(nil); err != nil {
-					t.Fatal(err)
-				}
-				if err := r.Reset(nil); err != nil {
-					t.Fatal(err)
+				if !bytes.Equal(random, output) {
+					t.Errorf("content mismatch after compressing and decompressing (attempt %d/%d)", i+1, N)
 				}
 			}
 		})

--- a/compress/lz4/lz4.go
+++ b/compress/lz4/lz4.go
@@ -52,6 +52,9 @@ func (c *Codec) Encode(dst, src []byte) ([]byte, error) {
 }
 
 func (c *Codec) Decode(dst, src []byte) ([]byte, error) {
+	// 3x seems like a common compression ratio, so we optimistically size the
+	// output buffer to that size. Feel free to change the value if you observe
+	// different behaviors.
 	dst = reserveAtLeast(dst, 3*len(src))
 
 	for {

--- a/compress/lz4/lz4.go
+++ b/compress/lz4/lz4.go
@@ -2,11 +2,7 @@
 package lz4
 
 import (
-	"bytes"
-	"io"
-
 	"github.com/pierrec/lz4/v4"
-	"github.com/segmentio/parquet-go/compress"
 	"github.com/segmentio/parquet-go/format"
 )
 
@@ -41,68 +37,25 @@ func (c *Codec) CompressionCodec() format.CompressionCodec {
 	return format.Lz4Raw
 }
 
-func (c *Codec) NewReader(r io.Reader) (compress.Reader, error) {
-	return &reader{reader: r}, nil
-}
+func (c *Codec) Encode(dst, src []byte) ([]byte, error) {
+	dst = reserveAtLeast(dst, len(src)/4)
 
-func (c *Codec) NewWriter(w io.Writer) (compress.Writer, error) {
-	return &writer{writer: w, compressor: lz4.CompressorHC{Level: c.Level}}, nil
-}
-
-type reader struct {
-	buffer bytes.Buffer
-	data   []byte
-	offset int
-	reader io.Reader
-}
-
-func (r *reader) Close() error {
-	r.offset = len(r.data)
-	r.reader = nil
-	return nil
-}
-
-func (r *reader) Reset(rr io.Reader) error {
-	r.buffer.Reset()
-	r.data = r.data[:0]
-	r.offset = 0
-	r.reader = rr
-	return nil
-}
-
-func (r *reader) Read(b []byte) (n int, err error) {
-	if r.offset == 0 && len(r.data) == 0 {
-		if err := r.decompress(); err != nil {
-			return 0, err
+	compressor := lz4.CompressorHC{Level: c.Level}
+	for {
+		n, err := compressor.CompressBlock(src, dst)
+		if err != nil { // see Decode for details about error handling
+			dst = make([]byte, 2*len(dst))
+		} else {
+			return dst[:n], nil
 		}
 	}
-	n = copy(b, r.data[r.offset:])
-	r.offset += n
-	if r.offset == len(r.data) {
-		err = io.EOF
-	}
-	return n, err
 }
 
-func (r *reader) decompress() error {
-	if r.reader == nil {
-		return io.EOF
-	}
-
-	_, err := r.buffer.ReadFrom(r.reader)
-	if err != nil {
-		return err
-	}
-
-	optimisticOutputSize := 3 * r.buffer.Len()
-	if cap(r.data) < optimisticOutputSize {
-		r.data = make([]byte, optimisticOutputSize)
-	} else {
-		r.data = r.data[:cap(r.data)]
-	}
+func (c *Codec) Decode(dst, src []byte) ([]byte, error) {
+	dst = reserveAtLeast(dst, 3*len(src))
 
 	for {
-		n, err := lz4.UncompressBlock(r.buffer.Bytes(), r.data)
+		n, err := lz4.UncompressBlock(src, dst)
 		// The lz4 package does not expose the error values, they are declared
 		// in internal/lz4errors. Based on what I read of the implementation,
 		// the only condition where this function errors is if the output buffer
@@ -110,46 +63,18 @@ func (r *reader) decompress() error {
 		//
 		// https://github.com/pierrec/lz4/blob/a5532e5996ee86d17f8ce2694c08fb5bf3c6b471/internal/lz4block/block.go#L45-L53
 		if err != nil {
-			r.data = make([]byte, 2*len(r.data))
+			dst = make([]byte, 2*len(dst))
 		} else {
-			r.data = r.data[:n]
-			return nil
+			return dst[:n], nil
 		}
 	}
 }
 
-type writer struct {
-	buffer     bytes.Buffer
-	data       []byte
-	writer     io.Writer
-	compressor lz4.CompressorHC
-}
-
-func (w *writer) Reset(ww io.Writer) error {
-	w.buffer.Reset()
-	w.data = w.data[:0]
-	w.writer = ww
-	return nil
-}
-
-func (w *writer) Write(b []byte) (int, error) {
-	if w.writer == nil {
-		return 0, io.ErrClosedPipe
+func reserveAtLeast(b []byte, n int) []byte {
+	if cap(b) < n {
+		b = make([]byte, n)
+	} else {
+		b = b[:cap(b)]
 	}
-	return w.buffer.Write(b)
-}
-
-func (w *writer) Close() (err error) {
-	if w.writer != nil && w.buffer.Len() > 0 {
-		limit := lz4.CompressBlockBound(w.buffer.Len())
-		if limit > cap(w.data) {
-			w.data = make([]byte, limit)
-		} else {
-			w.data = w.data[:limit]
-		}
-		size, _ := w.compressor.CompressBlock(w.buffer.Bytes(), w.data)
-		_, err = w.writer.Write(w.data[:size])
-	}
-	w.writer = nil
-	return err
+	return b
 }

--- a/compress/snappy/snappy.go
+++ b/compress/snappy/snappy.go
@@ -2,11 +2,7 @@
 package snappy
 
 import (
-	"bytes"
-	"io"
-
 	"github.com/klauspost/compress/snappy"
-	"github.com/segmentio/parquet-go/compress"
 	"github.com/segmentio/parquet-go/format"
 )
 
@@ -26,89 +22,10 @@ func (c *Codec) CompressionCodec() format.CompressionCodec {
 	return format.Snappy
 }
 
-func (c *Codec) NewReader(r io.Reader) (compress.Reader, error) {
-	return &reader{input: r, offset: -1}, nil
+func (c *Codec) Encode(dst, src []byte) ([]byte, error) {
+	return snappy.Encode(dst, src), nil
 }
 
-func (c *Codec) NewWriter(w io.Writer) (compress.Writer, error) {
-	return &writer{output: w}, nil
-}
-
-type reader struct {
-	input  io.Reader
-	buffer bytes.Buffer
-	offset int
-	data   []byte
-}
-
-func (r *reader) Close() error {
-	r.Reset(r.input)
-	return nil
-}
-
-func (r *reader) Reset(rr io.Reader) error {
-	r.input = rr
-	r.buffer.Reset()
-	r.offset = -1
-	r.data = r.data[:0]
-	return nil
-}
-
-func (r *reader) Read(b []byte) (int, error) {
-	if r.offset < 0 {
-		if r.input == nil {
-			return 0, io.EOF
-		}
-
-		_, err := r.buffer.ReadFrom(r.input)
-		if err != nil {
-			return 0, err
-		}
-
-		r.data, err = snappy.Decode(r.data[:0], r.buffer.Bytes())
-		if err != nil {
-			return 0, err
-		}
-
-		r.offset = 0
-	}
-
-	n := copy(b, r.data[r.offset:])
-	r.offset += n
-	if r.offset == len(r.data) {
-		return n, io.EOF
-	}
-	return n, nil
-}
-
-type writer struct {
-	output io.Writer
-	buffer []byte
-	data   []byte
-}
-
-func (w *writer) Close() error {
-	if w.output == nil {
-		w.buffer = w.buffer[:0]
-		return nil
-	}
-	if len(w.buffer) > 0 {
-		w.data = snappy.Encode(w.data[:0], w.buffer)
-		w.buffer = w.buffer[:0]
-	}
-	_, err := w.output.Write(w.data)
-	w.data = w.data[:0]
-	return err
-}
-
-func (w *writer) Reset(ww io.Writer) error {
-	w.output = ww
-	w.buffer = w.buffer[:0]
-	w.data = w.data[:0]
-	return nil
-}
-
-func (w *writer) Write(b []byte) (int, error) {
-	w.buffer = append(w.buffer, b...)
-	return len(b), nil
+func (c *Codec) Decode(dst, src []byte) ([]byte, error) {
+	return snappy.Decode(dst, src)
 }

--- a/compress/uncompressed/uncompressed.go
+++ b/compress/uncompressed/uncompressed.go
@@ -19,9 +19,9 @@ func (c *Codec) CompressionCodec() format.CompressionCodec {
 }
 
 func (c *Codec) Encode(dst, src []byte) ([]byte, error) {
-	return append(dst, src...), nil
+	return append(dst[:0], src...), nil
 }
 
 func (c *Codec) Decode(dst, src []byte) ([]byte, error) {
-	return append(dst, src...), nil
+	return append(dst[:0], src...), nil
 }

--- a/compress/uncompressed/uncompressed.go
+++ b/compress/uncompressed/uncompressed.go
@@ -4,9 +4,6 @@
 package uncompressed
 
 import (
-	"io"
-
-	"github.com/segmentio/parquet-go/compress"
 	"github.com/segmentio/parquet-go/format"
 )
 
@@ -21,20 +18,10 @@ func (c *Codec) CompressionCodec() format.CompressionCodec {
 	return format.Uncompressed
 }
 
-func (c *Codec) NewReader(r io.Reader) (compress.Reader, error) {
-	return &reader{r}, nil
+func (c *Codec) Encode(dst, src []byte) ([]byte, error) {
+	return append(dst, src...), nil
 }
 
-func (c *Codec) NewWriter(w io.Writer) (compress.Writer, error) {
-	return &writer{w}, nil
+func (c *Codec) Decode(dst, src []byte) ([]byte, error) {
+	return append(dst, src...), nil
 }
-
-type reader struct{ io.Reader }
-
-func (r *reader) Close() error             { return nil }
-func (r *reader) Reset(rr io.Reader) error { r.Reader = rr; return nil }
-
-type writer struct{ io.Writer }
-
-func (w *writer) Close() error             { return nil }
-func (w *writer) Reset(ww io.Writer) error { w.Writer = ww; return nil }

--- a/page.go
+++ b/page.go
@@ -56,9 +56,6 @@ type Page interface {
 
 	// Buffer returns the page as a BufferedPage, which may be the page itself
 	// if it was already buffered.
-	//
-	// Compressed pages will be consumed to create the returned buffered page,
-	// their content will no be readable anymore after the call.
 	Buffer() BufferedPage
 }
 

--- a/page_header.go
+++ b/page_header.go
@@ -23,10 +23,6 @@ type PageHeader interface {
 type DataPageHeader interface {
 	PageHeader
 
-	// Returns whether the page is compressed, according to the codec given as
-	// argument and details stored in the page header.
-	IsCompressed(format.CompressionCodec) bool
-
 	// Returns the encoding of the repetition level section.
 	RepetitionLevelEncoding() format.Encoding
 
@@ -96,10 +92,6 @@ func (v1 DataPageHeaderV1) NumValues() int64 {
 	return int64(v1.header.NumValues)
 }
 
-func (v1 DataPageHeaderV1) IsCompressed(codec format.CompressionCodec) bool {
-	return codec != format.Uncompressed
-}
-
 func (v1 DataPageHeaderV1) RepetitionLevelEncoding() format.Encoding {
 	return v1.header.RepetitionLevelEncoding
 }
@@ -150,10 +142,6 @@ func (v2 DataPageHeaderV2) NumNulls() int64 {
 
 func (v2 DataPageHeaderV2) NumRows() int64 {
 	return int64(v2.header.NumRows)
-}
-
-func (v2 DataPageHeaderV2) IsCompressed(codec format.CompressionCodec) bool {
-	return codec != format.Uncompressed && (v2.header.IsCompressed == nil || *v2.header.IsCompressed)
 }
 
 func (v2 DataPageHeaderV2) RepetitionLevelsByteLength() int64 {

--- a/reader.go
+++ b/reader.go
@@ -179,7 +179,7 @@ func (r *Reader) Read(row interface{}) (err error) {
 	}
 
 	if err := r.read.SeekToRow(r.rowIndex); err != nil {
-		return err
+		return fmt.Errorf("seeking reader to row %d: %w", r.rowIndex, err)
 	}
 
 	r.values, err = r.read.ReadRow(r.values[:0])

--- a/reader_test.go
+++ b/reader_test.go
@@ -65,14 +65,14 @@ type decimalColumn struct {
 }
 
 type addressBook struct {
-	Owner             utf8string
-	OwnerPhoneNumbers []utf8string
+	Owner             utf8string   `parquet:",plain"`
+	OwnerPhoneNumbers []utf8string `parquet:",plain"`
 	Contacts          []contact
 }
 
 type contact struct {
-	Name        utf8string
-	PhoneNumber utf8string
+	Name        utf8string `parquet:",plain"`
+	PhoneNumber utf8string `parquet:",plain"`
 }
 
 type listColumn2 struct {

--- a/writer.go
+++ b/writer.go
@@ -1026,10 +1026,14 @@ func (c *writerColumn) writeBufferedPage(page BufferedPage) (int64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("compressing parquet data page: %w", err)
 		}
-		// TODO: can we optimize this copy away?
-		buffer.Truncate(offset)
-		buffer.Write(b)
-		pageData = buffer.Bytes()
+		if offset == 0 {
+			pageData = b
+		} else {
+			// TODO: can this copy be optimized away?
+			buffer.Truncate(offset)
+			buffer.Write(b)
+			pageData = buffer.Bytes()
+		}
 	}
 
 	pageHeader := &format.PageHeader{

--- a/writer.go
+++ b/writer.go
@@ -202,8 +202,10 @@ type writer struct {
 	metadata  []format.KeyValue
 
 	buffers struct {
-		header bytes.Buffer
-		page   bytes.Buffer
+		compressed []byte
+		header     bytes.Buffer
+		page       bytes.Buffer
+		reader     bytes.Reader
 	}
 
 	columns       []*writerColumn
@@ -325,7 +327,10 @@ func newWriter(output io.Writer, config *WriterConfig) *writer {
 		// content, they are shared by all column chunks because they are only
 		// used during calls to writeDictionaryPage or writeDataPage, which are
 		// not done concurrently.
-		c.header.buffer, c.page.buffer = &w.buffers.header, &w.buffers.page
+		c.page.compressed = &w.buffers.compressed
+		c.page.buffer = &w.buffers.page
+		c.page.reader = &w.buffers.reader
+		c.header.buffer = &w.buffers.header
 		c.header.encoder.Reset(c.header.protocol.NewWriter(c.header.buffer))
 
 		if leaf.maxRepetitionLevel > 0 {
@@ -683,15 +688,6 @@ type writerColumn struct {
 
 	levels struct {
 		encoder encoding.Encoder
-		// In data pages v1, the repetition and definition levels are prefixed
-		// with the 4 bytes length of the sections. While the parquet-format
-		// documentation indicates that the length prefix is part of the hybrid
-		// RLE/Bit-Pack encoding, this is the only condition where it is used
-		// so we treat it as a special case rather than implementing it in the
-		// encoding.
-		//
-		// Reference https://github.com/apache/parquet-format/blob/master/Encodings.md#run-length-encoding--bit-packing-hybrid-rle--3
-		v1 lengthPrefixedWriter
 	}
 
 	header struct {
@@ -701,12 +697,12 @@ type writerColumn struct {
 	}
 
 	page struct {
-		buffer       *bytes.Buffer
-		filter       *bloomFilterEncoder
-		compressed   compress.Writer
-		uncompressed offsetTrackingWriter
-		encoding     format.Encoding
-		encoder      encoding.Encoder
+		compressed *[]byte
+		reader     *bytes.Reader
+		buffer     *bytes.Buffer
+		filter     *bloomFilterEncoder
+		encoding   format.Encoding
+		encoder    encoding.Encoder
 	}
 
 	dict struct {
@@ -959,50 +955,51 @@ func (c *writerColumn) writeBufferedPage(page BufferedPage) (int64, error) {
 	}
 
 	c.page.buffer.Reset()
-	repetitionLevelsByteLength := int32(0)
-	definitionLevelsByteLength := int32(0)
+	repetitionLevelsByteLength := 0
+	definitionLevelsByteLength := 0
 
-	if c.dataPageType == format.DataPageV2 {
+	switch c.dataPageType {
+	case format.DataPageV2:
 		if c.maxRepetitionLevel > 0 {
-			c.page.uncompressed.Reset(c.page.buffer)
-			c.levels.encoder.Reset(&c.page.uncompressed)
+			c.levels.encoder.Reset(c.page.buffer)
 			c.levels.encoder.SetBitWidth(bits.Len8(c.maxRepetitionLevel))
 			c.levels.encoder.EncodeInt8(page.RepetitionLevels())
-			repetitionLevelsByteLength = int32(c.page.uncompressed.offset)
+			repetitionLevelsByteLength = c.page.buffer.Len()
 		}
 		if c.maxDefinitionLevel > 0 {
-			c.page.uncompressed.Reset(c.page.buffer)
-			c.levels.encoder.Reset(&c.page.uncompressed)
+			c.levels.encoder.Reset(c.page.buffer)
 			c.levels.encoder.SetBitWidth(bits.Len8(c.maxDefinitionLevel))
 			c.levels.encoder.EncodeInt8(page.DefinitionLevels())
-			definitionLevelsByteLength = int32(c.page.uncompressed.offset)
+			definitionLevelsByteLength = c.page.buffer.Len() - repetitionLevelsByteLength
 		}
-	}
 
-	if !c.isCompressed {
-		c.page.uncompressed.Reset(c.page.buffer)
-	} else {
-		p, err := c.compressedPage(c.page.buffer)
-		if err != nil {
-			return 0, err
-		}
-		c.page.uncompressed.Reset(p)
-	}
-
-	if c.dataPageType == format.DataPage {
+	case format.DataPage:
+		// In data pages v1, the repetition and definition levels are prefixed
+		// with the 4 bytes length of the sections. While the parquet-format
+		// documentation indicates that the length prefix is part of the hybrid
+		// RLE/Bit-Pack encoding, this is the only condition where it is used
+		// so we treat it as a special case rather than implementing it in the
+		// encoding.
+		//
+		// Reference https://github.com/apache/parquet-format/blob/master/Encodings.md#run-length-encoding--bit-packing-hybrid-rle--3
+		lengthPlaceholder := make([]byte, 4)
 		if c.maxRepetitionLevel > 0 {
-			c.levels.v1.Reset(&c.page.uncompressed)
-			c.levels.encoder.Reset(&c.levels.v1)
+			buffer := c.page.buffer
+			buffer.Write(lengthPlaceholder)
+			offset := buffer.Len()
+			c.levels.encoder.Reset(buffer)
 			c.levels.encoder.SetBitWidth(bits.Len8(c.maxRepetitionLevel))
 			c.levels.encoder.EncodeInt8(page.RepetitionLevels())
-			c.levels.v1.Close()
+			binary.LittleEndian.PutUint32(buffer.Bytes()[offset-4:], uint32(buffer.Len()-offset))
 		}
 		if c.maxDefinitionLevel > 0 {
-			c.levels.v1.Reset(&c.page.uncompressed)
-			c.levels.encoder.Reset(&c.levels.v1)
+			buffer := c.page.buffer
+			buffer.Write(lengthPlaceholder)
+			offset := buffer.Len()
+			c.levels.encoder.Reset(buffer)
 			c.levels.encoder.SetBitWidth(bits.Len8(c.maxDefinitionLevel))
 			c.levels.encoder.EncodeInt8(page.DefinitionLevels())
-			c.levels.v1.Close()
+			binary.LittleEndian.PutUint32(buffer.Bytes()[offset-4:], uint32(buffer.Len()-offset))
 		}
 	}
 
@@ -1020,26 +1017,32 @@ func (c *writerColumn) writeBufferedPage(page BufferedPage) (int64, error) {
 		statistics = c.makePageStatistics(page)
 	}
 
-	c.page.encoder.Reset(&c.page.uncompressed)
+	c.page.encoder.Reset(c.page.buffer)
 	if err := page.WriteTo(c.page.encoder); err != nil {
 		return 0, err
 	}
-	if c.page.compressed != nil {
-		if err := c.page.compressed.Close(); err != nil {
-			return 0, err
+
+	uncompressedPageSize := c.page.buffer.Len()
+	pageData := c.page.buffer.Bytes()
+	if c.isCompressed {
+		offset := repetitionLevelsByteLength + definitionLevelsByteLength
+		b, err := c.compress(pageData[offset:])
+		if err != nil {
+			return 0, fmt.Errorf("compressing parquet data page: %w", err)
 		}
+		// TODO: can we optimize this copy away?
+		c.page.buffer.Truncate(offset)
+		c.page.buffer.Write(b)
+		pageData = c.page.buffer.Bytes()
 	}
 
 	c.header.buffer.Reset()
-	levelsByteLength := repetitionLevelsByteLength + definitionLevelsByteLength
-	uncompressedPageSize := c.page.uncompressed.offset + int64(levelsByteLength)
-	compressedPageSize := c.page.buffer.Len()
 
 	pageHeader := &format.PageHeader{
 		Type:                 c.dataPageType,
 		UncompressedPageSize: int32(uncompressedPageSize),
-		CompressedPageSize:   int32(compressedPageSize),
-		CRC:                  int32(crc32.ChecksumIEEE(c.page.buffer.Bytes())),
+		CompressedPageSize:   int32(len(pageData)),
+		CRC:                  int32(crc32.ChecksumIEEE(pageData)),
 	}
 
 	numRows := page.NumRows()
@@ -1059,8 +1062,8 @@ func (c *writerColumn) writeBufferedPage(page BufferedPage) (int64, error) {
 			NumNulls:                   int32(numNulls),
 			NumRows:                    int32(numRows),
 			Encoding:                   c.page.encoding,
-			DefinitionLevelsByteLength: definitionLevelsByteLength,
-			RepetitionLevelsByteLength: repetitionLevelsByteLength,
+			DefinitionLevelsByteLength: int32(definitionLevelsByteLength),
+			RepetitionLevelsByteLength: int32(repetitionLevelsByteLength),
 			IsCompressed:               &c.isCompressed,
 			Statistics:                 statistics,
 		}
@@ -1070,8 +1073,9 @@ func (c *writerColumn) writeBufferedPage(page BufferedPage) (int64, error) {
 		return 0, err
 	}
 	headerSize := int32(c.header.buffer.Len())
-	compressedSize := int64(headerSize) + int64(compressedPageSize)
-	if err := c.writePage(compressedSize, c.header.buffer, c.page.buffer); err != nil {
+	compressedSize := int64(headerSize) + int64(len(pageData))
+	c.page.reader.Reset(pageData)
+	if err := c.writePage(compressedSize, c.header.buffer, c.page.reader); err != nil {
 		return 0, err
 	}
 	c.recordPageStats(headerSize, pageHeader, page)
@@ -1154,27 +1158,22 @@ func (c *writerColumn) writePage(size int64, header, data io.Reader) error {
 
 func (c *writerColumn) writeDictionaryPage(output io.Writer, dict Dictionary) error {
 	c.page.buffer.Reset()
-
-	p, err := c.compressedPage(c.page.buffer)
-	if err != nil {
-		return err
-	}
-
-	c.page.uncompressed.Reset(p)
-	c.dict.encoder.Reset(&c.page.uncompressed)
+	c.dict.encoder.Reset(c.page.buffer)
 
 	if err := dict.Page().WriteTo(&c.dict.encoder); err != nil {
 		return fmt.Errorf("writing parquet dictionary page: %w", err)
 	}
-	if err := p.Close(); err != nil {
-		return fmt.Errorf("flushing compressed parquet dictionary page: %w", err)
+
+	pageData, err := c.compress(c.page.buffer.Bytes())
+	if err != nil {
+		return fmt.Errorf("compressing parquet dictionary page: %w", err)
 	}
 
 	pageHeader := &format.PageHeader{
 		Type:                 format.DictionaryPage,
-		UncompressedPageSize: int32(c.page.uncompressed.offset),
-		CompressedPageSize:   int32(c.page.buffer.Len()),
-		CRC:                  int32(crc32.ChecksumIEEE(c.page.buffer.Bytes())),
+		UncompressedPageSize: int32(c.page.buffer.Len()),
+		CompressedPageSize:   int32(len(pageData)),
+		CRC:                  int32(crc32.ChecksumIEEE(pageData)),
 		DictionaryPageHeader: &format.DictionaryPageHeader{
 			NumValues: int32(dict.Len()),
 			Encoding:  format.Plain,
@@ -1189,26 +1188,24 @@ func (c *writerColumn) writeDictionaryPage(output io.Writer, dict Dictionary) er
 	if _, err := output.Write(c.header.buffer.Bytes()); err != nil {
 		return err
 	}
-	if _, err := output.Write(c.page.buffer.Bytes()); err != nil {
+	if _, err := output.Write(pageData); err != nil {
 		return err
 	}
 	c.recordPageStats(int32(c.header.buffer.Len()), pageHeader, nil)
 	return nil
 }
 
-func (c *writerColumn) compressedPage(w io.Writer) (compress.Writer, error) {
-	if c.page.compressed == nil {
-		z, err := c.compression.NewWriter(w)
+func (c *writerColumn) compress(pageData []byte) ([]byte, error) {
+	if c.compression.CompressionCodec() != format.Uncompressed {
+		b := *c.page.compressed
+		b, err := c.compression.Encode(b[:0], pageData)
+		*c.page.compressed = b
 		if err != nil {
-			return nil, fmt.Errorf("creating compressor for parquet column chunk writer: %w", err)
+			return nil, err
 		}
-		c.page.compressed = z
-	} else {
-		if err := c.page.compressed.Reset(w); err != nil {
-			return nil, fmt.Errorf("resetting compressor for parquet column chunk writer: %w", err)
-		}
+		pageData = b
 	}
-	return c.page.compressed, nil
+	return pageData, nil
 }
 
 func (c *writerColumn) makePageStatistics(page Page) format.Statistics {
@@ -1303,31 +1300,6 @@ func sortPageEncodingStats(stats []format.PageEncodingStats) {
 		}
 		return s1.Encoding < s2.Encoding
 	})
-}
-
-type lengthPrefixedWriter struct {
-	writer io.Writer
-	buffer []byte
-}
-
-func (w *lengthPrefixedWriter) Reset(ww io.Writer) {
-	w.writer = ww
-	w.buffer = append(w.buffer[:0], 0, 0, 0, 0)
-}
-
-func (w *lengthPrefixedWriter) Close() error {
-	if len(w.buffer) > 0 {
-		defer func() { w.buffer = w.buffer[:0] }()
-		binary.LittleEndian.PutUint32(w.buffer, uint32(len(w.buffer))-4)
-		_, err := w.writer.Write(w.buffer)
-		return err
-	}
-	return nil
-}
-
-func (w *lengthPrefixedWriter) Write(b []byte) (int, error) {
-	w.buffer = append(w.buffer, b...)
-	return len(b), nil
 }
 
 type offsetTrackingWriter struct {


### PR DESCRIPTION
As I was working on https://github.com/segmentio/parquet-go/pull/161, it became apparent that a lot of the complexity of reading files came from the way the compression APIs were based on reading and writing byte streams, despite pages always being manipulated in memory.

With this PR, I am attempting to reduce this complexity to enable further optimizations by changing the compression models to stateless `Encode`/`Decode` methods instead of the `NewReader`/`NewWriter` we had previously.

While this is a breaking change, I don't expect this to impact users much since the compression codecs are managed internally, programs do not need to use them directly.