### PR TITLE
fix link to apache docs

### DIFF
--- a/parquet.go
+++ b/parquet.go
@@ -4,7 +4,7 @@
 // of Parquet's qualities as a storage format, see this blog post:
 // https://blog.twitter.com/engineering/en_us/a/2013/dremel-made-simple-with-parquet
 //
-// Or see the Parquet documentation: https://parquet.apache.org/documentation/latest/
+// Or see the Parquet documentation: https://parquet.apache.org/docs/
 package parquet
 
 func atLeastOne(size int) int {


### PR DESCRIPTION
The Apache Parquet docs have been relocated at a new address.