### PR TITLE
fix order benchmarks

### DIFF
--- a/internal/bits/order_test.go
+++ b/internal/bits/order_test.go
@@ -380,7 +380,7 @@ func BenchmarkOrderOfBool(b *testing.B) {
 
 func BenchmarkOrderOfInt32(b *testing.B) {
 	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
-		values := make([]int32, bufferSize/1)
+		values := make([]int32, bufferSize/4)
 		for i := 0; i < b.N; i++ {
 			bits.OrderOfInt32(values)
 		}
@@ -389,7 +389,7 @@ func BenchmarkOrderOfInt32(b *testing.B) {
 
 func BenchmarkOrderOfInt64(b *testing.B) {
 	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
-		values := make([]int64, bufferSize/1)
+		values := make([]int64, bufferSize/8)
 		for i := 0; i < b.N; i++ {
 			bits.OrderOfInt64(values)
 		}
@@ -398,7 +398,7 @@ func BenchmarkOrderOfInt64(b *testing.B) {
 
 func BenchmarkOrderOfUint32(b *testing.B) {
 	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
-		values := make([]uint32, bufferSize/1)
+		values := make([]uint32, bufferSize/4)
 		for i := 0; i < b.N; i++ {
 			bits.OrderOfUint32(values)
 		}
@@ -407,7 +407,7 @@ func BenchmarkOrderOfUint32(b *testing.B) {
 
 func BenchmarkOrderOfUint64(b *testing.B) {
 	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
-		values := make([]uint64, bufferSize/1)
+		values := make([]uint64, bufferSize/8)
 		for i := 0; i < b.N; i++ {
 			bits.OrderOfUint64(values)
 		}
@@ -416,7 +416,7 @@ func BenchmarkOrderOfUint64(b *testing.B) {
 
 func BenchmarkOrderOfFloat32(b *testing.B) {
 	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
-		values := make([]float32, bufferSize/1)
+		values := make([]float32, bufferSize/4)
 		for i := 0; i < b.N; i++ {
 			bits.OrderOfFloat32(values)
 		}
@@ -425,7 +425,7 @@ func BenchmarkOrderOfFloat32(b *testing.B) {
 
 func BenchmarkOrderOfFloat64(b *testing.B) {
 	forEachBenchmarkBufferSize(b, func(b *testing.B, bufferSize int) {
-		values := make([]float64, bufferSize/1)
+		values := make([]float64, bufferSize/8)
 		for i := 0; i < b.N; i++ {
 			bits.OrderOfFloat64(values)
 		}


### PR DESCRIPTION
Noticed a few misconfigurations in some of the benchmarks, causing them to run on much larger datasets and misreporting the performance of the algorithms.

Before:
```
cpu: Intel(R) Xeon(R) CPU @ 2.60GHz
BenchmarkOrderOfUint32/4KiB         	 6394976	       179.9 ns/op	22768.79 MB/s
BenchmarkOrderOfUint32/256KiB       	   55310	     21739 ns/op	12058.49 MB/s
BenchmarkOrderOfUint32/2048KiB      	    4725	    245473 ns/op	8543.30 MB/s
```
After:
```
cpu: Intel(R) Xeon(R) CPU @ 2.60GHz
BenchmarkOrderOfUint32/4KiB         	24478969	        45.84 ns/op	89352.60 MB/s
BenchmarkOrderOfUint32/256KiB       	  222945	      5416 ns/op	48403.56 MB/s
BenchmarkOrderOfUint32/2048KiB      	   18451	     66004 ns/op	31773.14 MB/s
```