### PR TITLE
ASIMD optimization for ARM64 CPU

### DIFF
--- a/internal/bits/min_amd64.go
+++ b/internal/bits/min_amd64.go
@@ -1,4 +1,4 @@
-//go:build !purego
+//go:build !purego && amd64
 
 package bits
 

--- a/internal/bits/min_amd64.s
+++ b/internal/bits/min_amd64.s
@@ -1,4 +1,4 @@
-//go:build !purego
+//go:build !purego && !arm64
 
 #include "textflag.h"
 #include "min_amd64.h"

--- a/internal/bits/min_arm64.go
+++ b/internal/bits/min_arm64.go
@@ -1,0 +1,27 @@
+//go:build !purego && arm64
+
+package bits
+
+//go:noescape
+func minBool(data []bool) bool
+
+////go:noescape
+//func minInt32(data []int32) int32
+//
+////go:noescape
+//func minInt64(data []int64) int64
+//
+////go:noescape
+//func minUint32(data []uint32) uint32
+//
+////go:noescape
+//func minUint64(data []uint64) uint64
+//
+////go:noescape
+//func minFloat32(data []float32) float32
+//
+////go:noescape
+//func minFloat64(data []float64) float64
+//
+//// go:noescape
+//func minBE128(data []byte) []byte

--- a/internal/bits/min_arm64.go
+++ b/internal/bits/min_arm64.go
@@ -6,8 +6,8 @@ package bits
 func minBool(data []bool) bool
 
 ////go:noescape
-//func minInt32(data []int32) int32
-//
+func minInt32(data []int32) int32
+
 ////go:noescape
 //func minInt64(data []int64) int64
 //

--- a/internal/bits/min_arm64.s
+++ b/internal/bits/min_arm64.s
@@ -1,0 +1,54 @@
+//go:build !purego && !amd64
+
+#include "textflag.h"
+
+// func minBool(data []bool) bool
+TEXT ·minBool(SB), NOSPLIT, $0-25
+    MOVD data_base+0(FP), R0 // data base
+    MOVD data_len+8(FP), R1 // length of data
+    MOVD $ret+24(FP), R2 // address for result
+
+    MOVD $0x0101010101010101, R4 // mask
+
+    CMP $0, R1
+    BEQ false
+
+    CMP $128, R1
+    BGE loop128
+
+loop:
+    CMP $0, R1
+    BEQ true
+
+    MOVB (R0), R4
+    CMP $0, R4
+    BEQ false
+    
+    ADD $1, R0, R0
+    SUB $1, R1, R1
+
+    B loop
+
+true:
+    MOVD R0, (R2)
+    RET
+
+false:
+    MOVD ZR, (R2)
+    RET
+
+loop128:
+    CMP $128, R1
+    BLT loop
+
+    VLD1 (R0), [V1.D2, V2.D2]
+    VAND V1.B16, V2.B16, V2.B16
+    VMOV V1.D[0], R5
+    VMOV V2.D[0], R6
+    AND R5, R6, R6
+    CMP R4, R6
+    BNE false 
+
+    ADD $128, R0, R0
+    SUB $128, R1, R1
+    B loop128

--- a/internal/bits/min_arm64.s
+++ b/internal/bits/min_arm64.s
@@ -52,3 +52,29 @@ loop128:
     ADD $128, R0, R0
     SUB $128, R1, R1
     B loop128
+
+// func minInt32(data []int32) int32
+TEXT ·minInt32(SB), NOSPLIT, $0-28
+    MOVD data_base+0(FP), R0 // data base
+    MOVD data_len+8(FP), R1 // length of data
+    MOVD $ret+24(FP), R2 // address for result
+
+    MOVD ZR, R3
+    MOVD $0x7FFFFFFF, R4
+    MOVD ZR, R6
+    MOVW$4, R7
+
+loop:
+    MOVW (R6)(R0), R5
+    CMP R5, R4
+    CSEL LT, R4, R5, R4
+
+    ADD $1, R3
+    MUL R7, R3, R6
+
+    CMP R3, R1
+    BNE loop
+
+done:
+    MOVW R4, (R2)
+    RET

--- a/internal/bits/min_default.go
+++ b/internal/bits/min_default.go
@@ -1,4 +1,4 @@
-//go:build !go1.18 && (purego || !amd64)
+//go:build !go1.18 && (purego || !amd64 || !arm64)
 
 package bits
 

--- a/internal/bits/min_go18.go
+++ b/internal/bits/min_go18.go
@@ -10,7 +10,7 @@ import (
 
 //func minBool(data []bool) bool { return boolEqualAll(data, true) }
 
-func minInt32(data []int32) int32 { return min(data) }
+//func minInt32(data []int32) int32 { return min(data) }
 
 func minInt64(data []int64) int64 { return min(data) }
 

--- a/internal/bits/min_go18.go
+++ b/internal/bits/min_go18.go
@@ -1,4 +1,4 @@
-//go:build go1.18 && (purego || !amd64)
+//go:build go1.18 && (purego || !amd64 || !arm64)
 
 package bits
 
@@ -8,7 +8,7 @@ import (
 	"github.com/segmentio/parquet-go/internal/cast"
 )
 
-func minBool(data []bool) bool { return boolEqualAll(data, true) }
+//func minBool(data []bool) bool { return boolEqualAll(data, true) }
 
 func minInt32(data []int32) int32 { return min(data) }
 

--- a/internal/bits/min_test.go
+++ b/internal/bits/min_test.go
@@ -3,6 +3,7 @@ package bits_test
 import (
 	"bytes"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/segmentio/parquet-go/internal/bits"
@@ -40,16 +41,18 @@ func FuzzMinBool(f *testing.F) {
 	f.Fuzz(func(t *testing.T, input []byte, size int) {
 		values := fuzzing.MakeRandBoolean(input, size)
 
-		expected := true
+		var expected bool
 		for i := range values {
 			if !values[i] {
 				expected = false
 				break
 			}
+			expected = true
 		}
 
-		if bits.MinBool(values) != expected {
+		if r := bits.MinBool(values); !reflect.DeepEqual(r, expected) {
 			t.Logf("expected: %t", expected)
+			t.Logf("got: %t", r)
 			t.Logf("values: %v", values)
 			t.Error("unexpected min value")
 		}

--- a/internal/bits/min_test.go
+++ b/internal/bits/min_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/segmentio/parquet-go/internal/bits"
+	"github.com/segmentio/parquet-go/internal/fuzzing"
 )
 
 func TestMinBool(t *testing.T) {
@@ -33,6 +34,26 @@ func TestMinBool(t *testing.T) {
 	if !bits.MinBool(values) {
 		t.Error("min value must be true when all input values are true")
 	}
+}
+
+func FuzzMinBool(f *testing.F) {
+	f.Fuzz(func(t *testing.T, input []byte, size int) {
+		values := fuzzing.MakeRandBoolean(input, size)
+
+		expected := true
+		for i := range values {
+			if !values[i] {
+				expected = false
+				break
+			}
+		}
+
+		if bits.MinBool(values) != expected {
+			t.Logf("expected: %t", expected)
+			t.Logf("values: %v", values)
+			t.Error("unexpected min value")
+		}
+	})
 }
 
 func TestMinInt32(t *testing.T) {

--- a/internal/fuzzing/fuzz.go
+++ b/internal/fuzzing/fuzz.go
@@ -1,0 +1,120 @@
+//go:build go1.18
+// +build go1.18
+
+package fuzzing
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"math/rand"
+
+	"github.com/segmentio/parquet-go/deprecated"
+)
+
+func MakeRandBoolean(data []byte, count int) []bool {
+	if count < 1 {
+		return nil
+	}
+	src := rand.New(newByteSource(data))
+	b := make([]bool, count)
+	for i := 0; i < count; i++ {
+		b[i] = src.Int63()&0x01 == 1
+	}
+	return b
+}
+
+func MakeRandFloat(data []byte, count int) []float32 {
+	if count < 1 {
+		return nil
+	}
+	src := rand.New(newByteSource(data))
+	f := make([]float32, count)
+	for i := 0; i < count; i++ {
+		f[i] = src.Float32()
+	}
+	return f
+}
+
+func MakeRandDouble(data []byte, count int) []float64 {
+	if count < 1 {
+		return nil
+	}
+	src := rand.New(newByteSource(data))
+	f := make([]float64, count)
+	for i := 0; i < count; i++ {
+		f[i] = src.Float64()
+	}
+
+	return f
+}
+
+func MakeRandInt32(data []byte, count int) []int32 {
+	if count < 1 {
+		return nil
+	}
+
+	src := rand.New(newByteSource(data))
+	a := make([]int32, count)
+	for i := 0; i < count; i++ {
+		a[i] = int32(src.Int63())
+	}
+	return a
+}
+
+func MakeRandInt64(data []byte, count int) []int64 {
+	if count < 1 {
+		return nil
+	}
+
+	src := rand.New(newByteSource(data))
+	a := make([]int64, count)
+	for i := 0; i < count; i++ {
+		a[i] = src.Int63()
+	}
+	return a
+}
+
+func MakeRandInt96(data []byte, count int) []deprecated.Int96 {
+	if count < 1 {
+		return nil
+	}
+
+	src := rand.New(newByteSource(data))
+	a := make([]deprecated.Int96, count)
+	for i := 0; i < count; i++ {
+		a[i] = deprecated.Int96{
+			uint32(src.Int63()),
+			uint32(src.Int63()),
+			uint32(src.Int63()),
+		}
+	}
+	return a
+}
+
+// byteSource is used to compose fuzz tests from a byte array.
+// This is to workaround the current stblib limitations.
+type byteSource struct {
+	*bytes.Reader
+}
+
+func newByteSource(data []byte) *byteSource {
+	return &byteSource{
+		Reader: bytes.NewReader(data),
+	}
+}
+
+func (s *byteSource) Uint64() uint64 {
+	var bytes [8]byte
+	if _, err := s.Read(bytes[:]); err != nil && !errors.Is(err, io.EOF) {
+		panic("byteSource: failed to read bytes")
+	}
+	return binary.BigEndian.Uint64(bytes[:])
+}
+
+func (s *byteSource) Int63() int64 {
+	return int64(s.Uint64() >> 1)
+}
+
+func (s *byteSource) Seed(seed int64) {}


### PR DESCRIPTION
Opening this draft PR to show the work in progress to adapt the various SIMD optimization to ASIMD/NEON for ARM64 CPUs.

I will add the different benchmark as we go. But some promising results so far.

```
name                old time/op    new time/op      delta
MinBool/4KiB-10       1.28µs ± 0%      0.02µs ± 0%    -98.64%  (p=0.008 n=5+5)
MinBool/256KiB-10     82.1µs ± 0%       1.2µs ± 1%    -98.49%  (p=0.008 n=5+5)
MinBool/2048KiB-10     652µs ± 0%        11µs ± 6%    -98.38%  (p=0.016 n=4+5)

name                old speed      new speed        delta
MinBool/4KiB-10     3.20GB/s ± 0%  235.31GB/s ± 0%  +7261.29%  (p=0.008 n=5+5)
MinBool/256KiB-10   3.19GB/s ± 0%  212.08GB/s ± 1%  +6539.94%  (p=0.008 n=5+5)
MinBool/2048KiB-10  3.22GB/s ± 0%  198.28GB/s ± 6%  +6064.08%  (p=0.016 n=4+5)
```