### PR TITLE
add deprecated BIT_PACKED encoding

### DIFF
--- a/column.go
+++ b/column.go
@@ -545,7 +545,6 @@ func (c *Column) decodeDataPageV2(header DataPageHeaderV2, page *dataPage) (Page
 	var data = page.data
 	page.repetitionLevels = page.repetitionLevels[:0]
 	page.definitionLevels = page.definitionLevels[:0]
-	//fmt.Printf("PAGE: %q\n", data)
 
 	if c.maxRepetitionLevel > 0 {
 		encoding := lookupLevelEncoding(header.RepetitionLevelEncoding(), c.maxRepetitionLevel)

--- a/encoding/bitpacked/bitpacked.go
+++ b/encoding/bitpacked/bitpacked.go
@@ -1,0 +1,120 @@
+package bitpacked
+
+import (
+	"github.com/segmentio/parquet-go/encoding"
+	"github.com/segmentio/parquet-go/format"
+	"github.com/segmentio/parquet-go/internal/bits"
+)
+
+type Encoding struct {
+	encoding.NotSupported
+	BitWidth int
+}
+
+func (e *Encoding) String() string {
+	return "BIT_PACKED"
+}
+
+func (e *Encoding) Encoding() format.Encoding {
+	return format.BitPacked
+}
+
+func (e *Encoding) EncodeLevels(dst, src []byte) ([]byte, error) {
+	dst, err := encodeLevels(dst[:0], src, uint(e.BitWidth))
+	return dst, e.wrap(err)
+}
+
+func (e *Encoding) DecodeLevels(dst, src []byte) ([]byte, error) {
+	dst, err := decodeLevels(dst[:0], src, uint(e.BitWidth))
+	return dst, e.wrap(err)
+}
+
+func (e *Encoding) wrap(err error) error {
+	if err != nil {
+		err = encoding.Error(e, err)
+	}
+	return err
+}
+
+func encodeLevels(dst, src []byte, bitWidth uint) ([]byte, error) {
+	if bitWidth == 0 || len(src) == 0 {
+		return append(dst[:0], 0), nil
+	}
+
+	n := bits.ByteCount(bitWidth) * len(src)
+	c := n + 1
+
+	if cap(dst) < c {
+		dst = make([]byte, c)
+	} else {
+		dst = dst[:c]
+		for i := range dst {
+			dst[i] = 0
+		}
+	}
+
+	bitMask := byte(1<<bitWidth) - 1
+	bitShift := 8 - bitWidth
+	bitOffset := uint(0)
+
+	for _, value := range src {
+		v := bitFlip(value) >> bitShift
+		i := bitOffset / 8
+		j := bitOffset % 8
+		dst[i+0] |= (v & bitMask) << j
+		dst[i+1] |= (v >> (8 - j))
+		bitOffset += bitWidth
+	}
+
+	return dst[:n], nil
+}
+
+func decodeLevels(dst, src []byte, bitWidth uint) ([]byte, error) {
+	if bitWidth == 0 || len(src) == 0 {
+		return append(dst[:0], 0), nil
+	}
+
+	numBits := bits.BitCount(len(src))
+	numValues := int(numBits / bitWidth)
+	if (numBits % bitWidth) != 0 {
+		numValues++
+	}
+
+	if cap(dst) < numValues {
+		dst = make([]byte, numValues)
+	} else {
+		dst = dst[:numValues]
+		for i := range dst {
+			dst[i] = 0
+		}
+	}
+
+	bitMask := byte(1<<bitWidth) - 1
+	bitShift := 8 - bitWidth
+	bitOffset := uint(0)
+
+	for k := range dst {
+		i := bitOffset / 8
+		j := bitOffset % 8
+		v := (src[i+0] >> j)
+		if int(i+1) < len(src) {
+			v |= (src[i+1] << (8 - j))
+		}
+		v &= bitMask
+		dst[k] = bitFlip(v) >> bitShift
+		bitOffset += bitWidth
+	}
+
+	return dst, nil
+}
+
+func bitFlip(b byte) byte {
+	return (((b >> 0) & 1) << 7) |
+		(((b >> 1) & 1) << 6) |
+		(((b >> 2) & 1) << 5) |
+		(((b >> 3) & 1) << 4) |
+		(((b >> 4) & 1) << 3) |
+		(((b >> 5) & 1) << 2) |
+		(((b >> 6) & 1) << 1) |
+		(((b >> 7) & 1) << 0)
+}

--- a/encoding/bitpacked/bitpacked_test.go
+++ b/encoding/bitpacked/bitpacked_test.go
@@ -1,0 +1,15 @@
+//go:build go1.18
+// +build go1.18
+
+package bitpacked_test
+
+import (
+	"testing"
+
+	"github.com/segmentio/parquet-go/encoding/fuzz"
+	"github.com/segmentio/parquet-go/encoding/rle"
+)
+
+func FuzzEncodeLevels(f *testing.F) {
+	fuzz.EncodeLevels(f, &rle.Encoding{BitWidth: 8})
+}

--- a/writer.go
+++ b/writer.go
@@ -691,14 +691,14 @@ func (wb *writerBuffers) reset() {
 
 func (wb *writerBuffers) encodeRepetitionLevels(page BufferedPage, maxRepetitionLevel byte) (err error) {
 	bitWidth := bits.Len8(maxRepetitionLevel)
-	encoding := &levelEncodings[bitWidth-1]
+	encoding := &levelEncodingsRLE[bitWidth-1]
 	wb.repetitions, err = encoding.EncodeLevels(wb.repetitions[:0], page.RepetitionLevels())
 	return err
 }
 
 func (wb *writerBuffers) encodeDefinitionLevels(page BufferedPage, maxDefinitionLevel byte) (err error) {
 	bitWidth := bits.Len8(maxDefinitionLevel)
-	encoding := &levelEncodings[bitWidth-1]
+	encoding := &levelEncodingsRLE[bitWidth-1]
 	wb.definitions, err = encoding.EncodeLevels(wb.definitions[:0], page.DefinitionLevels())
 	return err
 }


### PR DESCRIPTION
Fixes #154 

When opening files using the deprecated bit-packed encoding, parquet-go used to show that it did not support the encoding:
```
$ go test -v -run OpenFile/testdata/nested_lists.snappy.parquet
=== RUN   TestOpenFile
=== RUN   TestOpenFile/testdata/nested_lists.snappy.parquet
    file_test.go:48: message spark_schema {
        	optional group a {
        		repeated group list {
        			optional group element {
        				repeated group list {
        					optional group element {
        						repeated group list {
        							optional binary element (STRING);
        						}
        					}
        				}
        			}
        		}
        	}
        	required int32 b;
        }
    file_test.go:64: spark_schema
    file_test.go:64: . a
    file_test.go:64: . . list
    file_test.go:64: . . . element
    file_test.go:64: . . . . list
    file_test.go:64: . . . . . element
    file_test.go:64: . . . . . . list
    file_test.go:62: . . . . . . . element RLE SNAPPY
    file_test.go:62: . b NOT_SUPPORTED SNAPPY
--- PASS: TestOpenFile (0.00s)
    --- PASS: TestOpenFile/testdata/nested_lists.snappy.parquet (0.00s)
PASS
ok  	github.com/segmentio/parquet-go	0.247s
```

With this change, it now properly reads the bit-packed repetition and definition levels:
```
$ go test -v -run OpenFile/testdata/nested_lists.snappy.parquet
=== RUN   TestOpenFile
=== RUN   TestOpenFile/testdata/nested_lists.snappy.parquet
    file_test.go:48: message spark_schema {
        	optional group a {
        		repeated group list {
        			optional group element {
        				repeated group list {
        					optional group element {
        						repeated group list {
        							optional binary element (STRING);
        						}
        					}
        				}
        			}
        		}
        	}
        	required int32 b;
        }
    file_test.go:64: spark_schema
    file_test.go:64: . a
    file_test.go:64: . . list
    file_test.go:64: . . . element
    file_test.go:64: . . . . list
    file_test.go:64: . . . . . element
    file_test.go:64: . . . . . . list
    file_test.go:62: . . . . . . . element RLE SNAPPY
    file_test.go:62: . b BIT_PACKED SNAPPY
--- PASS: TestOpenFile (0.00s)
    --- PASS: TestOpenFile/testdata/nested_lists.snappy.parquet (0.00s)
PASS
ok  	github.com/segmentio/parquet-go	0.208s
```