### PR TITLE
Optimize parquet row reader

### DIFF
--- a/buffer_test.go
+++ b/buffer_test.go
@@ -452,7 +452,10 @@ func TestBufferRoundtripNestedRepeated(t *testing.T) {
 	for i := 0; ; i++ {
 		o := new(A)
 		err := r.Read(o)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
+			if i < len(objs) {
+				t.Errorf("too few rows were read: %d<%d", i, len(objs))
+			}
 			break
 		}
 		if !reflect.DeepEqual(*o, objs[i]) {

--- a/column_chunk.go
+++ b/column_chunk.go
@@ -191,113 +191,168 @@ func (r *columnChunkReader) writeRowsTo(w pageAndValueWriter, limit int64) (numR
 }
 */
 
-type columnReadRowFunc func(Row, byte, []columnChunkReader) (Row, error)
+type columnReadRowsFunc func([]Row, byte, []columnChunkReader) (int, error)
 
-func columnReadRowFuncOf(node Node, columnIndex int, repetitionDepth byte) (int, columnReadRowFunc) {
-	var read columnReadRowFunc
+func columnReadRowsFuncOf(node Node, columnIndex int, repetitionDepth byte) (int, columnReadRowsFunc) {
+	var read columnReadRowsFunc
 
 	if node.Repeated() {
 		repetitionDepth++
 	}
 
 	if node.Leaf() {
-		columnIndex, read = columnReadRowFuncOfLeaf(columnIndex, repetitionDepth)
+		columnIndex, read = columnReadRowsFuncOfLeaf(columnIndex, repetitionDepth)
 	} else {
-		columnIndex, read = columnReadRowFuncOfGroup(node, columnIndex, repetitionDepth)
+		columnIndex, read = columnReadRowsFuncOfGroup(node, columnIndex, repetitionDepth)
 	}
 
 	if node.Repeated() {
-		read = columnReadRowFuncOfRepeated(read, repetitionDepth)
+		read = columnReadRowsFuncOfRepeated(read, repetitionDepth)
 	}
 
 	return columnIndex, read
 }
 
 //go:noinline
-func columnReadRowFuncOfRepeated(read columnReadRowFunc, repetitionDepth byte) columnReadRowFunc {
-	return func(row Row, repetitionLevel byte, columns []columnChunkReader) (Row, error) {
-		var err error
+func columnReadRowsFuncOfRepeated(read columnReadRowsFunc, repetitionDepth byte) columnReadRowsFunc {
+	return func(rows []Row, repetitionLevel byte, columns []columnChunkReader) (int, error) {
+		for i := range rows {
+			// Repeated columns have variable number of values, we must process
+			// them one row at a time because we cannot predict how many values
+			// need to be consumed in each iteration.
+			row := rows[i : i+1]
 
-		for {
-			n := len(row)
-
-			if row, err = read(row, repetitionLevel, columns); err != nil {
-				return row, err
+			// The first pass looks for values marking the beginning of a row by
+			// having a repetition level equal to the current level.
+			n, err := read(row, repetitionLevel, columns)
+			if err != nil {
+				// The error here may likely be io.EOF, the read function may
+				// also have successfully read a row, which is indicated by a
+				// non-zero count. In this case, we increment the index to
+				// indicate to the caller than rows up to i+1 have been read.
+				if n > 0 {
+					i++
+				}
+				return i, err
 			}
-			if n == len(row) {
-				return row, nil
+
+			// The read function may return no errors and also read no rows in
+			// case where it had more values to read but none corresponded to
+			// the current repetition level. This is an indication that we will
+			// not be able to read more rows at this stage, we must return to
+			// the caller to let it set the repetition level to its current
+			// depth, which may allow us to read more values when called again.
+			if n == 0 {
+				return i, nil
 			}
 
-			repetitionLevel = repetitionDepth
+			// When we reach this stage, we have successfully read the first
+			// values of a row of repeated columns. We continue consuming more
+			// repeated values until we get the indication that we consumed
+			// them all (the read function returns zero and no errors).
+			for {
+				n, err := read(row, repetitionDepth, columns)
+				if err != nil {
+					return i + 1, err
+				}
+				if n == 0 {
+					break
+				}
+			}
 		}
+		return len(rows), nil
 	}
 }
 
 //go:noinline
-func columnReadRowFuncOfGroup(node Node, columnIndex int, repetitionDepth byte) (int, columnReadRowFunc) {
+func columnReadRowsFuncOfGroup(node Node, columnIndex int, repetitionDepth byte) (int, columnReadRowsFunc) {
 	fields := node.Fields()
+
+	if len(fields) == 0 {
+		return columnIndex, func(_ []Row, _ byte, _ []columnChunkReader) (int, error) {
+			return 0, io.EOF
+		}
+	}
+
 	if len(fields) == 1 {
 		// Small optimization for a somewhat common case of groups with a single
 		// column (like nested list elements for example); there is no need to
 		// loop over the group of a single element, we can simply skip to calling
 		// the inner read function.
-		return columnReadRowFuncOf(fields[0], columnIndex, repetitionDepth)
+		return columnReadRowsFuncOf(fields[0], columnIndex, repetitionDepth)
 	}
 
-	group := make([]columnReadRowFunc, len(fields))
+	group := make([]columnReadRowsFunc, len(fields))
 	for i := range group {
-		columnIndex, group[i] = columnReadRowFuncOf(fields[i], columnIndex, repetitionDepth)
+		columnIndex, group[i] = columnReadRowsFuncOf(fields[i], columnIndex, repetitionDepth)
 	}
 
-	return columnIndex, func(row Row, repetitionLevel byte, columns []columnChunkReader) (Row, error) {
-		var err error
+	return columnIndex, func(rows []Row, repetitionLevel byte, columns []columnChunkReader) (int, error) {
+		// When reading a group, we use the first column as an indicator of how
+		// may rows can be read during this call.
+		n, err := group[0](rows, repetitionLevel, columns)
 
-		for _, read := range group {
-			if row, err = read(row, repetitionLevel, columns); err != nil {
-				break
+		if n > 0 {
+			// Read values for all rows that the group is able to consume.
+			// Getting io.EOF from calling the read functions indicate that
+			// we consumed all values of that particular column, but there may
+			// be more to read in other columns, therefore we must always read
+			// all columns and cannot stop on the first error.
+			for _, read := range group[1:] {
+				_, err2 := read(rows[:n], repetitionLevel, columns)
+				if err2 != nil && !errors.Is(err2, io.EOF) {
+					return 0, err2
+				}
 			}
 		}
 
-		return row, err
+		return n, err
 	}
 }
 
 //go:noinline
-func columnReadRowFuncOfLeaf(columnIndex int, repetitionDepth byte) (int, columnReadRowFunc) {
-	var read columnReadRowFunc
+func columnReadRowsFuncOfLeaf(columnIndex int, repetitionDepth byte) (int, columnReadRowsFunc) {
+	var read columnReadRowsFunc
 
 	if repetitionDepth == 0 {
-		read = func(row Row, _ byte, columns []columnChunkReader) (Row, error) {
+		read = func(rows []Row, _ byte, columns []columnChunkReader) (int, error) {
+			// When the repetition depth is zero, we know that there is exactly
+			// one value per row for this column, and therefore we can consume
+			// as many values as there are rows to fill.
 			col := &columns[columnIndex]
 
-			for {
+			for n := 0; n < len(rows); {
 				if col.offset < len(col.buffer) {
-					row = append(row, col.buffer[col.offset])
+					rows[n] = append(rows[n], col.buffer[col.offset])
+					n++
 					col.offset++
-					return row, nil
+					continue
 				}
 				if err := col.readValues(); err != nil {
-					return row, err
+					return n, err
 				}
 			}
+
+			return len(rows), nil
 		}
 	} else {
-		read = func(row Row, repetitionLevel byte, columns []columnChunkReader) (Row, error) {
+		read = func(rows []Row, repetitionLevel byte, columns []columnChunkReader) (int, error) {
+			// When the repetition depth is not zero, we know that we will be
+			// called with a single row as input. We attempt to read at most one
+			// value of a single row and return to the caller.
 			col := &columns[columnIndex]
 
 			for {
 				if col.offset < len(col.buffer) {
-					if col.buffer[col.offset].repetitionLevel == repetitionLevel {
-						row = append(row, col.buffer[col.offset])
-						col.offset++
+					if col.buffer[col.offset].repetitionLevel != repetitionLevel {
+						return 0, nil
 					}
-					return row, nil
+					rows[0] = append(rows[0], col.buffer[col.offset])
+					col.offset++
+					return 1, nil
 				}
 				if err := col.readValues(); err != nil {
-					if repetitionLevel > 0 && err == io.EOF {
-						err = nil
-					}
-					return row, err
+					return 0, err
 				}
 			}
 		}

--- a/merge.go
+++ b/merge.go
@@ -54,8 +54,7 @@ func (r *mergedRowGroupRows) init(m *mergedRowGroup) {
 			// declared in this package; we may want to define an API to allow
 			// applications to participate in it.
 			if rd, ok := cursors[i].reader.(*rowGroupRows); ok {
-				rd.init(rd.rowGroup)
-				rd.rowGroup = nil
+				rd.init()
 				// TODO: this optimization is disabled for now, there are
 				// remaining blockers:
 				//

--- a/reader.go
+++ b/reader.go
@@ -189,7 +189,8 @@ func (r *Reader) Read(row interface{}) error {
 		return fmt.Errorf("seeking reader to row %d: %w", r.rowIndex, err)
 	}
 
-	if _, err := r.read.ReadRows(r.values[:]); err != nil {
+	n, err := r.read.ReadRows(r.values[:])
+	if n == 0 {
 		return err
 	}
 

--- a/reader.go
+++ b/reader.go
@@ -276,13 +276,16 @@ func (r *reader) init(schema *Schema, rowGroup RowGroup) {
 func (r *reader) Reset() {
 	r.rowIndex = 0
 
-	if rows, _ := r.rows.(*rowGroupRows); rows != nil {
+	if rows, ok := r.rows.(interface{ Reset() }); ok {
 		// This optimization works for the common case where the underlying type
 		// of the Rows instance is rowGroupRows, which should be true in most
 		// cases since even external implementations of the RowGroup interface
 		// can construct values of this type via the NewRowGroupRowReader
 		// function.
-		rows.reset()
+		//
+		// Foreign implementations of the Rows interface may also define a Reset
+		// method in order to participate in this optimization.
+		rows.Reset()
 		return
 	}
 

--- a/row_group.go
+++ b/row_group.go
@@ -329,20 +329,11 @@ func (r *rowGroupRows) ReadRows(rows []Row) (int, error) {
 		return 0, io.EOF
 	}
 
-	schema := r.rowGroup.Schema()
-
-	for n, row := range rows {
-		row, err := schema.readRow(row[:0], 0, r.columns)
-		rows[n] = row
-		if err == nil && len(row) == 0 {
-			err = io.EOF
-		}
-		if err != nil {
-			return n, err
-		}
+	for i := range rows {
+		rows[i] = rows[i][:0]
 	}
 
-	return len(rows), nil
+	return r.rowGroup.Schema().readRows(rows, 0, r.columns)
 }
 
 /*

--- a/schema.go
+++ b/schema.go
@@ -22,7 +22,7 @@ type Schema struct {
 	root        Node
 	deconstruct deconstructFunc
 	reconstruct reconstructFunc
-	readRows    columnReadRowsFunc
+	readRows    readRowsFunc
 	mapping     columnMapping
 	columns     [][]string
 }
@@ -103,7 +103,7 @@ func NewSchema(name string, root Node) *Schema {
 		root:        root,
 		deconstruct: makeDeconstructFunc(root),
 		reconstruct: makeReconstructFunc(root),
-		readRows:    makeColumnReadRowsFunc(root),
+		readRows:    makeReadRowsFunc(root),
 		mapping:     mapping,
 		columns:     columns,
 	}
@@ -136,8 +136,8 @@ func makeReconstructFunc(node Node) (reconstruct reconstructFunc) {
 	return reconstruct
 }
 
-func makeColumnReadRowsFunc(node Node) columnReadRowsFunc {
-	_, readRows := columnReadRowsFuncOf(node, 0, 0)
+func makeReadRowsFunc(node Node) readRowsFunc {
+	_, readRows := readRowsFuncOf(node, 0, 0)
 	return readRows
 }
 

--- a/schema.go
+++ b/schema.go
@@ -22,7 +22,7 @@ type Schema struct {
 	root        Node
 	deconstruct deconstructFunc
 	reconstruct reconstructFunc
-	readRow     columnReadRowFunc
+	readRows    columnReadRowsFunc
 	mapping     columnMapping
 	columns     [][]string
 }
@@ -103,7 +103,7 @@ func NewSchema(name string, root Node) *Schema {
 		root:        root,
 		deconstruct: makeDeconstructFunc(root),
 		reconstruct: makeReconstructFunc(root),
-		readRow:     makeColumnReadRowFunc(root),
+		readRows:    makeColumnReadRowsFunc(root),
 		mapping:     mapping,
 		columns:     columns,
 	}
@@ -136,9 +136,9 @@ func makeReconstructFunc(node Node) (reconstruct reconstructFunc) {
 	return reconstruct
 }
 
-func makeColumnReadRowFunc(node Node) columnReadRowFunc {
-	_, readRow := columnReadRowFuncOf(node, 0, 0)
-	return readRow
+func makeColumnReadRowsFunc(node Node) columnReadRowsFunc {
+	_, readRows := columnReadRowsFuncOf(node, 0, 0)
+	return readRows
 }
 
 // ConfigureRowGroup satisfies the RowGroupOption interface, allowing Schema

--- a/writer_test.go
+++ b/writer_test.go
@@ -599,7 +599,8 @@ func TestWriterRepeatedUUIDDict(t *testing.T) {
 	rowbuf := make([]parquet.Row, 1)
 	rows := f.RowGroups()[0].Rows()
 	defer rows.Close()
-	if _, err := rows.ReadRows(rowbuf); err != nil {
+	n, err := rows.ReadRows(rowbuf)
+	if n == 0 {
 		t.Fatalf("reading row from parquet file: %v", err)
 	}
 	if len(rowbuf[0]) != 1 {


### PR DESCRIPTION
Follow up to #183, this PR modifies the implementation of the row reading logic to take advantage of the fact that we can now read batches of rows and avoid traversing abstraction layer where possible.

Here's a snapshot comparing the `parquet.Buffer` benchmark added in #183 with this change:
```
name                old time/op    new time/op    delta
BufferReadRows100x    1.59µs ± 0%    0.87µs ± 0%  -45.57%  (p=0.000 n=9+8)

name                old row/s      new row/s      delta
BufferReadRows100x     62.8M ± 0%    115.4M ± 0%  +83.71%  (p=0.000 n=9+8)
```

In this PR, I also made the following changes:
* simplified the internal `columnCheckReader` and `rowGroupRows` types
* documented the algorithms that reconstruct columns into rows, they were a bit difficult to get back into so I imagine it might be useful to future maintenance
* renamed `columnReadRowFunc` to `readRowsFunc` to be less verbose