### PR TITLE
optimize and simplify DELTA_BYTE_ARRAY encoding

### DIFF
--- a/encoding/delta/delta.go
+++ b/encoding/delta/delta.go
@@ -1,7 +1,6 @@
 package delta
 
 import (
-	"bytes"
 	"sync"
 )
 
@@ -20,7 +19,6 @@ func (buf *int32Buffer) decode(src []byte) ([]byte, error) {
 
 var (
 	int32BufferPool sync.Pool // *int32Buffer
-	bytesBufferPool sync.Pool // *bytes.Buffer
 )
 
 func getInt32Buffer() *int32Buffer {
@@ -37,18 +35,4 @@ func getInt32Buffer() *int32Buffer {
 
 func putInt32Buffer(b *int32Buffer) {
 	int32BufferPool.Put(b)
-}
-
-func getBytesBuffer() *bytes.Buffer {
-	b, _ := bytesBufferPool.Get().(*bytes.Buffer)
-	if b != nil {
-		b.Reset()
-	} else {
-		b = new(bytes.Buffer)
-	}
-	return b
-}
-
-func putBytesBuffer(b *bytes.Buffer) {
-	bytesBufferPool.Put(b)
 }


### PR DESCRIPTION
While working on #186, I noticed a simple optimization that could be made to the DELTA_BYTE_ARRAY encoding. CPU profiles showed using the intermediary `bytes.Buffer` to construct the values made of the last value's prefix and current value's suffix had a measurable overhead.

![image](https://user-images.githubusercontent.com/865510/169666512-c503fdae-cfde-42ab-b246-5e1f4d411984.png)

Since we are working with byte slices on the input and output, this intermediary value is actually unnecessary, we can use a byte slice in the destination buffer where we wrote the last value instead. This change in the implementation also means that we do not need the optimization to maintain an internal pool of `bytes.Buffer`, since we are not using the intermediary buffer we can remove this complexity entirely.

```
name                                old time/op   new time/op   delta
Decode/DELTA_BYTE_ARRAY/byte_array    309µs ± 0%    279µs ± 0%   -9.68%  (p=0.000 n=10+10)

name                                old speed     new speed     delta
Decode/DELTA_BYTE_ARRAY/byte_array  468MB/s ± 0%  518MB/s ± 0%  +10.71%  (p=0.000 n=10+10)

```
```
name                                             old time/op   new time/op   delta
Decode/DELTA_BYTE_ARRAY/fixed_length_byte_array    194µs ± 0%    177µs ± 0%  -8.64%  (p=0.000 n=9+9)

name                                             old speed     new speed     delta
Decode/DELTA_BYTE_ARRAY/fixed_length_byte_array  824MB/s ± 0%  901MB/s ± 0%  +9.46%  (p=0.000 n=9+9)
```