### PR TITLE
add CPU feature checks for AVX2

### DIFF
--- a/bloom/block_amd64.go
+++ b/bloom/block_amd64.go
@@ -2,6 +2,8 @@
 
 package bloom
 
+import "golang.org/x/sys/cpu"
+
 // The functions in this file are SIMD-optimized versions of the functions
 // declared in block_optimized.go for x86 targets.
 //
@@ -24,6 +26,7 @@ package bloom
 // block_optimized.go; the delta comparing to functions in block_default.go is
 // significantly larger but not very interesting since those functions have no
 // practical use cases.
+var hasAVX2 = cpu.X86.HasAVX2
 
 //go:noescape
 func blockInsert(b *Block, x uint32)

--- a/bloom/block_amd64.s
+++ b/bloom/block_amd64.s
@@ -2,6 +2,15 @@
 
 #include "textflag.h"
 
+#define salt0 0x47b6137b
+#define salt1 0x44974d91
+#define salt2 0x8824ad5b
+#define salt3 0xa2b7289d
+#define salt4 0x705495c7
+#define salt5 0x2df1424b
+#define salt6 0x9efc4947
+#define salt7 0x5c6bfb31
+
 DATA ones+0(SB)/4, $1
 DATA ones+4(SB)/4, $1
 DATA ones+8(SB)/4, $1
@@ -12,14 +21,14 @@ DATA ones+24(SB)/4, $1
 DATA ones+28(SB)/4, $1
 GLOBL ones(SB), RODATA|NOPTR, $32
 
-DATA salt+0(SB)/4, $0x47b6137b
-DATA salt+4(SB)/4, $0x44974d91
-DATA salt+8(SB)/4, $0x8824ad5b
-DATA salt+12(SB)/4, $0xa2b7289d
-DATA salt+16(SB)/4, $0x705495c7
-DATA salt+20(SB)/4, $0x2df1424b
-DATA salt+24(SB)/4, $0x9efc4947
-DATA salt+28(SB)/4, $0x5c6bfb31
+DATA salt+0(SB)/4, $salt0
+DATA salt+4(SB)/4, $salt1
+DATA salt+8(SB)/4, $salt2
+DATA salt+12(SB)/4, $salt3
+DATA salt+16(SB)/4, $salt4
+DATA salt+20(SB)/4, $salt5
+DATA salt+24(SB)/4, $salt6
+DATA salt+28(SB)/4, $salt7
 GLOBL salt(SB), RODATA|NOPTR, $32
 
 // This initial block is a SIMD implementation of the mask function declared in
@@ -46,19 +55,52 @@ GLOBL salt(SB), RODATA|NOPTR, $32
     VPSRLD $27, tmp, tmp \
     VPSLLVD tmp, dst, dst
 
+#define insert(salt, src, dst) \
+    MOVL src, CX \
+    IMULL salt, CX \
+    SHRL $27, CX \
+    MOVL $1, DX \
+    SHLL CX, DX \
+    ORL DX, dst
+
+#define check(salt, b, x) \
+    MOVL b, CX \
+    MOVL x, DX \
+    IMULL salt, DX \
+    SHRL $27, DX \
+    BTL DX, CX \
+    JAE notfound
+
 // func blockInsert(b *Block, x uint32)
 TEXT ·blockInsert(SB), NOSPLIT, $0-16
     MOVQ b+0(FP), AX
+    CMPB ·hasAVX2(SB), $0
+    JE fallback
+avx2:
     generateMask(x+8(FP), Y1, Y0)
     // Set all 1 bits of the mask in the bloom filter block.
     VPOR (AX), Y0, Y0
     VMOVDQU Y0, (AX)
     VZEROUPPER
     RET
+fallback:
+    MOVL x+8(FP), BX
+    insert($salt0, BX, 0(AX))
+    insert($salt1, BX, 4(AX))
+    insert($salt2, BX, 8(AX))
+    insert($salt3, BX, 12(AX))
+    insert($salt4, BX, 16(AX))
+    insert($salt5, BX, 20(AX))
+    insert($salt6, BX, 24(AX))
+    insert($salt7, BX, 28(AX))
+    RET
 
 // func blockCheck(b *Block, x uint32) bool
 TEXT ·blockCheck(SB), NOSPLIT, $0-17
     MOVQ b+0(FP), AX
+    CMPB ·hasAVX2(SB), $0
+    JE fallback
+avx2:
     generateMask(x+8(FP), Y1, Y0)
     // Compare the 1 bits of the mask with the bloom filter block, then compare
     // the result with the mask, expecting equality if the value `x` was present
@@ -67,4 +109,21 @@ TEXT ·blockCheck(SB), NOSPLIT, $0-17
     VPTEST Y0, Y1      // if (Y0 & ^Y1) != 0 { CF = 1 }
     SETCS ret+16(FP)   // return CF == 1
     VZEROUPPER
+    RET
+fallback:
+    MOVL x+8(FP), BX
+    check($salt0, 0(AX), BX)
+    check($salt1, 4(AX), BX)
+    check($salt2, 8(AX), BX)
+    check($salt3, 12(AX), BX)
+    check($salt4, 16(AX), BX)
+    check($salt5, 20(AX), BX)
+    check($salt6, 24(AX), BX)
+    check($salt7, 28(AX), BX)
+    MOVB $1, CX
+    JMP done
+notfound:
+    XORB CX, CX
+done:
+    MOVB CX, ret+16(FP)
     RET

--- a/bloom/block_optimized.go
+++ b/bloom/block_optimized.go
@@ -24,41 +24,26 @@ package bloom
 // The benchmarks measure throughput based on the byte size of a bloom filter
 // block.
 
-func mask(x uint32) Block {
-	return Block{
-		0: 1 << ((x * salt0) >> 27),
-		1: 1 << ((x * salt1) >> 27),
-		2: 1 << ((x * salt2) >> 27),
-		3: 1 << ((x * salt3) >> 27),
-		4: 1 << ((x * salt4) >> 27),
-		5: 1 << ((x * salt5) >> 27),
-		6: 1 << ((x * salt6) >> 27),
-		7: 1 << ((x * salt7) >> 27),
-	}
-}
-
 func (b *Block) Insert(x uint32) {
-	masked := mask(x)
-	b[0] |= masked[0]
-	b[1] |= masked[1]
-	b[2] |= masked[2]
-	b[3] |= masked[3]
-	b[4] |= masked[4]
-	b[5] |= masked[5]
-	b[6] |= masked[6]
-	b[7] |= masked[7]
+	b[0] |= 1 << ((x * salt0) >> 27)
+	b[1] |= 1 << ((x * salt1) >> 27)
+	b[2] |= 1 << ((x * salt2) >> 27)
+	b[3] |= 1 << ((x * salt3) >> 27)
+	b[4] |= 1 << ((x * salt4) >> 27)
+	b[5] |= 1 << ((x * salt5) >> 27)
+	b[6] |= 1 << ((x * salt6) >> 27)
+	b[7] |= 1 << ((x * salt7) >> 27)
 }
 
 func (b *Block) Check(x uint32) bool {
-	masked := mask(x)
-	return ((b[0] & masked[0]) != 0) &&
-		((b[1] & masked[1]) != 0) &&
-		((b[2] & masked[2]) != 0) &&
-		((b[3] & masked[3]) != 0) &&
-		((b[4] & masked[4]) != 0) &&
-		((b[5] & masked[5]) != 0) &&
-		((b[6] & masked[6]) != 0) &&
-		((b[7] & masked[7]) != 0)
+	return ((b[0] & (1 << ((x * salt0) >> 27))) != 0) &&
+		((b[1] & (1 << ((x * salt1) >> 27))) != 0) &&
+		((b[2] & (1 << ((x * salt2) >> 27))) != 0) &&
+		((b[3] & (1 << ((x * salt3) >> 27))) != 0) &&
+		((b[4] & (1 << ((x * salt4) >> 27))) != 0) &&
+		((b[5] & (1 << ((x * salt5) >> 27))) != 0) &&
+		((b[6] & (1 << ((x * salt6) >> 27))) != 0) &&
+		((b[7] & (1 << ((x * salt7) >> 27))) != 0)
 }
 
 func (f SplitBlockFilter) insertBulk(x []uint64) {

--- a/bloom/block_test.go
+++ b/bloom/block_test.go
@@ -1,13 +1,14 @@
 package bloom_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/segmentio/parquet-go/bloom"
 )
 
 func TestBlock(t *testing.T) {
-	for i := uint64(0); i < 2; /*math.MaxUint32*/ i = (i * 2) + 1 {
+	for i := uint64(0); i < math.MaxUint32; i = (i * 2) + 1 {
 		x := uint32(i)
 		b := bloom.Block{}
 		b.Insert(x)

--- a/bloom/block_test.go
+++ b/bloom/block_test.go
@@ -1,14 +1,13 @@
 package bloom_test
 
 import (
-	"math"
 	"testing"
 
 	"github.com/segmentio/parquet-go/bloom"
 )
 
 func TestBlock(t *testing.T) {
-	for i := uint64(0); i < math.MaxUint32; i = (i * 2) + 1 {
+	for i := uint64(0); i < 2; /*math.MaxUint32*/ i = (i * 2) + 1 {
 		x := uint32(i)
 		b := bloom.Block{}
 		b.Insert(x)

--- a/bloom/filter_amd64.s
+++ b/bloom/filter_amd64.s
@@ -2,6 +2,15 @@
 
 #include "textflag.h"
 
+#define salt0 0x47b6137b
+#define salt1 0x44974d91
+#define salt2 0x8824ad5b
+#define salt3 0xa2b7289d
+#define salt4 0x705495c7
+#define salt5 0x2df1424b
+#define salt6 0x9efc4947
+#define salt7 0x5c6bfb31
+
 // See block_amd64.s for a description of this algorithm.
 #define generateMask(src, dst) \
     VMOVDQA ones(SB), dst \
@@ -32,23 +41,41 @@
     MOVQ tmpXMM, r2 \
     VPEXTRQ $1, tmpXMM, r3
 
+#define insert(salt, src, dst) \
+    MOVL src, CX \
+    IMULL salt, CX \
+    SHRL $27, CX \
+    MOVL $1, DX \
+    SHLL CX, DX \
+    ORL DX, dst
+
+#define check(salt, b, x) \
+    MOVL b, CX \
+    MOVL x, DX \
+    IMULL salt, DX \
+    SHRL $27, DX \
+    BTL DX, CX \
+    JAE notfound
+
 // func filterInsertBulk(f []Block, x []uint64)
 TEXT ·filterInsertBulk(SB), NOSPLIT, $0-48
     MOVQ f_base+0(FP), AX
     MOVQ f_len+8(FP), CX
     MOVQ x_base+24(FP), BX
     MOVQ x_len+32(FP), DX
+    CMPB ·hasAVX2(SB), $0
+    JE fallback
+avx2:
     VPBROADCASTQ f_base+8(FP), Y0
-
     // Loop initialization, SI holds the current index in `x`, DI is the number
     // of elements in `x` rounded down to the nearest multiple of 4.
     XORQ SI, SI
     MOVQ DX, DI
     SHRQ $2, DI
     SHLQ $2, DI
-loop4x64:
+avx2loop4x64:
     CMPQ SI, DI
-    JAE loop
+    JAE avx2loop1x64
 
     // The masks and indexes for 4 input hashes are computed in each loop
     // iteration. The hashes are loaded in Y1 so we can use vector instructions
@@ -84,22 +111,44 @@ loop4x64:
     applyMask(Y9, (AX)(R11*1))
 
     ADDQ $4, SI
-    JMP loop4x64
-loop:
+    JMP avx2loop4x64
+avx2loop1x64:
     // Compute trailing elements in `x` if the length was not a multiple of 4.
     // This is the same algorithm as the one in the loop4x64 section, working
     // on a single mask/block pair at a time.
     CMPQ SI, DX
-    JE done
+    JE avx2done
     MOVQ (BX)(SI*8), R8
     VPBROADCASTD (BX)(SI*8), Y0
     fasthash1x64(CX, R8)
     generateMask(Y0, Y1)
     applyMask(Y1, (AX)(R8*1))
     INCQ SI
+    JMP avx2loop1x64
+avx2done:
+    VZEROUPPER
+    JMP done
+fallback:
+    XORQ SI, SI
+    MOVQ DX, DI
+    MOVQ CX, R10
+loop:
+    CMPQ SI, DI
+    JE done
+    MOVLQZX (BX)(SI*8), R8
+    MOVQ (BX)(SI*8), R9
+    fasthash1x64(R10, R9)
+    insert($salt0, R8, 0(AX)(R9*1))
+    insert($salt1, R8, 4(AX)(R9*1))
+    insert($salt2, R8, 8(AX)(R9*1))
+    insert($salt3, R8, 12(AX)(R9*1))
+    insert($salt4, R8, 16(AX)(R9*1))
+    insert($salt5, R8, 20(AX)(R9*1))
+    insert($salt6, R8, 24(AX)(R9*1))
+    insert($salt7, R8, 28(AX)(R9*1))
+    INCQ SI
     JMP loop
 done:
-    VZEROUPPER
     RET
 
 // func filterInsert(f []Block, x uint64)
@@ -107,11 +156,26 @@ TEXT ·filterInsert(SB), NOSPLIT, $0-32
     MOVQ f_base+0(FP), AX
     MOVQ f_len+8(FP), BX
     MOVQ x+24(FP), CX
-    VPBROADCASTD x+24(FP), Y1
     fasthash1x64(BX, CX)
+    CMPB ·hasAVX2(SB), $0
+    JE fallback
+avx2:
+    VPBROADCASTD x+24(FP), Y1
     generateMask(Y1, Y0)
     applyMask(Y0, (AX)(CX*1))
     VZEROUPPER
+    RET
+fallback:
+    ADDQ CX, AX
+    MOVL x+24(FP), BX
+    insert($salt0, BX, 0(AX))
+    insert($salt1, BX, 4(AX))
+    insert($salt2, BX, 8(AX))
+    insert($salt3, BX, 12(AX))
+    insert($salt4, BX, 16(AX))
+    insert($salt5, BX, 20(AX))
+    insert($salt6, BX, 24(AX))
+    insert($salt7, BX, 28(AX))
     RET
 
 // func filterCheck(f []Block, x uint64) bool
@@ -119,11 +183,32 @@ TEXT ·filterCheck(SB), NOSPLIT, $0-33
     MOVQ f_base+0(FP), AX
     MOVQ f_len+8(FP), BX
     MOVQ x+24(FP), CX
-    VPBROADCASTD x+24(FP), Y1
     fasthash1x64(BX, CX)
+    CMPB ·hasAVX2(SB), $0
+    JE fallback
+avx2:
+    VPBROADCASTD x+24(FP), Y1
     generateMask(Y1, Y0)
     VPAND (AX)(CX*1), Y0, Y1
     VPTEST Y0, Y1
     SETCS ret+32(FP)
     VZEROUPPER
+    RET
+fallback:
+    ADDQ CX, AX
+    MOVL x+24(FP), BX
+    check($salt0, 0(AX), BX)
+    check($salt1, 4(AX), BX)
+    check($salt2, 8(AX), BX)
+    check($salt3, 12(AX), BX)
+    check($salt4, 16(AX), BX)
+    check($salt5, 20(AX), BX)
+    check($salt6, 24(AX), BX)
+    check($salt7, 28(AX), BX)
+    MOVB $1, CX
+    JMP done
+notfound:
+    XORB CX, CX
+done:
+    MOVB CX, ret+32(FP)
     RET


### PR DESCRIPTION
Fixes #189 

The `bloom` package was making the assumption that AVX2 would be available, however it appears that some users are running programs that depend on parquet-go on intel CPUs which do not have AVX2.

The PR adds a check for the AVX2 CPU feature in the assembly functions for amd64. The cost of this check is measurable in the benchmarks we have for bloom filters:

```
name              old time/op    new time/op    delta
Fasthash            1.18ns ± 1%    1.19ns ± 1%     ~     (p=0.735 n=9+10)
BlockInsert         2.35ns ± 1%    2.25ns ± 1%   -4.39%  (p=0.000 n=9+10)
BlockCheck          2.10ns ± 2%    2.39ns ± 2%  +13.75%  (p=0.000 n=10+10)
FilterInsertBulk    16.9ns ± 2%    17.3ns ± 3%   +2.42%  (p=0.001 n=10+9)
FilterInsert        2.40ns ± 3%    2.77ns ±11%  +15.64%  (p=0.000 n=10+10)
FilterCheck         2.69ns ± 1%    2.97ns ± 1%  +10.67%  (p=0.000 n=10+8)

name              old speed      new speed      delta
Fasthash          27.0GB/s ± 1%  26.9GB/s ± 1%     ~     (p=0.661 n=9+10)
BlockInsert       13.6GB/s ± 1%  14.2GB/s ± 1%   +4.61%  (p=0.000 n=9+10)
BlockCheck        15.2GB/s ± 2%  13.4GB/s ± 2%  -12.10%  (p=0.000 n=10+10)
FilterInsertBulk  30.2GB/s ± 2%  29.5GB/s ± 3%   -2.36%  (p=0.001 n=10+9)
FilterInsert      13.3GB/s ± 3%  11.6GB/s ±10%  -13.33%  (p=0.000 n=10+10)
FilterCheck       11.9GB/s ± 1%  10.8GB/s ± 1%   -9.64%  (p=0.000 n=10+8)
```

The `Block*` and `FilterInsert` functions aren't very important, `FilterInsertBulk` and `FilterCheck` are the functions used by the parquet-go package.

* The `FilterInsertBulk` benchmark measures a 2% drop in throughput, this seems acceptable to me, especially considering we can amortize this further by increasing the number of values in the bulk insert to reduce this overhead
* The `FilterCheck` benchmark measures a ~10% drop in throughput, this function tests a single value hash in a bloom filter, so it is more sensitive to the new instructions. The check runs in <3ns, so it seems to be an acceptable as well.

It appears to have no measurable impact on the high level `SplitBloomFilter` benchmark:
```
name              old time/op    new time/op    delta
SplitBlockFilter    1.94µs ± 1%    1.92µs ± 0%  -0.72%  (p=0.001 n=10+8)

name              old speed      new speed      delta
SplitBlockFilter  4.13GB/s ± 1%  4.16GB/s ± 0%  +0.73%  (p=0.001 n=10+8)
```
