### PR TITLE
Optimize generic types

### DIFF
--- a/column_buffer.go
+++ b/column_buffer.go
@@ -765,7 +765,7 @@ func (col *booleanColumnBuffer) WriteBooleans(values []bool) (int, error) {
 		ptr: *(*unsafe.Pointer)(unsafe.Pointer(&values)),
 		len: len(values),
 	}
-	col.writeValues(rows, 1, 0)
+	col.writeValues(rows, unsafe.Sizeof(false), 0)
 	return rows.len, nil
 }
 

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -806,7 +806,7 @@ func (col *booleanColumnBuffer) writeValues(rows array, size, offset uintptr) {
 		if n := rows.len - i; n >= 8 {
 			// At this stage, we know that that we have at least 8 bits to write
 			// and the bits will be aligned on the address of a byte in the
-			// output buffer. We can work on 8 values per loop iterations,
+			// output buffer. We can work on 8 values per loop iteration,
 			// packing them into a single byte and writing it to the output
 			// buffer. This effectively reduces by 87.5% the number of memory
 			// stores that the program needs to perform to generate the values.

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -1628,8 +1628,8 @@ func (col *fixedLenByteArrayColumnBuffer) writeValues(rows array, size, offset u
 }
 
 func (col *fixedLenByteArrayColumnBuffer) writeValues128(rows array, size, offset uintptr) {
-	c := 16 * col.Cap()
-	n := 16 * (col.Len() + rows.len)
+	c := cap(col.data)
+	n := len(col.data) + (16 * rows.len)
 	if c < n {
 		col.data = append(make([]byte, 0, max(n, 2*c)), col.data...)
 	}

--- a/column_buffer_go18.go
+++ b/column_buffer_go18.go
@@ -11,15 +11,6 @@ import (
 	"github.com/segmentio/parquet-go/internal/unsafecast"
 )
 
-type array struct {
-	ptr unsafe.Pointer
-	len int
-}
-
-func (a array) index(i int, size, offset uintptr) unsafe.Pointer {
-	return unsafe.Add(a.ptr, uintptr(i)*size+offset)
-}
-
 func makeArray[T any](s []T) array {
 	return array{
 		ptr: *(*unsafe.Pointer)(unsafe.Pointer(&s)),
@@ -619,11 +610,7 @@ func (w *columnBufferWriter) writeRowsBool(rows array, size, offset uintptr, lev
 
 	switch c := w.columns[levels.columnIndex].(type) {
 	case *booleanColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.writeValue(*(*bool)(p))
-		}
-
+		c.writeValues(rows, size, offset)
 	default:
 		w.reset()
 		for i := 0; i < rows.len; i++ {

--- a/column_buffer_go18.go
+++ b/column_buffer_go18.go
@@ -633,17 +633,9 @@ func (w *columnBufferWriter) writeRowsInt(rows array, size, offset uintptr, leve
 
 	switch c := w.columns[levels.columnIndex].(type) {
 	case *int64ColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, int64(*(*int)(p)))
-		}
-
+		c.writeValues(rows, size, offset)
 	case *uint64ColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, uint64(*(*uint)(p)))
-		}
-
+		c.writeValues(rows, size, offset)
 	default:
 		w.reset()
 		for i := 0; i < rows.len; i++ {
@@ -666,17 +658,9 @@ func (w *columnBufferWriter) writeRowsInt8(rows array, size, offset uintptr, lev
 
 	switch c := w.columns[levels.columnIndex].(type) {
 	case *int32ColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, int32(*(*int8)(p)))
-		}
-
+		c.writeValues(rows, size, offset)
 	case *uint32ColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, uint32(*(*uint8)(p)))
-		}
-
+		c.writeValues(rows, size, offset)
 	default:
 		w.reset()
 		for i := 0; i < rows.len; i++ {
@@ -699,17 +683,9 @@ func (w *columnBufferWriter) writeRowsInt16(rows array, size, offset uintptr, le
 
 	switch c := w.columns[levels.columnIndex].(type) {
 	case *int32ColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, int32(*(*int16)(p)))
-		}
-
+		c.writeValues(rows, size, offset)
 	case *uint32ColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, uint32(*(*uint16)(p)))
-		}
-
+		c.writeValues(rows, size, offset)
 	default:
 		w.reset()
 		for i := 0; i < rows.len; i++ {
@@ -732,17 +708,9 @@ func (w *columnBufferWriter) writeRowsInt32(rows array, size, offset uintptr, le
 
 	switch c := w.columns[levels.columnIndex].(type) {
 	case *int32ColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, *(*int32)(p))
-		}
-
+		c.writeValues(rows, size, offset)
 	case *uint32ColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, *(*uint32)(p))
-		}
-
+		c.writeValues(rows, size, offset)
 	default:
 		w.reset()
 		for i := 0; i < rows.len; i++ {
@@ -765,17 +733,9 @@ func (w *columnBufferWriter) writeRowsInt64(rows array, size, offset uintptr, le
 
 	switch c := w.columns[levels.columnIndex].(type) {
 	case *int64ColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, *(*int64)(p))
-		}
-
+		c.writeValues(rows, size, offset)
 	case *uint64ColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, *(*uint64)(p))
-		}
-
+		c.writeValues(rows, size, offset)
 	default:
 		w.reset()
 		for i := 0; i < rows.len; i++ {
@@ -798,11 +758,7 @@ func (w *columnBufferWriter) writeRowsInt96(rows array, size, offset uintptr, le
 
 	switch c := w.columns[levels.columnIndex].(type) {
 	case *int96ColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, *(*deprecated.Int96)(p))
-		}
-
+		c.writeValues(rows, size, offset)
 	default:
 		w.reset()
 		for i := 0; i < rows.len; i++ {
@@ -825,11 +781,7 @@ func (w *columnBufferWriter) writeRowsFloat32(rows array, size, offset uintptr, 
 
 	switch c := w.columns[levels.columnIndex].(type) {
 	case *floatColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, *(*float32)(p))
-		}
-
+		c.writeValues(rows, size, offset)
 	default:
 		w.reset()
 		for i := 0; i < rows.len; i++ {
@@ -852,11 +804,7 @@ func (w *columnBufferWriter) writeRowsFloat64(rows array, size, offset uintptr, 
 
 	switch c := w.columns[levels.columnIndex].(type) {
 	case *doubleColumnBuffer:
-		for i := 0; i < rows.len; i++ {
-			p := rows.index(i, size, offset)
-			c.values = append(c.values, *(*float64)(p))
-		}
-
+		c.writeValues(rows, size, offset)
 	default:
 		w.reset()
 		for i := 0; i < rows.len; i++ {

--- a/encoding/plain/plain.go
+++ b/encoding/plain/plain.go
@@ -208,11 +208,18 @@ func AppendDouble(b []byte, v float64) []byte {
 }
 
 func AppendByteArray(b, v []byte) []byte {
-	i := len(b)
-	j := i + 4
-	b = append(b, 0, 0, 0, 0)
+	length := [ByteArrayLengthSize]byte{}
+	PutByteArrayLength(length[:], len(v))
+	b = append(b, length[:]...)
 	b = append(b, v...)
-	PutByteArrayLength(b[i:j:j], len(v))
+	return b
+}
+
+func AppendByteArrayString(b []byte, v string) []byte {
+	length := [ByteArrayLengthSize]byte{}
+	PutByteArrayLength(length[:], len(v))
+	b = append(b, length[:]...)
+	b = append(b, v...)
 	return b
 }
 

--- a/parquet.go
+++ b/parquet.go
@@ -31,3 +31,12 @@ func max(a, b int) int {
 	}
 	return b
 }
+
+func resize(buf []byte, size int) []byte {
+	if cap(buf) < size {
+		tmp := make([]byte, len(buf), 2*size)
+		copy(tmp, buf)
+		buf = tmp
+	}
+	return buf[:size]
+}

--- a/parquet.go
+++ b/parquet.go
@@ -31,12 +31,3 @@ func max(a, b int) int {
 	}
 	return b
 }
-
-func resize(buf []byte, size int) []byte {
-	if cap(buf) < size {
-		tmp := make([]byte, len(buf), 2*size)
-		copy(tmp, buf)
-		buf = tmp
-	}
-	return buf[:size]
-}

--- a/value.go
+++ b/value.go
@@ -367,6 +367,9 @@ func (v Value) Kind() Kind { return ^Kind(v.kind) }
 // IsNull returns true if v is the null value.
 func (v Value) IsNull() bool { return v.kind == 0 }
 
+// Byte returns v as a byte, which may truncate the underlying byte.
+func (v Value) Byte() byte { return byte(v.u64) }
+
 // Boolean returns v as a bool, assuming the underlying type is BOOLEAN.
 func (v Value) Boolean() bool { return v.u64 != 0 }
 


### PR DESCRIPTION
Based on #186, this PR adds a few optimizations to reduce the CPU footprint of.

I think we're getting close to the maximum throughput we can get using just Go, this will be a good baseline to compare to for future optimizations:

```
goos: linux
goarch: amd64
pkg: github.com/segmentio/parquet-go
cpu: Intel(R) Xeon(R) CPU @ 2.60GHz
```

```
name                                          old time/op  new time/op  delta
GenericBuffer/benchmarkRowType/go1.18          384ns ± 5%   174ns ± 3%   -54.79%  (p=0.000 n=10+9)
GenericBuffer/booleanColumn/go1.18             464ns ± 4%    97ns ± 4%   -79.06%  (p=0.000 n=9+10)
GenericBuffer/int32Column/go1.18               226ns ± 5%    72ns ± 2%   -68.08%  (p=0.000 n=10+10)
GenericBuffer/int64Column/go1.18               223ns ± 2%    72ns ± 4%   -67.64%  (p=0.000 n=8+10)
GenericBuffer/floatColumn/go1.18               208ns ±14%    77ns ± 3%   -62.90%  (p=0.000 n=10+10)
GenericBuffer/doubleColumn/go1.18              217ns ± 3%    78ns ± 4%   -64.17%  (p=0.000 n=10+10)
GenericBuffer/byteArrayColumn/go1.18          1.26µs ± 2%  1.07µs ± 3%   -14.91%  (p=0.000 n=8+9)
GenericBuffer/fixedLenByteArrayColumn/go1.18   587ns ± 4%   604ns ± 3%    +2.93%  (p=0.001 n=10+9)
GenericBuffer/stringColumn/go1.18             1.03µs ±27%  0.66µs ± 2%   -35.88%  (p=0.000 n=10+8)
GenericBuffer/indexedStringColumn/go1.18      4.25µs ± 3%  4.21µs ± 3%      ~     (p=0.289 n=10+10)
GenericBuffer/uuidColumn/go1.18                180ns ± 2%   108ns ± 2%   -40.13%  (p=0.000 n=10+9)
GenericBuffer/mapColumn/go1.18                72.7µs ± 8%  72.1µs ± 2%      ~     (p=0.400 n=10+9)
GenericBuffer/decimalColumn/go1.18             224ns ± 4%    72ns ± 3%   -67.67%  (p=0.000 n=10+10)
GenericBuffer/contact/go1.18                  1.79µs ± 7%  1.39µs ± 8%   -22.50%  (p=0.000 n=10+10)

name                                          old row/s    new row/s    delta
GenericBuffer/benchmarkRowType/go1.18           260M ± 5%    576M ± 3%  +121.14%  (p=0.000 n=10+9)
GenericBuffer/booleanColumn/go1.18              216M ± 4%   1029M ± 4%  +377.50%  (p=0.000 n=9+10)
GenericBuffer/int32Column/go1.18                443M ± 5%   1386M ± 2%  +213.15%  (p=0.000 n=10+10)
GenericBuffer/int64Column/go1.18                445M ± 6%   1387M ± 4%  +211.54%  (p=0.000 n=9+10)
GenericBuffer/floatColumn/go1.18                484M ±13%   1299M ± 3%  +168.38%  (p=0.000 n=10+10)
GenericBuffer/doubleColumn/go1.18               460M ± 3%   1285M ± 4%  +179.13%  (p=0.000 n=10+10)
GenericBuffer/byteArrayColumn/go1.18           78.9M ± 5%   93.4M ± 3%   +18.31%  (p=0.000 n=9+9)
GenericBuffer/fixedLenByteArrayColumn/go1.18    170M ± 4%    166M ± 3%    -2.85%  (p=0.001 n=10+9)
GenericBuffer/stringColumn/go1.18              99.5M ±23%  152.1M ± 2%   +52.96%  (p=0.000 n=10+8)
GenericBuffer/indexedStringColumn/go1.18       23.5M ± 3%   23.8M ± 3%      ~     (p=0.280 n=10+10)
GenericBuffer/uuidColumn/go1.18                 556M ± 2%    928M ± 2%   +66.99%  (p=0.000 n=10+9)
GenericBuffer/mapColumn/go1.18                 1.38M ± 7%   1.39M ± 2%      ~     (p=0.400 n=10+9)
GenericBuffer/decimalColumn/go1.18              446M ± 4%   1380M ± 3%  +209.24%  (p=0.000 n=10+10)
GenericBuffer/contact/go1.18                   55.8M ± 7%   72.1M ± 7%   +29.02%  (p=0.000 n=10+10)
```

One interesting aspect of this change is that both the code paths using type information and the code using the `parquet.Value` abstractions now use the same underlying implementation. Future improvements will then apply to either approach, yielding greater efficiency in a wider variety of use cases.