### PR TITLE
add parquet.Row.Clone

### DIFF
--- a/row.go
+++ b/row.go
@@ -24,7 +24,7 @@ type Row []Value
 // Clone creates a copy of the row which shares no pointers.
 //
 // This method is useful to capture rows after a call to RowReader.ReadRows when
-// values need to be retain before the next call to ReadRows or after the life
+// values need to be retained before the next call to ReadRows or after the lifespan
 // span of the reader.
 func (row Row) Clone() Row {
 	clone := make(Row, len(row))

--- a/row.go
+++ b/row.go
@@ -21,6 +21,19 @@ const (
 // position in the row.
 type Row []Value
 
+// Clone creates a copy of the row which shares no pointers.
+//
+// This method is useful to capture rows after a call to RowReader.ReadRows when
+// values need to be retain before the next call to ReadRows or after the life
+// span of the reader.
+func (row Row) Clone() Row {
+	clone := make(Row, len(row))
+	for i := range row {
+		clone[i] = row[i].Clone()
+	}
+	return clone
+}
+
 // Equal returns true if row and other contain the same sequence of values.
 func (row Row) Equal(other Row) bool {
 	if len(row) != len(other) {

--- a/row.go
+++ b/row.go
@@ -25,7 +25,7 @@ type Row []Value
 //
 // This method is useful to capture rows after a call to RowReader.ReadRows when
 // values need to be retained before the next call to ReadRows or after the lifespan
-// span of the reader.
+// of the reader.
 func (row Row) Clone() Row {
 	clone := make(Row, len(row))
 	for i := range row {

--- a/row_test.go
+++ b/row_test.go
@@ -8,6 +8,16 @@ import (
 	"github.com/segmentio/parquet-go"
 )
 
+func TestRowClone(t *testing.T) {
+	row := parquet.Row{
+		parquet.ValueOf(42).Level(0, 1, 0),
+		parquet.ValueOf("Hello World").Level(1, 1, 1),
+	}
+	if clone := row.Clone(); !row.Equal(clone) {
+		t.Error("row and its clone are not equal")
+	}
+}
+
 func TestDeconstructionReconstruction(t *testing.T) {
 	type Person struct {
 		FirstName string


### PR DESCRIPTION
Following up from user feedback, this PR adds a `Clone` method to the `parquet.Row` type to support common use cases of having to capture the values read from calls to `parquet.RowReader.ReadRows`.
