### PR TITLE
Optimize writing optional columns (part 3)

### DIFF
--- a/level.go
+++ b/level.go
@@ -1,0 +1,27 @@
+package parquet
+
+import "github.com/segmentio/parquet-go/internal/bits"
+
+func countLevelsEqual(levels []byte, value byte) int {
+	return bits.CountByte(levels, value)
+}
+
+func countLevelsNotEqual(levels []byte, value byte) int {
+	return len(levels) - countLevelsEqual(levels, value)
+}
+
+func appendLevel(levels []byte, value byte, count int) []byte {
+	i := len(levels)
+	n := len(levels) + count
+
+	if cap(levels) < n {
+		newLevels := make([]byte, n, 2*n)
+		copy(newLevels, levels)
+		levels = newLevels
+	} else {
+		levels = levels[:n]
+	}
+
+	memset(levels[i:], value)
+	return levels
+}

--- a/level_amd64.go
+++ b/level_amd64.go
@@ -1,0 +1,6 @@
+//go:build !purego
+
+package parquet
+
+//go:noescape
+func memset(dst []byte, src byte)

--- a/level_amd64.s
+++ b/level_amd64.s
@@ -1,0 +1,55 @@
+//go:build !purego
+
+#include "textflag.h"
+
+// func memset(dst []byte, src byte)
+TEXT ·memset(SB), NOSPLIT, $0-32
+    MOVQ dst+0(FP), AX
+    MOVQ dst+8(FP), BX
+    MOVBQZX src+24(FP), CX
+    XORQ SI, SI
+
+    CMPQ BX, $8
+    JBE test
+
+    CMPQ BX, $64
+    JB init8
+
+    CMPB ·hasAVX2(SB), $0
+    JE init8
+
+    MOVQ BX, DX
+    SHRQ $6, DX
+    SHLQ $6, DX
+    MOVQ CX, X0
+    VPBROADCASTB X0, Y0
+loop64:
+    VMOVDQU Y0, (AX)(SI*1)
+    VMOVDQU Y0, 32(AX)(SI*1)
+    ADDQ $64, SI
+    CMPQ SI, DX
+    JNE loop64
+    VMOVDQU Y0, -64(AX)(BX*1)
+    VMOVDQU Y0, -32(AX)(BX*1)
+    VZEROUPPER
+    RET
+init8:
+    MOVQ $0x0101010101010101, R8
+    IMULQ R8, CX
+
+    MOVQ BX, DX
+    SHRQ $3, DX
+    SHLQ $3, DX
+loop8:
+    MOVQ CX, (AX)(SI*1)
+    ADDQ $8, SI
+    CMPQ SI, DX
+    JNE loop8
+    JMP test
+loop:
+    MOVB CX, (AX)(SI*1)
+    INCQ SI
+test:
+    CMPQ SI, BX
+    JNE loop
+    RET

--- a/level_amd64.s
+++ b/level_amd64.s
@@ -7,7 +7,6 @@ TEXT ·memset(SB), NOSPLIT, $0-32
     MOVQ dst+0(FP), AX
     MOVQ dst+8(FP), BX
     MOVBQZX src+24(FP), CX
-    XORQ SI, SI
 
     CMPQ BX, $8
     JBE test
@@ -18,6 +17,7 @@ TEXT ·memset(SB), NOSPLIT, $0-32
     CMPB ·hasAVX2(SB), $0
     JE init8
 
+    XORQ SI, SI
     MOVQ BX, DX
     SHRQ $6, DX
     SHLQ $6, DX
@@ -33,23 +33,22 @@ loop64:
     VMOVDQU Y0, -32(AX)(BX*1)
     VZEROUPPER
     RET
+
 init8:
     MOVQ $0x0101010101010101, R8
     IMULQ R8, CX
-
-    MOVQ BX, DX
-    SHRQ $3, DX
-    SHLQ $3, DX
 loop8:
-    MOVQ CX, (AX)(SI*1)
-    ADDQ $8, SI
-    CMPQ SI, DX
-    JNE loop8
-    JMP test
+    MOVQ CX, -8(AX)(BX*1)
+    SUBQ $8, BX
+    CMPQ BX, $8
+    JAE loop8
+    MOVQ CX, (AX)
+    RET
+
 loop:
-    MOVB CX, (AX)(SI*1)
-    INCQ SI
+    MOVB CX, -1(AX)(BX*1)
+    DECQ BX
 test:
-    CMPQ SI, BX
+    CMPQ BX, $0
     JNE loop
     RET

--- a/level_purego.go
+++ b/level_purego.go
@@ -1,0 +1,9 @@
+//go:build purego || !amd64
+
+package parquet
+
+func memset(dst []byte, src byte) {
+	for i := range dst {
+		dst[i] = src
+	}
+}

--- a/level_test.go
+++ b/level_test.go
@@ -1,0 +1,43 @@
+package parquet
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMemset(t *testing.T) {
+	const N = 100_0000
+	buffer := make([]byte, N)
+
+	for n := 1; n <= N; n = (n * 2) + 1 {
+		t.Run(fmt.Sprintf("size=%d", n), func(t *testing.T) {
+			b := buffer[:n]
+
+			for i := range b {
+				b[i] = 0
+			}
+
+			memset(b, 42)
+
+			for i, c := range b {
+				if c != 42 {
+					t.Fatalf("byte at index %d has value %d", i, c)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMemset(b *testing.B) {
+	for _, size := range []int{0, 10, 100, 1000, 10_000} {
+		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+			data := make([]byte, size)
+
+			for i := 0; i < b.N; i++ {
+				memset(data, 1)
+			}
+
+			b.SetBytes(int64(size))
+		})
+	}
+}

--- a/null.go
+++ b/null.go
@@ -8,6 +8,7 @@ import (
 	"unsafe"
 
 	"github.com/segmentio/parquet-go/deprecated"
+	"github.com/segmentio/parquet-go/internal/unsafecast"
 )
 
 // nullIndexFunc is the type of functions used to detect null values in rows.
@@ -32,9 +33,7 @@ func nullIndex[T comparable](bits []uint64, rows array, size, offset uintptr) {
 }
 
 func nullIndexStruct(bits []uint64, rows array, size, offset uintptr) {
-	for i := range bits {
-		bits[i] = ^uint64(0)
-	}
+	memset(unsafecast.Slice[byte](bits), 0xFF)
 }
 
 func nullIndexFuncOf(t reflect.Type) nullIndexFunc {

--- a/page.go
+++ b/page.go
@@ -275,35 +275,6 @@ func errPageBoundsOutOfRange(i, j, n int64) error {
 	return fmt.Errorf("page bounds out of range [%d:%d]: with length %d", i, j, n)
 }
 
-func countLevelsEqual(levels []byte, value byte) int {
-	return bits.CountByte(levels, value)
-}
-
-func countLevelsNotEqual(levels []byte, value byte) int {
-	return len(levels) - countLevelsEqual(levels, value)
-}
-
-func appendLevel(levels []byte, value byte, count int) []byte {
-	if count > 0 {
-		i := len(levels)
-		n := len(levels) + count
-
-		if cap(levels) < n {
-			newLevels := make([]byte, n)
-			copy(newLevels, levels)
-			levels = newLevels
-		} else {
-			levels = levels[:n]
-		}
-
-		fill := levels[i:]
-		for i := range fill {
-			fill[i] = value
-		}
-	}
-	return levels
-}
-
 type optionalPage struct {
 	base               BufferedPage
 	maxDefinitionLevel byte


### PR DESCRIPTION
Based on https://github.com/segmentio/parquet-go/pull/206, this PR adds optimizations for the `appendLevel` function employed to write definition and repetition levels.

Most of the time of this function was spent on a loop assigning single-byte level values:
```go
fill := levels[i:]
for i := range fill {
    fill[i] = value
}
```
I replaced this statement with a `memset` function (similar to the C stdlib).

The following snapshot of benchmark shows the intended effect of the code change:
```
name                                      old time/op  new time/op  delta
GenericBuffer/optionalInt32Column/go1.18  1.70µs ± 0%  1.53µs ± 1%   -9.96%  (p=0.000 n=8+8)

name                                      old row/s    new row/s    delta
GenericBuffer/optionalInt32Column/go1.18    589M ± 0%    654M ± 1%  +11.06%  (p=0.000 n=8+8)
```