### PR TITLE
Optimize writing optional columns (part 5)

### DIFF
--- a/buffer_go18_test.go
+++ b/buffer_go18_test.go
@@ -37,6 +37,7 @@ func TestGenericBuffer(t *testing.T) {
 	testGenericBuffer[*contact](t)
 	testGenericBuffer[paddedBooleanColumn](t)
 	testGenericBuffer[optionalInt32Column](t)
+	testGenericBuffer[repeatedInt32Column](t)
 }
 
 func testGenericBuffer[Row any](t *testing.T) {
@@ -112,6 +113,7 @@ func BenchmarkGenericBuffer(b *testing.B) {
 	benchmarkGenericBuffer[contact](b)
 	benchmarkGenericBuffer[paddedBooleanColumn](b)
 	benchmarkGenericBuffer[optionalInt32Column](b)
+	benchmarkGenericBuffer[repeatedInt32Column](b)
 }
 
 func benchmarkGenericBuffer[Row generator[Row]](b *testing.B) {

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -379,16 +379,10 @@ func (col *optionalColumnBuffer) writeValues(rows array, size, offset uintptr, l
 		col.rows = tmp
 	}
 
-	newRows := col.rows[i:]
 	if levels.definitionLevel != col.maxDefinitionLevel {
-		for i := range newRows {
-			newRows[i] = -1
-		}
+		broadcastValueInt32(col.rows[i:], -1)
 	} else {
-		rowIndex := int32(col.base.Len())
-		for i := range newRows {
-			newRows[i] = rowIndex + int32(i)
-		}
+		broadcastRangeInt32(col.rows[i:], int32(col.base.Len()))
 		col.base.writeValues(rows, size, offset, levels)
 	}
 }

--- a/column_buffer_amd64.go
+++ b/column_buffer_amd64.go
@@ -6,6 +6,13 @@ import (
 	"unsafe"
 )
 
+func broadcastValueInt32(dst []int32, src int8) {
+	memset(unsafe.Slice(*(**byte)(unsafe.Pointer(&dst)), len(dst)*4), byte(src))
+}
+
+//go:noescape
+func broadcastRangeInt32(dst []int32, base int32)
+
 //go:noescape
 func writeValuesBitpack(values unsafe.Pointer, rows array, size, offset uintptr)
 

--- a/column_buffer_amd64.go
+++ b/column_buffer_amd64.go
@@ -4,6 +4,8 @@ package parquet
 
 import (
 	"unsafe"
+
+	"golang.org/x/sys/cpu"
 )
 
 func broadcastValueInt32(dst []int32, src int8) {
@@ -11,48 +13,58 @@ func broadcastValueInt32(dst []int32, src int8) {
 }
 
 //go:noescape
-func broadcastRangeInt32(dst []int32, base int32)
+func broadcastRangeInt32AVX2(dst []int32, base int32)
+
+func broadcastRangeInt32(dst []int32, base int32) {
+	if len(dst) >= minLenAVX2 && cpu.X86.HasAVX2 {
+		broadcastRangeInt32AVX2(dst, base)
+	} else {
+		for i := range dst {
+			dst[i] = base + int32(i)
+		}
+	}
+}
 
 //go:noescape
-func writeValuesBitpack(values unsafe.Pointer, rows array, size, offset uintptr)
+func writeValuesBitpackAVX2(values unsafe.Pointer, rows array, size, offset uintptr)
 
 //go:noescape
-func writeValues32bits(values unsafe.Pointer, rows array, size, offset uintptr)
+func writeValues32bitsAVX2(values unsafe.Pointer, rows array, size, offset uintptr)
 
 //go:noescpae
-func writeValues64bits(values unsafe.Pointer, rows array, size, offset uintptr)
+func writeValues64bitsAVX2(values unsafe.Pointer, rows array, size, offset uintptr)
 
 //go:noescape
-func writeValues128bits(values unsafe.Pointer, rows array, size, offset uintptr)
+func writeValues128bitsAVX2(values unsafe.Pointer, rows array, size, offset uintptr)
 
 func writeValuesBool(values []byte, rows array, size, offset uintptr) {
-	writeValuesBitpack(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
+	writeValuesBitpackAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
 }
 
 func writeValuesInt32(values []int32, rows array, size, offset uintptr) {
-	writeValues32bits(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
+	writeValues32bitsAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
 }
 
 func writeValuesInt64(values []int64, rows array, size, offset uintptr) {
-	writeValues64bits(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
+	writeValues64bitsAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
 }
 
 func writeValuesUint32(values []uint32, rows array, size, offset uintptr) {
-	writeValues32bits(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
+	writeValues32bitsAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
 }
 
 func writeValuesUint64(values []uint64, rows array, size, offset uintptr) {
-	writeValues64bits(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
+	writeValues64bitsAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
 }
 
 func writeValuesUint128(values []byte, rows array, size, offset uintptr) {
-	writeValues128bits(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
+	writeValues128bitsAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
 }
 
 func writeValuesFloat32(values []float32, rows array, size, offset uintptr) {
-	writeValues32bits(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
+	writeValues32bitsAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
 }
 
 func writeValuesFloat64(values []float64, rows array, size, offset uintptr) {
-	writeValues64bits(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
+	writeValues64bitsAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
 }

--- a/column_buffer_amd64.s
+++ b/column_buffer_amd64.s
@@ -2,8 +2,8 @@
 
 #include "textflag.h"
 
-// func broadcastRangeInt32(dst []int32, base int32)
-TEXT ·broadcastRangeInt32(SB), NOSPLIT, $0-32
+// func broadcastRangeInt32AVX2(dst []int32, base int32)
+TEXT ·broadcastRangeInt32AVX2(SB), NOSPLIT, $0-32
     MOVQ dst+0(FP), AX
     MOVQ dst+8(FP), BX
     MOVL base+24(FP), CX
@@ -11,9 +11,6 @@ TEXT ·broadcastRangeInt32(SB), NOSPLIT, $0-32
 
     CMPQ BX, $8
     JB test1x4
-
-    CMPB ·hasAVX2(SB), $0
-    JE test1x4
 
     VMOVDQU rangeInt32<>(SB), Y0         // [0,1,2,3,4,5,6,7]
     VPBROADCASTD rangeInt32<>+32(SB), Y1 // [8,8,8,8,8,8,8,8]
@@ -55,8 +52,8 @@ DATA rangeInt32<>+24(SB)/4, $6
 DATA rangeInt32<>+28(SB)/4, $7
 DATA rangeInt32<>+32(SB)/4, $8
 
-// func writeValuesBitpack(values unsafe.Pointer, rows array, size, offset uintptr)
-TEXT ·writeValuesBitpack(SB), NOSPLIT, $0-40
+// func writeValuesBitpackAVX2(values unsafe.Pointer, rows array, size, offset uintptr)
+TEXT ·writeValuesBitpackAVX2(SB), NOSPLIT, $0-40
     MOVQ values_base+0(FP), AX
     MOVQ rows_base+8(FP), BX
     MOVQ rows_len+16(FP), CX
@@ -70,9 +67,6 @@ init:
     ADDQ DI, BX
     SHRQ $3, CX
     XORQ SI, SI
-
-    CMPB ·hasAVX2(SB), $0
-    JE loop
 
     // Make sure `size - offset` is at least 4 bytes, otherwise VPGATHERDD
     // may read data beyond the end of the program memory and trigger a fault.
@@ -151,8 +145,8 @@ loop:
     JNE loop
     RET
 
-// func writeValues32bits(values unsafe.Pointer, rows array, size, offset uintptr)
-TEXT ·writeValues32bits(SB), NOSPLIT, $0-40
+// func writeValues32bitsAVX2(values unsafe.Pointer, rows array, size, offset uintptr)
+TEXT ·writeValues32bitsAVX2(SB), NOSPLIT, $0-40
     MOVQ values_base+0(FP), AX
     MOVQ rows_base+8(FP), BX
     MOVQ rows_len+16(FP), CX
@@ -166,9 +160,6 @@ TEXT ·writeValues32bits(SB), NOSPLIT, $0-40
 
     CMPQ CX, $8
     JB loop1x4
-
-    CMPB ·hasAVX2(SB), $0
-    JE loop1x4
 
     MOVQ CX, DI
     SHRQ $3, DI
@@ -203,8 +194,8 @@ loop1x4:
 done:
     RET
 
-// func writeValues64bits(values unsafe.Pointer, rows array, size, offset uintptr)
-TEXT ·writeValues64bits(SB), NOSPLIT, $0-40
+// func writeValues64bitsAVX2(values unsafe.Pointer, rows array, size, offset uintptr)
+TEXT ·writeValues64bitsAVX2(SB), NOSPLIT, $0-40
     MOVQ values_base+0(FP), AX
     MOVQ rows_base+8(FP), BX
     MOVQ rows_len+16(FP), CX
@@ -218,9 +209,6 @@ TEXT ·writeValues64bits(SB), NOSPLIT, $0-40
 
     CMPQ CX, $4
     JB loop1x8
-
-    CMPB ·hasAVX2(SB), $0
-    JE loop1x8
 
     MOVQ CX, DI
     SHRQ $2, DI
@@ -254,8 +242,8 @@ loop1x8:
 done:
     RET
 
-// func writeValues128bits(values unsafe.Pointer, rows array, size, offset uintptr)
-TEXT ·writeValues128bits(SB), NOSPLIT, $0-40
+// func writeValues128bitsAVX2(values unsafe.Pointer, rows array, size, offset uintptr)
+TEXT ·writeValues128bitsAVX2(SB), NOSPLIT, $0-40
     MOVQ values_base+0(FP), AX
     MOVQ rows_base+8(FP), BX
     MOVQ rows_len+16(FP), CX
@@ -269,9 +257,6 @@ TEXT ·writeValues128bits(SB), NOSPLIT, $0-40
 
     CMPQ CX, $2
     JB loop1x16
-
-    CMPB ·hasAVX2(SB), $0
-    JE loop1x16
 
     MOVQ CX, DI
     SHRQ $1, DI

--- a/column_buffer_purego.go
+++ b/column_buffer_purego.go
@@ -4,6 +4,19 @@ package parquet
 
 import "unsafe"
 
+func broadcastValueInt32(dst []int32, src int8) {
+	value := 0x01010101 * int32(src)
+	for i := range dst {
+		dst[i] = value
+	}
+}
+
+func broadcastRangeInt32(dst []int32, base int32) {
+	for i := range dst {
+		dst[i] = base + int32(i)
+	}
+}
+
 func writeValuesBool(values []byte, rows array, size, offset uintptr) {
 	for i, j := 0, 0; i < rows.len; i += 8 {
 		b0 := *(*byte)(rows.index(i+0, size, offset))

--- a/column_buffer_purego.go
+++ b/column_buffer_purego.go
@@ -2,8 +2,6 @@
 
 package parquet
 
-import "unsafe"
-
 func broadcastValueInt32(dst []int32, src int8) {
 	value := 0x01010101 * int32(src)
 	for i := range dst {
@@ -18,68 +16,33 @@ func broadcastRangeInt32(dst []int32, base int32) {
 }
 
 func writeValuesBool(values []byte, rows array, size, offset uintptr) {
-	for i, j := 0, 0; i < rows.len; i += 8 {
-		b0 := *(*byte)(rows.index(i+0, size, offset))
-		b1 := *(*byte)(rows.index(i+1, size, offset))
-		b2 := *(*byte)(rows.index(i+2, size, offset))
-		b3 := *(*byte)(rows.index(i+3, size, offset))
-		b4 := *(*byte)(rows.index(i+4, size, offset))
-		b5 := *(*byte)(rows.index(i+5, size, offset))
-		b6 := *(*byte)(rows.index(i+6, size, offset))
-		b7 := *(*byte)(rows.index(i+7, size, offset))
-
-		values[j] = (b0 & 1) |
-			((b1 & 1) << 1) |
-			((b2 & 1) << 2) |
-			((b3 & 1) << 3) |
-			((b4 & 1) << 4) |
-			((b5 & 1) << 5) |
-			((b6 & 1) << 6) |
-			((b7 & 1) << 7)
-		j++
-	}
+	panic("unreachable")
 }
 
 func writeValuesInt32(values []int32, rows array, size, offset uintptr) {
-	for i := range values {
-		values[i] = *(*int32)(rows.index(i, size, offset))
-	}
+	panic("unreachable")
 }
 
 func writeValuesInt64(values []int64, rows array, size, offset uintptr) {
-	for i := range values {
-		values[i] = *(*int64)(rows.index(i, size, offset))
-	}
+	panic("unreachable")
 }
 
 func writeValuesUint32(values []uint32, rows array, size, offset uintptr) {
-	for i := range values {
-		values[i] = *(*uint32)(rows.index(i, size, offset))
-	}
+	panic("unreachable")
 }
 
 func writeValuesUint64(values []uint64, rows array, size, offset uintptr) {
-	for i := range values {
-		values[i] = *(*uint64)(rows.index(i, size, offset))
-	}
+	panic("unreachable")
 }
 
 func writeValuesUint128(values []byte, rows array, size, offset uintptr) {
-	data := unsafe.Pointer(&values[0])
-	for i := 0; i < rows.len; i++ {
-		p := rows.index(i, size, offset)
-		*(*[16]byte)(unsafe.Add(data, i*16)) = *(*[16]byte)(p)
-	}
+	panic("unreachable")
 }
 
 func writeValuesFloat32(values []float32, rows array, size, offset uintptr) {
-	for i := range values {
-		values[i] = *(*float32)(rows.index(i, size, offset))
-	}
+	panic("unreachable")
 }
 
 func writeValuesFloat64(values []float64, rows array, size, offset uintptr) {
-	for i := range values {
-		values[i] = *(*float64)(rows.index(i, size, offset))
-	}
+	panic("unreachable")
 }

--- a/column_buffer_test.go
+++ b/column_buffer_test.go
@@ -1,0 +1,41 @@
+package parquet
+
+import "testing"
+
+func TestBroadcastValueInt32(t *testing.T) {
+	buf := make([]int32, 123)
+	broadcastValueInt32(buf, 0x0A)
+
+	for i, v := range buf {
+		if v != 0x0A0A0A0A {
+			t.Fatalf("wrong value at index %d: %v", i, v)
+		}
+	}
+}
+
+func TestBroadcastRangeInt32(t *testing.T) {
+	buf := make([]int32, 123)
+	broadcastRangeInt32(buf, 1)
+
+	for i, v := range buf {
+		if v != int32(1+i) {
+			t.Fatalf("wrong value at index %d: %v", i, v)
+		}
+	}
+}
+
+func BenchmarkBroadcastValueInt32(b *testing.B) {
+	buf := make([]int32, 1000)
+	for i := 0; i < b.N; i++ {
+		broadcastValueInt32(buf, -1)
+	}
+	b.SetBytes(4 * int64(len(buf)))
+}
+
+func BenchmarkBroadcastRangeInt32(b *testing.B) {
+	buf := make([]int32, 1000)
+	for i := 0; i < b.N; i++ {
+		broadcastRangeInt32(buf, 0)
+	}
+	b.SetBytes(4 * int64(len(buf)))
+}

--- a/level_amd64.go
+++ b/level_amd64.go
@@ -2,5 +2,17 @@
 
 package parquet
 
+import "golang.org/x/sys/cpu"
+
 //go:noescape
-func memset(dst []byte, src byte)
+func memsetAVX2(dst []byte, src byte)
+
+func memset(dst []byte, src byte) {
+	if len(dst) >= minLenAVX2 && cpu.X86.HasAVX2 {
+		memsetAVX2(dst, src)
+	} else {
+		for i := range dst {
+			dst[i] = src
+		}
+	}
+}

--- a/level_amd64.s
+++ b/level_amd64.s
@@ -2,8 +2,8 @@
 
 #include "textflag.h"
 
-// func memset(dst []byte, src byte)
-TEXT ·memset(SB), NOSPLIT, $0-32
+// func memsetAVX2(dst []byte, src byte)
+TEXT ·memsetAVX2(SB), NOSPLIT, $0-32
     MOVQ dst+0(FP), AX
     MOVQ dst+8(FP), BX
     MOVBQZX src+24(FP), CX
@@ -13,9 +13,6 @@ TEXT ·memset(SB), NOSPLIT, $0-32
 
     CMPQ BX, $64
     JB init8
-
-    CMPB ·hasAVX2(SB), $0
-    JE init8
 
     XORQ SI, SI
     MOVQ BX, DX

--- a/parquet_amd64.go
+++ b/parquet_amd64.go
@@ -4,8 +4,18 @@ package parquet
 
 import "golang.org/x/sys/cpu"
 
+const (
+	// For very short inputs we are better off staying in Go code; since the
+	// functions get inlined the abstractions have zero overhead then.
+	minLenAVX2 = 8
+)
+
 var (
 	// This variable is used in x86 assembly source files to gate the use of
 	// AVX2 instructions depending on whether the CPU supports it.
 	hasAVX2 = cpu.X86.HasAVX2
 )
+
+func optimize(n int) bool {
+	return n >= minLenAVX2 && hasAVX2
+}

--- a/parquet_purego.go
+++ b/parquet_purego.go
@@ -1,0 +1,5 @@
+//go:build purego || !amd64
+
+package parquet
+
+func optimize(int) bool { return false }

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -183,6 +183,18 @@ func (row optionalInt32Column) generate(prng *rand.Rand) optionalInt32Column {
 	return optionalInt32Column{Value: prng.Int31n(100)}
 }
 
+type repeatedInt32Column struct {
+	Values []int32
+}
+
+func (row repeatedInt32Column) generate(prng *rand.Rand) repeatedInt32Column {
+	row.Values = make([]int32, prng.Intn(10))
+	for i := range row.Values {
+		row.Values[i] = prng.Int31n(10)
+	}
+	return row
+}
+
 type listColumn2 struct {
 	Value utf8string `parquet:",optional"`
 }

--- a/reader_go18_test.go
+++ b/reader_go18_test.go
@@ -38,6 +38,7 @@ func TestGenericReader(t *testing.T) {
 	testGenericReader[*contact](t)
 	testGenericReader[paddedBooleanColumn](t)
 	testGenericReader[optionalInt32Column](t)
+	testGenericReader[repeatedInt32Column](t)
 }
 
 func testGenericReader[Row any](t *testing.T) {

--- a/writer_go18_test.go
+++ b/writer_go18_test.go
@@ -28,6 +28,7 @@ func BenchmarkGenericWriter(b *testing.B) {
 	benchmarkGenericWriter[contact](b)
 	benchmarkGenericWriter[paddedBooleanColumn](b)
 	benchmarkGenericWriter[optionalInt32Column](b)
+	benchmarkGenericWriter[repeatedInt32Column](b)
 }
 
 func benchmarkGenericWriter[Row generator[Row]](b *testing.B) {


### PR DESCRIPTION
Following up from #210, a significant amount of time was spent on simple loops assigning row index values in the `optionalBufferColumn` type. This PR optimizes those code paths to improve throughput of the parquet file writer.

```
name                                      old time/op  new time/op  delta
GenericWriter/optionalInt32Column/go1.18  3.30µs ± 1%  2.90µs ± 1%  -12.12%  (p=0.000 n=10+10)

name                                      old row/s    new row/s    delta
GenericWriter/optionalInt32Column/go1.18    303M ± 1%    345M ± 1%  +13.79%  (p=0.000 n=10+10)
```