### PR TITLE
Optimize boolean dictionary

### DIFF
--- a/dictionary_amd64.go
+++ b/dictionary_amd64.go
@@ -30,13 +30,6 @@ func dictionaryLookup32bits(dict []uint32, indexes []int32, rows array, size, of
 //go:noescape
 func dictionaryLookup64bits(dict []uint64, indexes []int32, rows array, size, offset uintptr) errno
 
-func (d *booleanDictionary) lookup(indexes []int32, rows array, size, offset uintptr) {
-	checkLookupIndexBounds(indexes, rows)
-	for i, j := range indexes {
-		*(*bool)(rows.index(i, size, offset)) = d.index(j)
-	}
-}
-
 func (d *int32Dictionary) lookup(indexes []int32, rows array, size, offset uintptr) {
 	checkLookupIndexBounds(indexes, rows)
 	dict := *(*[]uint32)(unsafe.Pointer(&d.values))

--- a/dictionary_purego.go
+++ b/dictionary_purego.go
@@ -4,13 +4,6 @@ package parquet
 
 import "unsafe"
 
-func (d *booleanDictionary) lookup(indexes []int32, rows array, size, offset uintptr) {
-	checkLookupIndexBounds(indexes, rows)
-	for i, j := range indexes {
-		*(*bool)(rows.index(i, size, offset)) = d.index(j)
-	}
-}
-
 func (d *int32Dictionary) lookup(indexes []int32, rows array, size, offset uintptr) {
 	checkLookupIndexBounds(indexes, rows)
 	for i, j := range indexes {


### PR DESCRIPTION
Follow up from https://github.com/segmentio/parquet-go/pull/214, this PR simplifies and optimizes the implementation of boolean dictionaries.

Boolean dictionaries are not very useful since boolean values can be bit-packed to use a minimum amount of space, but this seems to be a popular construct in the test files we gathered. The code simplification makes it a worthy change in my opinion.

```
name                       old time/op  new time/op   delta
Dictionary/Bounds/BOOLEAN  18.1ns ± 0%   18.1ns ± 0%       ~     (p=0.780 n=10+10)
Dictionary/Insert/BOOLEAN  16.6µs ± 0%    0.8µs ± 0%    -95.42%  (p=0.000 n=10+9)
Dictionary/Lookup/BOOLEAN  1.71µs ± 0%   1.70µs ± 0%     -0.66%  (p=0.000 n=10+8)

name                       old value/s  new value/s   delta
Dictionary/Bounds/BOOLEAN   55.3G ± 0%    55.3G ± 0%       ~     (p=0.739 n=10+10)
Dictionary/Insert/BOOLEAN   60.1M ± 0%  1314.2M ± 0%  +2085.24%  (p=0.000 n=10+9)
Dictionary/Lookup/BOOLEAN    583M ± 0%     587M ± 0%     +0.67%  (p=0.000 n=10+8)
```