### PR TITLE
Optimize UUID types

### DIFF
--- a/array.go
+++ b/array.go
@@ -15,6 +15,10 @@ func makeArrayValue(values []Value) array {
 	return *(*array)(unsafe.Pointer(&values))
 }
 
+func makeArrayBE128(values []*[16]byte) array {
+	return *(*array)(unsafe.Pointer(&values))
+}
+
 func (a array) index(i int, size, offset uintptr) unsafe.Pointer {
 	return unsafe.Add(a.ptr, uintptr(i)*size+offset)
 }

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -110,6 +110,21 @@ var bufferTests = [...]struct {
 	},
 
 	{
+		scenario: "fixed length byte array",
+		typ:      parquet.FixedLenByteArrayType(10),
+		values: [][]interface{}{
+			{},
+			{[10]byte{}},
+			{[10]byte{0: 1}},
+			{
+				[10]byte{0: 0}, [10]byte{0: 2}, [10]byte{0: 1}, [10]byte{0: 4}, [10]byte{0: 3},
+				[10]byte{0: 6}, [10]byte{0: 5}, [10]byte{0: 8}, [10]byte{0: 7}, [10]byte{0: 10},
+				[10]byte{0: 11}, [10]byte{0: 12}, [10]byte{9: 0xFF},
+			},
+		},
+	},
+
+	{
 		scenario: "uuid",
 		typ:      parquet.UUID().Type(),
 		values: [][]interface{}{

--- a/column_buffer_amd64.go
+++ b/column_buffer_amd64.go
@@ -35,7 +35,7 @@ func writeValues32bitsAVX2(values unsafe.Pointer, rows array, size, offset uintp
 func writeValues64bitsAVX2(values unsafe.Pointer, rows array, size, offset uintptr)
 
 //go:noescape
-func writeValues128bitsAVX2(values unsafe.Pointer, rows array, size, offset uintptr)
+func writeValues128bits(values unsafe.Pointer, rows array, size, offset uintptr)
 
 func writeValuesBool(values []byte, rows array, size, offset uintptr) {
 	writeValuesBitpackAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
@@ -58,7 +58,7 @@ func writeValuesUint64(values []uint64, rows array, size, offset uintptr) {
 }
 
 func writeValuesUint128(values []byte, rows array, size, offset uintptr) {
-	writeValues128bitsAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
+	writeValues128bits(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
 }
 
 func writeValuesFloat32(values []float32, rows array, size, offset uintptr) {

--- a/column_buffer_amd64.go
+++ b/column_buffer_amd64.go
@@ -57,14 +57,14 @@ func writeValuesUint64(values []uint64, rows array, size, offset uintptr) {
 	writeValues64bitsAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
 }
 
-func writeValuesUint128(values []byte, rows array, size, offset uintptr) {
-	writeValues128bits(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
-}
-
 func writeValuesFloat32(values []float32, rows array, size, offset uintptr) {
 	writeValues32bitsAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
 }
 
 func writeValuesFloat64(values []float64, rows array, size, offset uintptr) {
 	writeValues64bitsAVX2(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
+}
+
+func writeValuesBE128(values [][16]byte, rows array, size, offset uintptr) {
+	writeValues128bits(*(*unsafe.Pointer)(unsafe.Pointer(&values)), rows, size, offset)
 }

--- a/column_buffer_amd64.s
+++ b/column_buffer_amd64.s
@@ -238,7 +238,6 @@ TEXT ·writeValues128bits(SB), NOSPLIT, $0-40
     MOVQ rows_len+16(FP), CX
     MOVQ size+24(FP), DX
     ADDQ offset+32(FP), BX
-    XORQ SI, SI
 
     CMPQ CX, $0
     JE done
@@ -246,6 +245,7 @@ TEXT ·writeValues128bits(SB), NOSPLIT, $0-40
     CMPQ CX, $1
     JE tail
 
+    XORQ SI, SI
     MOVQ CX, DI
     SHRQ $1, DI
     SHLQ $1, DI

--- a/column_buffer_amd64.s
+++ b/column_buffer_amd64.s
@@ -231,50 +231,42 @@ loop1x8:
 done:
     RET
 
-// func writeValues128bitsAVX2(values unsafe.Pointer, rows array, size, offset uintptr)
-TEXT ·writeValues128bitsAVX2(SB), NOSPLIT, $0-40
+// func writeValues128bits(values unsafe.Pointer, rows array, size, offset uintptr)
+TEXT ·writeValues128bits(SB), NOSPLIT, $0-40
     MOVQ values+0(FP), AX
     MOVQ rows_ptr+8(FP), BX
     MOVQ rows_len+16(FP), CX
     MOVQ size+24(FP), DX
-
-    XORQ SI, SI
     ADDQ offset+32(FP), BX
+    XORQ SI, SI
 
     CMPQ CX, $0
     JE done
 
-    CMPQ CX, $2
-    JB loop1x16
+    CMPQ CX, $1
+    JE tail
 
     MOVQ CX, DI
     SHRQ $1, DI
     SHLQ $1, DI
-loop2x16:
-    VMOVDQU (BX), X0
-    VMOVDQU (BX)(DX*1), X1
+loop:
+    MOVOU (BX), X0
+    MOVOU (BX)(DX*1), X1
 
-    VMOVDQU X0, (AX)
-    VMOVDQU X1, 16(AX)
+    MOVOU X0, (AX)
+    MOVOU X1, 16(AX)
 
-    ADDQ $32, AX
     LEAQ (BX)(DX*2), BX
+    ADDQ $32, AX
     ADDQ $2, SI
     CMPQ SI, DI
-    JNE loop2x16
-    VZEROUPPER
+    JNE loop
 
     CMPQ SI, CX
     JE done
-loop1x16:
+tail:
     MOVOU (BX), X0
     MOVOU X0, (AX)
-
-    ADDQ $16, AX
-    ADDQ DX, BX
-    INCQ SI
-    CMPQ SI, CX
-    JNE loop1x16
 done:
     RET
 

--- a/column_buffer_purego.go
+++ b/column_buffer_purego.go
@@ -35,14 +35,16 @@ func writeValuesUint64(values []uint64, rows array, size, offset uintptr) {
 	panic("unreachable")
 }
 
-func writeValuesUint128(values []byte, rows array, size, offset uintptr) {
-	panic("unreachable")
-}
-
 func writeValuesFloat32(values []float32, rows array, size, offset uintptr) {
 	panic("unreachable")
 }
 
 func writeValuesFloat64(values []float64, rows array, size, offset uintptr) {
 	panic("unreachable")
+}
+
+func writeValuesBE128(values [][16]byte, rows array, size, offset uintptr) {
+	for i := range values {
+		values[i] = *(*[16]byte)(rows.index(i, size, offset))
+	}
 }

--- a/compare.go
+++ b/compare.go
@@ -1,6 +1,8 @@
 package parquet
 
 import (
+	"encoding/binary"
+
 	"github.com/segmentio/parquet-go/deprecated"
 )
 
@@ -90,4 +92,39 @@ func compareUint64(v1, v2 uint64) int {
 	default:
 		return 0
 	}
+}
+
+func compareBE128(v1, v2 *[16]byte) int {
+	x := binary.BigEndian.Uint64(v1[:8])
+	y := binary.BigEndian.Uint64(v2[:8])
+	switch {
+	case x < y:
+		return -1
+	case x > y:
+		return +1
+	}
+	x = binary.BigEndian.Uint64(v1[8:])
+	y = binary.BigEndian.Uint64(v2[8:])
+	switch {
+	case x < y:
+		return -1
+	case x > y:
+		return +1
+	default:
+		return 0
+	}
+}
+
+func lessBE128(v1, v2 *[16]byte) bool {
+	x := binary.BigEndian.Uint64(v1[:8])
+	y := binary.BigEndian.Uint64(v2[:8])
+	switch {
+	case x < y:
+		return true
+	case x > y:
+		return false
+	}
+	x = binary.BigEndian.Uint64(v1[8:])
+	y = binary.BigEndian.Uint64(v2[8:])
+	return x < y
 }

--- a/compare_test.go
+++ b/compare_test.go
@@ -1,0 +1,21 @@
+package parquet
+
+import "testing"
+
+func BenchmarkCompareBE128(b *testing.B) {
+	v1 := [16]byte{}
+	v2 := [16]byte{}
+
+	for i := 0; i < b.N; i++ {
+		compareBE128(&v1, &v2)
+	}
+}
+
+func BenchmarkLessBE128(b *testing.B) {
+	v1 := [16]byte{}
+	v2 := [16]byte{}
+
+	for i := 0; i < b.N; i++ {
+		lessBE128(&v1, &v2)
+	}
+}

--- a/dictionary.go
+++ b/dictionary.go
@@ -1050,28 +1050,7 @@ func (d *be128Dictionary) Lookup(indexes []int32, values []Value) {
 
 func (d *be128Dictionary) Bounds(indexes []int32) (min, max Value) {
 	if len(indexes) > 0 {
-		minValue := d.index(indexes[0])
-		maxValue := minValue
-		values := [64]*[16]byte{}
-
-		for i := 1; i < len(indexes); i += len(values) {
-			n := len(indexes) - i
-			if n > len(values) {
-				n = len(values)
-			}
-			j := i + n
-			d.lookupPointer(indexes[i:j:j], makeArrayBE128(values[:n:n]), unsafe.Sizeof(values[0]), 0)
-
-			for _, value := range values[:n:n] {
-				switch {
-				case lessBE128(value, minValue):
-					minValue = value
-				case lessBE128(maxValue, value):
-					maxValue = value
-				}
-			}
-		}
-
+		minValue, maxValue := d.bounds(indexes)
 		min = d.makeValue(minValue)
 		max = d.makeValue(maxValue)
 	}

--- a/dictionary.go
+++ b/dictionary.go
@@ -1043,9 +1043,9 @@ func (d *be128Dictionary) insertValues(indexes []int32, count int, valueAt func(
 }
 
 func (d *be128Dictionary) Lookup(indexes []int32, values []Value) {
-	model := d.makeValue(&zeroBE128) // pre-assign the length 16 to all values
+	model := d.makeValueString("")
 	memsetValues(values, model)
-	d.lookupPointer(indexes, makeArrayValue(values), unsafe.Sizeof(model), unsafe.Offsetof(model.ptr))
+	d.lookupString(indexes, makeArrayValue(values), unsafe.Sizeof(model), unsafe.Offsetof(model.ptr))
 }
 
 func (d *be128Dictionary) Bounds(indexes []int32) (min, max Value) {

--- a/dictionary_amd64.go
+++ b/dictionary_amd64.go
@@ -4,6 +4,8 @@ package parquet
 
 import (
 	"unsafe"
+
+	"github.com/segmentio/parquet-go/internal/bits"
 )
 
 //go:noescape
@@ -35,6 +37,9 @@ func dictionaryLookupByteArrayString(dict []uint32, page []byte, indexes []int32
 
 //go:noescape
 func dictionaryLookupFixedLenByteArrayString(dict []byte, len int, indexes []int32, rows array, size, offset uintptr) errno
+
+//go:noescape
+func dictionaryLookupFixedLenByteArrayPointer(dict []byte, len int, indexes []int32, rows array, size, offset uintptr) errno
 
 func (d *int32Dictionary) lookup(indexes []int32, rows array, size, offset uintptr) {
 	checkLookupIndexBounds(indexes, rows)
@@ -78,6 +83,12 @@ func (d *uint32Dictionary) lookup(indexes []int32, rows array, size, offset uint
 func (d *uint64Dictionary) lookup(indexes []int32, rows array, size, offset uintptr) {
 	checkLookupIndexBounds(indexes, rows)
 	dictionaryLookup64bits(d.values, indexes, rows, size, offset).check()
+}
+
+func (d *be128Dictionary) lookupPointer(indexes []int32, rows array, size, offset uintptr) {
+	checkLookupIndexBounds(indexes, rows)
+	dict := bits.Uint128ToBytes(d.values)
+	dictionaryLookupFixedLenByteArrayPointer(dict, 16, indexes, rows, size, offset).check()
 }
 
 func (d *int32Dictionary) bounds(indexes []int32) (min, max int32) {

--- a/dictionary_amd64.go
+++ b/dictionary_amd64.go
@@ -27,6 +27,9 @@ func dictionaryBoundsUint32(dict []uint32, indexes []int32) (min, max uint32, er
 func dictionaryBoundsUint64(dict []uint64, indexes []int32) (min, max uint64, err errno)
 
 //go:noescape
+func dictionaryBoundsBE128(dict [][16]byte, indexes []int32) (min, max *[16]byte, err errno)
+
+//go:noescape
 func dictionaryLookup32bits(dict []uint32, indexes []int32, rows array, size, offset uintptr) errno
 
 //go:noescape
@@ -123,6 +126,12 @@ func (d *uint32Dictionary) bounds(indexes []int32) (min, max uint32) {
 
 func (d *uint64Dictionary) bounds(indexes []int32) (min, max uint64) {
 	min, max, err := dictionaryBoundsUint64(d.values, indexes)
+	err.check()
+	return min, max
+}
+
+func (d *be128Dictionary) bounds(indexes []int32) (min, max *[16]byte) {
+	min, max, err := dictionaryBoundsBE128(d.values, indexes)
 	err.check()
 	return min, max
 }

--- a/dictionary_amd64.go
+++ b/dictionary_amd64.go
@@ -88,6 +88,12 @@ func (d *uint64Dictionary) lookup(indexes []int32, rows array, size, offset uint
 	dictionaryLookup64bits(d.values, indexes, rows, size, offset).check()
 }
 
+func (d *be128Dictionary) lookupString(indexes []int32, rows array, size, offset uintptr) {
+	checkLookupIndexBounds(indexes, rows)
+	dict := bits.Uint128ToBytes(d.values)
+	dictionaryLookupFixedLenByteArrayString(dict, 16, indexes, rows, size, offset).check()
+}
+
 func (d *be128Dictionary) lookupPointer(indexes []int32, rows array, size, offset uintptr) {
 	checkLookupIndexBounds(indexes, rows)
 	dict := bits.Uint128ToBytes(d.values)

--- a/dictionary_amd64.s
+++ b/dictionary_amd64.s
@@ -814,6 +814,49 @@ indexOutOfBounds:
     MOVQ $errnoIndexOutOfBounds, AX
     JMP return
 
+// This is the same algorithm as dictionaryLookupFixedLenByteArrayString but we
+// only store the pointer to the location hodling the value instead of storing
+// the pair of pointer and length. Since the length is fixed for this dictionary
+// type, the application can assume it at the call site.
+//
+// func dictionaryLookupFixedLenByteArrayPointer(dict []byte, len int, indexes []int32, rows array, size, offset uintptr) errno
+TEXT ·dictionaryLookupFixedLenByteArrayPointer(SB), NOSPLIT, $0-96
+    MOVQ dict_base+0(FP), AX
+    MOVQ dict_len+8(FP), BX
+
+    MOVQ len+24(FP), CX
+
+    MOVQ indexes_base+32(FP), DX
+    MOVQ indexes_len+40(FP), R8
+
+    MOVQ rows_ptr+56(FP), R9
+    MOVQ size+72(FP), R10
+    ADDQ offset+80(FP), R9
+
+    XORQ DI, DI
+    XORQ SI, SI
+loop:
+    MOVL (DX)(SI*4), DI
+    IMULQ CX, DI
+    CMPL DI, BX
+    JAE indexOutOfBounds
+
+    ADDQ AX, DI
+    MOVQ DI, (R9)
+
+    ADDQ R10, R9
+    INCQ SI
+test:
+    CMPQ SI, R8
+    JNE loop
+    XORQ AX, AX
+return:
+    MOVQ AX, ret+88(FP)
+    RET
+indexOutOfBounds:
+    MOVQ $errnoIndexOutOfBounds, AX
+    JMP return
+
 GLOBL ·range0n8(SB), RODATA|NOPTR, $40
 DATA ·range0n8+0(SB)/4, $0
 DATA ·range0n8+4(SB)/4, $1

--- a/dictionary_purego.go
+++ b/dictionary_purego.go
@@ -170,3 +170,29 @@ func (d *uint64Dictionary) bounds(indexes []int32) (min, max uint64) {
 
 	return min, max
 }
+
+func (d *be128Dictionary) bounds(indexes []int32) (min, max *[16]byte) {
+	values := [64]*[16]byte{}
+	min = d.index(indexes[0])
+	max = min
+
+	for i := 1; i < len(indexes); i += len(values) {
+		n := len(indexes) - i
+		if n > len(values) {
+			n = len(values)
+		}
+		j := i + n
+		d.lookupPointer(indexes[i:j:j], makeArrayBE128(values[:n:n]), unsafe.Sizeof(values[0]), 0)
+
+		for _, value := range values[:n:n] {
+			switch {
+			case lessBE128(value, min):
+				min = value
+			case lessBE128(max, value):
+				max = value
+			}
+		}
+	}
+
+	return min, max
+}

--- a/dictionary_purego.go
+++ b/dictionary_purego.go
@@ -62,6 +62,13 @@ func (d *uint64Dictionary) lookup(indexes []int32, rows array, size, offset uint
 	}
 }
 
+func (d *be128Dictionary) lookupPointer(indexes []int32, rows array, size, offset uintptr) {
+	checkLookupIndexBounds(indexes, rows)
+	for i, j := range indexes {
+		*(**[16]byte)(rows.index(i, size, offset)) = d.index(j)
+	}
+}
+
 func (d *int32Dictionary) bounds(indexes []int32) (min, max int32) {
 	min = d.index(indexes[0])
 	max = min

--- a/dictionary_purego.go
+++ b/dictionary_purego.go
@@ -62,6 +62,15 @@ func (d *uint64Dictionary) lookup(indexes []int32, rows array, size, offset uint
 	}
 }
 
+func (d *be128Dictionary) lookupString(indexes []int32, rows array, size, offset uintptr) {
+	checkLookupIndexBounds(indexes, rows)
+	s := "0123456789ABCDEF"
+	for i, j := range indexes {
+		*(**[16]byte)(unsafe.Pointer(&s)) = d.index(j)
+		*(*string)(rows.index(i, size, offset)) = s
+	}
+}
+
 func (d *be128Dictionary) lookupPointer(indexes []int32, rows array, size, offset uintptr) {
 	checkLookupIndexBounds(indexes, rows)
 	for i, j := range indexes {

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -16,6 +16,7 @@ var dictionaryTypes = [...]parquet.Type{
 	parquet.FloatType,
 	parquet.DoubleType,
 	parquet.ByteArrayType,
+	parquet.FixedLenByteArrayType(10),
 	parquet.FixedLenByteArrayType(16),
 	parquet.Uint(32).Type(),
 	parquet.Uint(64).Type(),

--- a/offset_index.go
+++ b/offset_index.go
@@ -117,3 +117,10 @@ func (i uint64OffsetIndex) NumPages() int                { return 1 }
 func (i uint64OffsetIndex) Offset(int) int64             { return 0 }
 func (i uint64OffsetIndex) CompressedPageSize(int) int64 { return i.page.Size() }
 func (i uint64OffsetIndex) FirstRowIndex(int) int64      { return 0 }
+
+type be128OffsetIndex struct{ page *be128Page }
+
+func (i be128OffsetIndex) NumPages() int                { return 1 }
+func (i be128OffsetIndex) Offset(int) int64             { return 0 }
+func (i be128OffsetIndex) CompressedPageSize(int) int64 { return i.page.Size() }
+func (i be128OffsetIndex) FirstRowIndex(int) int64      { return 0 }

--- a/page_values.go
+++ b/page_values.go
@@ -122,8 +122,7 @@ func (r *booleanPageValues) ReadBooleans(values []bool) (n int, err error) {
 
 func (r *booleanPageValues) ReadValues(values []Value) (n int, err error) {
 	for n < len(values) && r.offset < int(r.page.numValues) {
-		values[n] = makeValueBoolean(r.page.valueAt(r.offset))
-		values[n].columnIndex = r.page.columnIndex
+		values[n] = r.page.makeValue(r.page.valueAt(r.offset))
 		r.offset++
 		n++
 	}
@@ -154,8 +153,7 @@ func (r *int32PageValues) ReadInt32s(values []int32) (n int, err error) {
 
 func (r *int32PageValues) ReadValues(values []Value) (n int, err error) {
 	for n < len(values) && r.offset < len(r.page.values) {
-		values[n] = makeValueInt32(r.page.values[r.offset])
-		values[n].columnIndex = r.page.columnIndex
+		values[n] = r.page.makeValue(r.page.values[r.offset])
 		r.offset++
 		n++
 	}
@@ -186,8 +184,7 @@ func (r *int64PageValues) ReadInt64s(values []int64) (n int, err error) {
 
 func (r *int64PageValues) ReadValues(values []Value) (n int, err error) {
 	for n < len(values) && r.offset < len(r.page.values) {
-		values[n] = makeValueInt64(r.page.values[r.offset])
-		values[n].columnIndex = r.page.columnIndex
+		values[n] = r.page.makeValue(r.page.values[r.offset])
 		r.offset++
 		n++
 	}
@@ -218,8 +215,7 @@ func (r *int96PageValues) ReadInt96s(values []deprecated.Int96) (n int, err erro
 
 func (r *int96PageValues) ReadValues(values []Value) (n int, err error) {
 	for n < len(values) && r.offset < len(r.page.values) {
-		values[n] = makeValueInt96(r.page.values[r.offset])
-		values[n].columnIndex = r.page.columnIndex
+		values[n] = r.page.makeValue(r.page.values[r.offset])
 		r.offset++
 		n++
 	}
@@ -250,8 +246,7 @@ func (r *floatPageValues) ReadFloats(values []float32) (n int, err error) {
 
 func (r *floatPageValues) ReadValues(values []Value) (n int, err error) {
 	for n < len(values) && r.offset < len(r.page.values) {
-		values[n] = makeValueFloat(r.page.values[r.offset])
-		values[n].columnIndex = r.page.columnIndex
+		values[n] = r.page.makeValue(r.page.values[r.offset])
 		r.offset++
 		n++
 	}
@@ -282,8 +277,7 @@ func (r *doublePageValues) ReadDoubles(values []float64) (n int, err error) {
 
 func (r *doublePageValues) ReadValues(values []Value) (n int, err error) {
 	for n < len(values) && r.offset < len(r.page.values) {
-		values[n] = makeValueDouble(r.page.values[r.offset])
-		values[n].columnIndex = r.page.columnIndex
+		values[n] = r.page.makeValue(r.page.values[r.offset])
 		r.offset++
 		n++
 	}
@@ -337,8 +331,7 @@ func (r *byteArrayPageValues) readByteArrays(values []byte) (c, n int, err error
 func (r *byteArrayPageValues) ReadValues(values []Value) (n int, err error) {
 	for n < len(values) && r.offset < len(r.page.values) {
 		value := r.page.valueAt(uint32(r.offset))
-		values[n] = makeValueBytes(ByteArray, value)
-		values[n].columnIndex = r.page.columnIndex
+		values[n] = r.page.makeValueBytes(value)
 		r.offset += plain.ByteArrayLengthSize
 		r.offset += len(value)
 		n++
@@ -376,8 +369,7 @@ func (r *fixedLenByteArrayPageValues) ReadFixedLenByteArrays(values []byte) (n i
 
 func (r *fixedLenByteArrayPageValues) ReadValues(values []Value) (n int, err error) {
 	for n < len(values) && r.offset < len(r.page.data) {
-		values[n] = makeValueBytes(FixedLenByteArray, r.page.data[r.offset:r.offset+r.page.size])
-		values[n].columnIndex = r.page.columnIndex
+		values[n] = r.page.makeValueBytes(r.page.data[r.offset : r.offset+r.page.size])
 		r.offset += r.page.size
 		n++
 	}
@@ -408,8 +400,7 @@ func (r *uint32PageValues) ReadUint32s(values []uint32) (n int, err error) {
 
 func (r *uint32PageValues) ReadValues(values []Value) (n int, err error) {
 	for n < len(values) && r.offset < len(r.page.values) {
-		values[n] = makeValueUint32(r.page.values[r.offset])
-		values[n].columnIndex = r.page.columnIndex
+		values[n] = r.page.makeValue(r.page.values[r.offset])
 		r.offset++
 		n++
 	}
@@ -440,8 +431,24 @@ func (r *uint64PageValues) ReadUint64s(values []uint64) (n int, err error) {
 
 func (r *uint64PageValues) ReadValues(values []Value) (n int, err error) {
 	for n < len(values) && r.offset < len(r.page.values) {
-		values[n] = makeValueUint64(r.page.values[r.offset])
-		values[n].columnIndex = r.page.columnIndex
+		values[n] = r.page.makeValue(r.page.values[r.offset])
+		r.offset++
+		n++
+	}
+	if r.offset == len(r.page.values) {
+		err = io.EOF
+	}
+	return n, err
+}
+
+type be128PageValues struct {
+	page   *be128Page
+	offset int
+}
+
+func (r *be128PageValues) ReadValues(values []Value) (n int, err error) {
+	for n < len(values) && r.offset < len(r.page.values) {
+		values[n] = r.page.makeValue(&r.page.values[r.offset])
 		r.offset++
 		n++
 	}

--- a/schema.go
+++ b/schema.go
@@ -2,6 +2,7 @@ package parquet
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -564,7 +565,7 @@ func makeStructField(f reflect.StructField) structField {
 			case reflect.Int64:
 				baseType = Int64Type
 			case reflect.Array:
-				baseType = FixedLenByteArrayType(calcDecimalFixedLenByteArraySize(precision))
+				baseType = FixedLenByteArrayType(decimalFixedLenByteArraySize(precision))
 			default:
 				throwInvalidFieldTag(f, option)
 			}
@@ -610,6 +611,12 @@ func makeStructField(f reflect.StructField) structField {
 	}
 
 	return field
+}
+
+// FixedLenByteArray decimals are sized based on precision
+// this function calculates the necessary byte array size.
+func decimalFixedLenByteArraySize(precision int) int {
+	return int(math.Ceil((math.Log10(2) + float64(precision)) / math.Log10(256)))
 }
 
 func forEachStructTagOption(st reflect.StructTag, do func(option, args string)) {

--- a/type.go
+++ b/type.go
@@ -3,11 +3,8 @@ package parquet
 import (
 	"bytes"
 	"fmt"
-	"math"
-	"reflect"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/segmentio/parquet-go/deprecated"
 	"github.com/segmentio/parquet-go/encoding"
 	"github.com/segmentio/parquet-go/format"
@@ -522,10 +519,59 @@ func (t fixedLenByteArrayType) Decode(dst, src []byte, enc encoding.Encoding) ([
 	return enc.DecodeFixedLenByteArray(dst, src, t.length)
 }
 
+type be128Type struct{} // big-endian 128 bits
+
+func (t be128Type) String() string { return "FIXED_LEN_BYTE_ARRAY(16)" }
+
+func (t be128Type) Kind() Kind { return FixedLenByteArray }
+
+func (t be128Type) Length() int { return 16 }
+
+func (t be128Type) Compare(a, b Value) int {
+	return compareBE128((*[16]byte)(a.ByteArray()), (*[16]byte)(b.ByteArray()))
+}
+
+func (t be128Type) ColumnOrder() *format.ColumnOrder { return &typeDefinedColumnOrder }
+
+func (t be128Type) LogicalType() *format.LogicalType { return nil }
+
+func (t be128Type) ConvertedType() *deprecated.ConvertedType { return nil }
+
+func (t be128Type) PhysicalType() *format.Type { return &physicalTypes[FixedLenByteArray] }
+
+func (t be128Type) NewColumnIndexer(sizeLimit int) ColumnIndexer {
+	return newBE128ColumnIndexer()
+}
+
+func (t be128Type) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
+	return newBE128ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
+}
+
+func (t be128Type) NewDictionary(columnIndex, numValues int, data []byte) Dictionary {
+	return newBE128Dictionary(t, makeColumnIndex(columnIndex), makeNumValues(numValues), data)
+}
+
+func (t be128Type) NewPage(columnIndex, numValues int, data []byte) Page {
+	return newBE128Page(t, makeColumnIndex(columnIndex), makeNumValues(numValues), data)
+}
+
+func (t be128Type) Encode(dst, src []byte, enc encoding.Encoding) ([]byte, error) {
+	return enc.EncodeFixedLenByteArray(dst, src, 16)
+}
+
+func (t be128Type) Decode(dst, src []byte, enc encoding.Encoding) ([]byte, error) {
+	return enc.DecodeFixedLenByteArray(dst, src, 16)
+}
+
 // FixedLenByteArrayType constructs a type for fixed-length values of the given
 // size (in bytes).
 func FixedLenByteArrayType(length int) Type {
-	return fixedLenByteArrayType{length: length}
+	switch length {
+	case 16:
+		return be128Type{}
+	default:
+		return fixedLenByteArrayType{length: length}
+	}
 }
 
 // Int constructs a leaf node of signed integer logical type of the given bit
@@ -713,12 +759,6 @@ func (t *intType) Decode(dst, src []byte, enc encoding.Encoding) ([]byte, error)
 	}
 }
 
-// FixedLenByteArray decimals are sized based on precision
-// this function calculates the necessary byte array size
-func calcDecimalFixedLenByteArraySize(precision int) int {
-	return int(math.Ceil((math.Log10(2) + float64(precision)) / math.Log10(256)))
-}
-
 // Decimal constructs a leaf node of decimal logical type with the given
 // scale, precision, and underlying type.
 //
@@ -802,10 +842,6 @@ func (t *stringType) NewPage(columnIndex, numValues int, data []byte) Page {
 	return newByteArrayPage(t, makeColumnIndex(columnIndex), makeNumValues(numValues), data)
 }
 
-func (t *stringType) GoType() reflect.Type {
-	return reflect.TypeOf("")
-}
-
 func (t *stringType) Encode(dst, src []byte, enc encoding.Encoding) ([]byte, error) {
 	return enc.EncodeByteArray(dst, src)
 }
@@ -828,16 +864,12 @@ func (t *uuidType) Kind() Kind { return FixedLenByteArray }
 func (t *uuidType) Length() int { return 16 }
 
 func (t *uuidType) Compare(a, b Value) int {
-	return bytes.Compare(a.ByteArray(), b.ByteArray())
+	return compareBE128((*[16]byte)(a.ByteArray()), (*[16]byte)(b.ByteArray()))
 }
 
-func (t *uuidType) ColumnOrder() *format.ColumnOrder {
-	return &typeDefinedColumnOrder
-}
+func (t *uuidType) ColumnOrder() *format.ColumnOrder { return &typeDefinedColumnOrder }
 
-func (t *uuidType) PhysicalType() *format.Type {
-	return &physicalTypes[FixedLenByteArray]
-}
+func (t *uuidType) PhysicalType() *format.Type { return &physicalTypes[FixedLenByteArray] }
 
 func (t *uuidType) LogicalType() *format.LogicalType {
 	return &format.LogicalType{UUID: (*format.UUIDType)(t)}
@@ -846,23 +878,19 @@ func (t *uuidType) LogicalType() *format.LogicalType {
 func (t *uuidType) ConvertedType() *deprecated.ConvertedType { return nil }
 
 func (t *uuidType) NewColumnIndexer(sizeLimit int) ColumnIndexer {
-	return newFixedLenByteArrayColumnIndexer(16, sizeLimit)
+	return newBE128ColumnIndexer()
 }
 
 func (t *uuidType) NewDictionary(columnIndex, numValues int, data []byte) Dictionary {
-	return newFixedLenByteArrayDictionary(t, makeColumnIndex(columnIndex), makeNumValues(numValues), data)
+	return newBE128Dictionary(t, makeColumnIndex(columnIndex), makeNumValues(numValues), data)
 }
 
 func (t *uuidType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
-	return newFixedLenByteArrayColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
+	return newBE128ColumnBuffer(t, makeColumnIndex(columnIndex), bufferSize)
 }
 
 func (t *uuidType) NewPage(columnIndex, numValues int, data []byte) Page {
-	return newFixedLenByteArrayPage(t, makeColumnIndex(columnIndex), makeNumValues(numValues), data)
-}
-
-func (t *uuidType) GoType() reflect.Type {
-	return reflect.TypeOf(uuid.UUID{})
+	return newBE128Page(t, makeColumnIndex(columnIndex), makeNumValues(numValues), data)
 }
 
 func (t *uuidType) Encode(dst, src []byte, enc encoding.Encoding) ([]byte, error) {
@@ -920,10 +948,6 @@ func (t *enumType) NewColumnBuffer(columnIndex, bufferSize int) ColumnBuffer {
 
 func (t *enumType) NewPage(columnIndex, numValues int, data []byte) Page {
 	return newByteArrayPage(t, makeColumnIndex(columnIndex), makeNumValues(numValues), data)
-}
-
-func (t *enumType) GoType() reflect.Type {
-	return reflect.TypeOf("")
 }
 
 func (t *enumType) Encode(dst, src []byte, enc encoding.Encoding) ([]byte, error) {

--- a/value.go
+++ b/value.go
@@ -802,11 +802,6 @@ func DeepEqual(v1, v2 Value) bool {
 }
 
 var (
-	// The zero-value of a big-endian 128 bits object. This variable is used to
-	// initialize parquet.Value to a non-null, fixed-length byte arrary of size
-	// 16.
-	zeroBE128 [16]byte
-
 	_ fmt.Formatter = Value{}
 	_ fmt.Stringer  = Value{}
 )

--- a/value.go
+++ b/value.go
@@ -802,6 +802,11 @@ func DeepEqual(v1, v2 Value) bool {
 }
 
 var (
+	// The zero-value of a big-endian 128 bits object. This variable is used to
+	// initialize parquet.Value to a non-null, fixed-length byte arrary of size
+	// 16.
+	zeroBE128 [16]byte
+
 	_ fmt.Formatter = Value{}
 	_ fmt.Stringer  = Value{}
 )


### PR DESCRIPTION
The code was starting to be crippled with checks for fixed-length byte arrays of size 16 as a mechanism to use better code paths for the common case of using columns of type `[16]byte` (e.g. UUIDs, Trace IDs, etc...).

Rather than having these details spread through the codebase, I would like to introduce a new set of types which provide the internal specialization for these column types.

Having knowledege of the type size enables more optimizations as well, both on the Go side (see `compareBE128`, `lessBE128`), but also in assembly routines, for example in the dictionary encoding:

```
name                                        old time/op  new time/op  delta
Dictionary/Bounds/FIXED_LEN_BYTE_ARRAY(16)  8.05µs ± 0%  1.14µs ± 0%   -85.87%  (p=0.000 n=8+10)
Dictionary/Insert/FIXED_LEN_BYTE_ARRAY(16)  20.0µs ± 1%  20.9µs ± 1%    +4.32%  (p=0.000 n=10+9)
Dictionary/Lookup/FIXED_LEN_BYTE_ARRAY(16)   857ns ± 1%   856ns ± 0%      ~     (p=0.309 n=8+9)

name                                        old value/s  new value/s  delta
Dictionary/Bounds/FIXED_LEN_BYTE_ARRAY(16)    124M ± 0%    879M ± 0%  +607.77%  (p=0.000 n=8+10)
Dictionary/Insert/FIXED_LEN_BYTE_ARRAY(16)   50.0M ± 1%   47.9M ± 1%    -4.14%  (p=0.000 n=10+9)
Dictionary/Lookup/FIXED_LEN_BYTE_ARRAY(16)   1.17G ± 1%   1.17G ± 0%      ~     (p=0.236 n=8+9)
```

The increase on the insert path is due to the Go runtime optimizing the map implementation when the key is a `string`. The key type being changed to `[16]byte`, there is a small runtime cost. What the benchmark doesn't show tho is the fact that using `string` keys requires more heap allocations and memory copies.