### PR TITLE
Optimize delta prefix search

### DIFF
--- a/encoding/delta/byte_array.go
+++ b/encoding/delta/byte_array.go
@@ -1,6 +1,7 @@
 package delta
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 
@@ -235,6 +236,6 @@ func binarySearchPrefixLength(base, data []byte) int {
 		n = len(data)
 	}
 	return sort.Search(n, func(i int) bool {
-		return string(base[:i+1]) != string(data[:i+1])
+		return !bytes.Equal(base[:i+1], data[:i+1])
 	})
 }

--- a/encoding/delta/byte_array_test.go
+++ b/encoding/delta/byte_array_test.go
@@ -2,6 +2,7 @@ package delta
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -128,20 +129,27 @@ func testSearchPrefixLength(t *testing.T, prefixLength func(base, data []byte) i
 	}
 }
 
-func BenchmarkLinearSearchkPrefixLength(b *testing.B) {
+func BenchmarkLinearSearchPrefixLength(b *testing.B) {
 	benchmarkSearchPrefixLength(b, linearSearchPrefixLength)
 }
 
-func BenchmarkBinarySearchkPrefixLength(b *testing.B) {
+func BenchmarkBinarySearchPrefixLength(b *testing.B) {
 	benchmarkSearchPrefixLength(b, func(base, data []byte) int {
 		return binarySearchPrefixLength(len(base)/2, base, data)
 	})
 }
 
 func benchmarkSearchPrefixLength(b *testing.B, prefixLength func(base, data []byte) int) {
-	value := bytes.Repeat([]byte("0123456789"), 100)
+	buffer := bytes.Repeat([]byte("0123456789"), 100)
 
-	for i := 0; i < b.N; i++ {
-		_ = prefixLength(value, value)
+	for _, size := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+			base := buffer[:size]
+			data := buffer[:size/2]
+
+			for i := 0; i < b.N; i++ {
+				_ = prefixLength(base, data)
+			}
+		})
 	}
 }

--- a/encoding/delta/byte_array_test.go
+++ b/encoding/delta/byte_array_test.go
@@ -12,7 +12,7 @@ func TestLinearSearchPrefixLength(t *testing.T) {
 
 func TestBinarySearchPrefixLength(t *testing.T) {
 	testSearchPrefixLength(t, func(base, data []byte) int {
-		return binarySearchPrefixLength(len(base)/2, base, data)
+		return binarySearchPrefixLength(base, data)
 	})
 }
 
@@ -135,7 +135,7 @@ func BenchmarkLinearSearchPrefixLength(b *testing.B) {
 
 func BenchmarkBinarySearchPrefixLength(b *testing.B) {
 	benchmarkSearchPrefixLength(b, func(base, data []byte) int {
-		return binarySearchPrefixLength(len(base)/2, base, data)
+		return binarySearchPrefixLength(base, data)
 	})
 }
 


### PR DESCRIPTION
This PR fixes a somewhat broken implementation of the binary search of prefix lengths in the DELTA_BYTE_ARRAY encoding.

```
name                                old time/op  new time/op  delta
BinarySearchPrefixLength/size=10    14.7ns ± 0%  11.3ns ± 2%  -23.21%  (p=0.000 n=9+10)
BinarySearchPrefixLength/size=100   41.1ns ± 2%  19.6ns ± 6%  -52.34%  (p=0.000 n=10+10)
BinarySearchPrefixLength/size=1000  88.3ns ± 1%  27.6ns ± 4%  -68.71%  (p=0.000 n=9+10)
```