### PR TITLE
Fix bitpack fallback for amd64 non-avx2

### DIFF
--- a/encoding/rle/rle_amd64.go
+++ b/encoding/rle/rle_amd64.go
@@ -18,6 +18,7 @@ func init() {
 		encodeInt32Bitpack = encodeInt32BitpackAVX2
 	default:
 		encodeInt32IndexEqual8Contiguous = encodeInt32IndexEqual8ContiguousSSE
+		encodeInt32Bitpack = encodeInt32BitpackDefault
 	}
 }
 


### PR DESCRIPTION
This PR fixes the `encodeInt32Bitpack` fallback for amd64 without AVX2.  Fixes #232    Notably, this occurs when running on an intel mac in docker.  This functionality is covered by the existing `TestEncoding/RLE/int32` test.  

Signed-off-by: Martin Disibio <mdisibio@gmail.com>