### PR TITLE
Optimize reading dictionary pages

### DIFF
--- a/dictionary.go
+++ b/dictionary.go
@@ -1192,22 +1192,17 @@ type indexedPageValues struct {
 }
 
 func (r *indexedPageValues) ReadValues(values []Value) (n int, err error) {
-	dict := r.page.typ.dict
-	pageValues := r.page.values
-	columnIndex := r.page.columnIndex
-
-	for n < len(values) && r.offset < len(pageValues) {
-		v := dict.Index(pageValues[r.offset])
-		v.columnIndex = columnIndex
-		values[n] = v
-		r.offset++
-		n++
+	if n = len(r.page.values) - r.offset; n == 0 {
+		return 0, io.EOF
 	}
-
-	if r.offset == len(pageValues) {
+	if n > len(values) {
+		n = len(values)
+	}
+	r.page.typ.dict.Lookup(r.page.values[r.offset:r.offset+n], values[:n])
+	r.offset += n
+	if r.offset == len(r.page.values) {
 		err = io.EOF
 	}
-
 	return n, err
 }
 


### PR DESCRIPTION
This PR optimizes reading of indexed pages (backed by a dictionary). The `indexedPageValues` type used to make individual calls to the dictionary's `Index` method to lookup values; however, the approach exacerbated the cost of going through abstraction layers, resulting in most of the compute time being spent on function invocation.

Instead, we can use the dictionary's `Lookup` method which allows looking up an array of value indexes, which we have available in the page that we are reading.

The change was highly effective to improve throughput of reads from indexed pages:

```
name                                          old time/op  new time/op  delta
MergeFiles/STRING_(dict)/groups=2,rows=20000  19.6µs ± 1%   4.9µs ± 1%   -74.98%  (p=0.000 n=10+10)

name                                          old row/s    new row/s    delta
MergeFiles/STRING_(dict)/groups=2,rows=20000   49.4M ± 1%  197.3M ± 1%  +299.67%  (p=0.000 n=10+10)
```

Contributes to https://github.com/segmentio/parquet-go/issues/226