### PR TITLE
Fix stack overflow of jsonType.String()

### DIFF
--- a/type.go
+++ b/type.go
@@ -999,7 +999,7 @@ func JSON() Node { return Leaf(&jsonType{}) }
 
 type jsonType format.JsonType
 
-func (t *jsonType) String() string { return (*jsonType)(t).String() }
+func (t *jsonType) String() string { return (*format.JsonType)(t).String() }
 
 func (t *jsonType) Kind() Kind { return ByteArray }
 


### PR DESCRIPTION
Fix https://github.com/segmentio/parquet-go/issues/243