### PR TITLE
Add Schema constructor for reflect.Type

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -89,6 +89,10 @@ func SchemaOf(model interface{}) *Schema {
 
 var cachedSchemas sync.Map // map[reflect.Type]*Schema
 
+func SchemaOfReflectType(model reflect.Type) *Schema {
+	return schemaOf(model)
+}
+
 func schemaOf(model reflect.Type) *Schema {
 	cached, _ := cachedSchemas.Load(model)
 	schema, _ := cached.(*Schema)


### PR DESCRIPTION
Our schema became known only in runtime, that's why we create type in runtime by reflection.