### PR TITLE
[#189] do not use MOVBE instruction when compiling for x86

### DIFF
--- a/dictionary_amd64.s
+++ b/dictionary_amd64.s
@@ -598,8 +598,10 @@ TEXT ·dictionaryBoundsBE128(SB), NOSPLIT, $0-72
     SHLQ $4, DI // the dictionary contains 16 byte words
     LEAQ (AX)(DI*1), R8
     MOVQ R8, R9
-    MOVBEQQ 0(AX)(DI*1), R10 // min (high)
-    MOVBEQQ 8(AX)(DI*1), R11 // min (low)
+    MOVQ 0(AX)(DI*1), R10 // min (high)
+    MOVQ 8(AX)(DI*1), R11 // min (low)
+    BSWAPQ R10
+    BSWAPQ R11
     MOVQ R10, R12 // max (high)
     MOVQ R11, R13 // max (low)
 

--- a/page_max_amd64.s
+++ b/page_max_amd64.s
@@ -565,13 +565,17 @@ loop16:
     //
     // This loop is also taken if the CPU has no support for AVX-512.
 loop:
-    MOVBEQQ (AX), R8
-    MOVBEQQ (BX), R9
+    MOVQ (AX), R8
+    MOVQ (BX), R9
+    BSWAPQ R8
+    BSWAPQ R9
     CMPQ R8, R9
     JA more
     JB next
-    MOVBEQQ 8(AX), R8
-    MOVBEQQ 8(BX), R9
+    MOVQ 8(AX), R8
+    MOVQ 8(BX), R9
+    BSWAPQ R8
+    BSWAPQ R9
     CMPQ R8, R9
     JAE next
 more:

--- a/page_min_amd64.s
+++ b/page_min_amd64.s
@@ -560,13 +560,17 @@ loop16:
     //
     // This loop is also take if the CPU has no support for AVX-512.
 loop:
-    MOVBEQQ (AX), R8
-    MOVBEQQ (BX), R9
+    MOVQ (AX), R8
+    MOVQ (BX), R9
+    BSWAPQ R8
+    BSWAPQ R9
     CMPQ R8, R9
     JB less
     JA next
-    MOVBEQQ 8(AX), R8
-    MOVBEQQ 8(BX), R9
+    MOVQ 8(AX), R8
+    MOVQ 8(BX), R9
+    BSWAPQ R8
+    BSWAPQ R9
     CMPQ R8, R9
     JAE next
 less:


### PR DESCRIPTION
It appears MOVBE was not supported on Intel Ivy Bridge CPUs. This PR replaces the use of MOVBE by the combination of MOV+BSWAP.

Fixes #189 
