### PR TITLE
Select bitpack encoding and decoding implementation at runtime

### DIFF
--- a/encoding/rle/rle.go
+++ b/encoding/rle/rle.go
@@ -506,3 +506,51 @@ func encodeInt32BitpackDefault(dst []byte, src [][8]int32, bitWidth uint) int {
 	bitpack.PackInt32(dst, bits, bitWidth)
 	return bitpack.ByteCount(uint(len(src)*8) * bitWidth)
 }
+
+func encodeBytesBitpackDefault(dst []byte, src []uint64, bitWidth uint) int {
+	bitMask := uint64(1<<bitWidth) - 1
+	n := 0
+
+	for _, word := range src {
+		word = (word & bitMask) |
+			(((word >> 8) & bitMask) << (1 * bitWidth)) |
+			(((word >> 16) & bitMask) << (2 * bitWidth)) |
+			(((word >> 24) & bitMask) << (3 * bitWidth)) |
+			(((word >> 32) & bitMask) << (4 * bitWidth)) |
+			(((word >> 40) & bitMask) << (5 * bitWidth)) |
+			(((word >> 48) & bitMask) << (6 * bitWidth)) |
+			(((word >> 56) & bitMask) << (7 * bitWidth))
+		binary.LittleEndian.PutUint64(dst[n:], word)
+		n += int(bitWidth)
+	}
+
+	return n
+}
+
+func decodeBytesBitpackDefault(dst, src []byte, count, bitWidth uint) {
+	dst = dst[:0]
+
+	bitMask := uint64(1<<bitWidth) - 1
+	byteCount := bitpack.ByteCount(8 * bitWidth)
+
+	for i := 0; count > 0; count -= 8 {
+		j := i + byteCount
+
+		bits := [8]byte{}
+		copy(bits[:], src[i:j])
+		word := binary.LittleEndian.Uint64(bits[:])
+
+		dst = append(dst,
+			byte((word>>(0*bitWidth))&bitMask),
+			byte((word>>(1*bitWidth))&bitMask),
+			byte((word>>(2*bitWidth))&bitMask),
+			byte((word>>(3*bitWidth))&bitMask),
+			byte((word>>(4*bitWidth))&bitMask),
+			byte((word>>(5*bitWidth))&bitMask),
+			byte((word>>(6*bitWidth))&bitMask),
+			byte((word>>(7*bitWidth))&bitMask),
+		)
+
+		i = j
+	}
+}

--- a/encoding/rle/rle_amd64.go
+++ b/encoding/rle/rle_amd64.go
@@ -9,6 +9,8 @@ import (
 var (
 	encodeInt32IndexEqual8Contiguous func(words [][8]int32) int
 	encodeInt32Bitpack               func(dst []byte, src [][8]int32, bitWidth uint) int
+	encodeBytesBitpack               func(dst []byte, src []uint64, bitWidth uint) int
+	decodeBytesBitpack               func(dst, src []byte, count, bitWidth uint)
 )
 
 func init() {
@@ -20,10 +22,19 @@ func init() {
 		encodeInt32IndexEqual8Contiguous = encodeInt32IndexEqual8ContiguousSSE
 		encodeInt32Bitpack = encodeInt32BitpackDefault
 	}
+
+	switch {
+	case cpu.X86.HasBMI2:
+		encodeBytesBitpack = encodeBytesBitpackBMI2
+		decodeBytesBitpack = decodeBytesBitpackBMI2
+	default:
+		encodeBytesBitpack = encodeBytesBitpackDefault
+		decodeBytesBitpack = decodeBytesBitpackDefault
+	}
 }
 
 //go:noescape
-func encodeBytesBitpack(dst []byte, src []uint64, bitWidth uint) int
+func encodeBytesBitpackBMI2(dst []byte, src []uint64, bitWidth uint) int
 
 //go:noescape
 func encodeInt32IndexEqual8ContiguousAVX2(words [][8]int32) int
@@ -46,4 +57,4 @@ func encodeInt32BitpackAVX2(dst []byte, src [][8]int32, bitWidth uint) int {
 }
 
 //go:noescape
-func decodeBytesBitpack(dst, src []byte, count, bitWidth uint)
+func decodeBytesBitpackBMI2(dst, src []byte, count, bitWidth uint)

--- a/encoding/rle/rle_amd64.s
+++ b/encoding/rle/rle_amd64.s
@@ -12,8 +12,8 @@ DATA bitMasks<>+40(SB)/8, $0b001111110011111100111111001111110011111100111111001
 DATA bitMasks<>+48(SB)/8, $0b0111111101111111011111110111111101111111011111110111111101111111
 DATA bitMasks<>+56(SB)/8, $0b1111111111111111111111111111111111111111111111111111111111111111
 
-// func decodeBytesBitpack(dst, src []byte, count, bitWidth uint)
-TEXT ·decodeBytesBitpack(SB), NOSPLIT, $0-64
+// func decodeBytesBitpackBMI2(dst, src []byte, count, bitWidth uint)
+TEXT ·decodeBytesBitpackBMI2(SB), NOSPLIT, $0-64
     MOVQ dst_base+0(FP), AX
     MOVQ src_base+24(FP), BX
     MOVQ count+48(FP), CX
@@ -34,8 +34,8 @@ test:
     JNE loop
     RET
 
-// func encodeBytesBitpack(dst []byte, src []uint64, bitWidth uint) int
-TEXT ·encodeBytesBitpack(SB), NOSPLIT, $0-64
+// func encodeBytesBitpackBMI2(dst []byte, src []uint64, bitWidth uint) int
+TEXT ·encodeBytesBitpackBMI2(SB), NOSPLIT, $0-64
     MOVQ dst_base+0(FP), AX
     MOVQ src_base+24(FP), BX
     MOVQ src_len+32(FP), CX

--- a/encoding/rle/rle_purego.go
+++ b/encoding/rle/rle_purego.go
@@ -9,23 +9,7 @@ import (
 )
 
 func encodeBytesBitpack(dst []byte, src []uint64, bitWidth uint) int {
-	bitMask := uint64(1<<bitWidth) - 1
-	n := 0
-
-	for _, word := range src {
-		word = (word & bitMask) |
-			(((word >> 8) & bitMask) << (1 * bitWidth)) |
-			(((word >> 16) & bitMask) << (2 * bitWidth)) |
-			(((word >> 24) & bitMask) << (3 * bitWidth)) |
-			(((word >> 32) & bitMask) << (4 * bitWidth)) |
-			(((word >> 40) & bitMask) << (5 * bitWidth)) |
-			(((word >> 48) & bitMask) << (6 * bitWidth)) |
-			(((word >> 56) & bitMask) << (7 * bitWidth))
-		binary.LittleEndian.PutUint64(dst[n:], word)
-		n += int(bitWidth)
-	}
-
-	return n
+	return encodeBytesBitpackDefault(dst, src, bitWidth)
 }
 
 func encodeInt32IndexEqual8Contiguous(words [][8]int32) (n int) {
@@ -40,29 +24,5 @@ func encodeInt32Bitpack(dst []byte, src [][8]int32, bitWidth uint) int {
 }
 
 func decodeBytesBitpack(dst, src []byte, count, bitWidth uint) {
-	dst = dst[:0]
-
-	bitMask := uint64(1<<bitWidth) - 1
-	byteCount := bitpack.ByteCount(8 * bitWidth)
-
-	for i := 0; count > 0; count -= 8 {
-		j := i + byteCount
-
-		bits := [8]byte{}
-		copy(bits[:], src[i:j])
-		word := binary.LittleEndian.Uint64(bits[:])
-
-		dst = append(dst,
-			byte((word>>(0*bitWidth))&bitMask),
-			byte((word>>(1*bitWidth))&bitMask),
-			byte((word>>(2*bitWidth))&bitMask),
-			byte((word>>(3*bitWidth))&bitMask),
-			byte((word>>(4*bitWidth))&bitMask),
-			byte((word>>(5*bitWidth))&bitMask),
-			byte((word>>(6*bitWidth))&bitMask),
-			byte((word>>(7*bitWidth))&bitMask),
-		)
-
-		i = j
-	}
+	return decodeBytesBitpackDefault(dst, src, count, bitWidth)
 }


### PR DESCRIPTION
👋🏻 Hi!! This PR adds runtime selection of the bitpack encoding and decoding implementation to addresses the last issue I am bumping into related to `SIGILL`s we were seeing while investigating https://github.com/segmentio/parquet-go/issues/189. 

On current main (`69748705dd0`):

```shell
$ go test . -c && gdb parquet-go.test
 (gdb) display/i $pc
1: x/i $pc
=> 0x717429 <[...]/encoding/rle.encodeBytesBitpack+41>:	pext   %rdi,%r8,%r8
```

The `PEXT` instructions seems to have been introduced with [Haswell](https://en.wikipedia.org/wiki/X86_Bit_manipulation_instruction_set).

Let me know why do you think, and thanks for all your work!! 😄 

## Test plan
```
[javierhonduco@computer parquet-go]$ cat /proc/cpuinfo | grep name | head -1
model name	: Intel(R) Core(TM) i5-3450 CPU @ 3.10GHz
[javierhonduco@computer parquet-go]$ go test -race .
ok  	github.com/segmentio/parquet-go	16.047s
```




