### PR TITLE
fix issue 254

### DIFF
--- a/page_values.go
+++ b/page_values.go
@@ -331,7 +331,7 @@ func (r *byteArrayPageValues) readByteArrays(values []byte) (c, n int, err error
 func (r *byteArrayPageValues) ReadValues(values []Value) (n int, err error) {
 	for n < len(values) && r.offset < len(r.page.values) {
 		value := r.page.valueAt(uint32(r.offset))
-		values[n] = r.page.makeValueBytes(value)
+		values[n] = r.page.makeValueBytes(copyBytes(value))
 		r.offset += plain.ByteArrayLengthSize
 		r.offset += len(value)
 		n++
@@ -369,7 +369,7 @@ func (r *fixedLenByteArrayPageValues) ReadFixedLenByteArrays(values []byte) (n i
 
 func (r *fixedLenByteArrayPageValues) ReadValues(values []Value) (n int, err error) {
 	for n < len(values) && r.offset < len(r.page.data) {
-		values[n] = r.page.makeValueBytes(r.page.data[r.offset : r.offset+r.page.size])
+		values[n] = r.page.makeValueBytes(copyBytes(r.page.data[r.offset : r.offset+r.page.size]))
 		r.offset += r.page.size
 		n++
 	}


### PR DESCRIPTION
Fixes #254 

When a page boundary was crossed while loading column values, the page buffer being recycled via a sync.Pool was causing values loaded for other columns to be invalidated even tho the whole row had not yet been returned to the application.

This PR may introduce a performance regression on the read paths when rows contain values of type BYTE_ARRAY or FIXED_LEN_BYTE_ARRAY as we will now be making a copy of these instead of taking references to the underlying page buffer. This will be addressed in a follow up.
