### PR TITLE
Fix de-/reconstruction of pointer slices

### DIFF
--- a/row_test.go
+++ b/row_test.go
@@ -164,6 +164,24 @@ func TestDeconstructionReconstruction(t *testing.T) {
 		},
 
 		{
+			scenario: "top level slice pointer",
+			input: struct {
+				List []*List2
+			}{
+				List: []*List2{
+					{Value: "foo"},
+					{Value: "bar"},
+				},
+			},
+			values: [][]parquet.Value{
+				0: {
+					parquet.ValueOf("foo").Level(0, 2, 0),
+					parquet.ValueOf("bar").Level(1, 2, 0),
+				},
+			},
+		},
+
+		{
 			scenario: "sub level nil pointer field",
 			input: User{
 				ID: uuid.MustParse("A65B576D-9299-4769-9D93-04BE0583F027"),

--- a/schema.go
+++ b/schema.go
@@ -404,6 +404,11 @@ func (f *structField) Value(base reflect.Value) reflect.Value {
 	switch base.Kind() {
 	case reflect.Map:
 		return base.MapIndex(reflect.ValueOf(&f.name).Elem())
+	case reflect.Pointer:
+		if base.IsNil() {
+			base.Set(reflect.New(base.Type().Elem()))
+		}
+		return fieldByIndex(base.Elem(), f.index)
 	default:
 		if len(f.index) == 1 {
 			return base.Field(f.index[0])

--- a/schema.go
+++ b/schema.go
@@ -404,7 +404,7 @@ func (f *structField) Value(base reflect.Value) reflect.Value {
 	switch base.Kind() {
 	case reflect.Map:
 		return base.MapIndex(reflect.ValueOf(&f.name).Elem())
-	case reflect.Pointer:
+	case reflect.Ptr:
 		if base.IsNil() {
 			base.Set(reflect.New(base.Type().Elem()))
 		}


### PR DESCRIPTION
This adds a test and a potential fix for destruction/reconstruction of a struct with a pointer slice.

