### PR TITLE
buffer_test.go: Add test case for reusing writer with bloomfilters

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -893,9 +893,10 @@ func (c *writerColumn) flushFilterPages() error {
 		// If there is a dictionary, it contains all the values that we need to
 		// write to the filter.
 		if dict := c.dictionary; dict != nil {
-			if c.filter.bits == nil {
-				c.resizeBloomFilter(int64(dict.Len()))
-			}
+			// Need to always attempt to resize the filter, as the writer might
+			// be reused after resetting which would have reset the length of
+			// the filter to 0.
+			c.resizeBloomFilter(int64(dict.Len()))
 			if err := c.writePageToFilter(dict.Page()); err != nil {
 				return err
 			}

--- a/writer_test.go
+++ b/writer_test.go
@@ -652,3 +652,33 @@ func TestWriterRepeatedUUIDDict(t *testing.T) {
 		t.Errorf("expected to get UUID %q back out, got %q", inputID, rowbuf[0][0].Bytes())
 	}
 }
+
+func TestWriterResetWithBloomFilters(t *testing.T) {
+	type Test struct {
+		Value string `parquet:"value,dict"`
+	}
+
+	writer := parquet.NewWriter(new(bytes.Buffer),
+		parquet.BloomFilters(
+			parquet.SplitBlockFilter("value"),
+		),
+	)
+
+	if err := writer.Write(&Test{Value: "foo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	writer.Reset(new(bytes.Buffer))
+
+	if err := writer.Write(&Test{Value: "bar"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
I don't know why yet, but this test appears to fail on arm64. Opening mainly to see if it works on amd64 and to see if anyone has an idea what the culprit might be.

@achille-roussel 