### PR TITLE
fix issue 252

### DIFF
--- a/value.go
+++ b/value.go
@@ -671,7 +671,7 @@ func assignValue(dst reflect.Value, src Value) error {
 				return nil
 			}
 		default:
-			val = reflect.ValueOf(v)
+			val = reflect.ValueOf(string(v))
 		}
 
 	case FixedLenByteArray:


### PR DESCRIPTION
Fixes #252 

The PR fixes the panic reported when using `parquet.GenericReader[any]`, as well as another panic occurring when using `parquet.GenericWriter[any]`, and adds examples of how to use these constructs.