### PR TITLE
fix compression with LZ4_RAW when the output is incompressible

### DIFF
--- a/compress/lz4/lz4.go
+++ b/compress/lz4/lz4.go
@@ -45,6 +45,8 @@ func (c *Codec) Encode(dst, src []byte) ([]byte, error) {
 		n, err := compressor.CompressBlock(src, dst)
 		if err != nil { // see Decode for details about error handling
 			dst = make([]byte, 2*len(dst))
+		} else if n == 0 {
+			dst = reserveAtLeast(dst, lz4.CompressBlockBound(len(src)))
 		} else {
 			return dst[:n], nil
 		}


### PR DESCRIPTION
The bug caused https://github.com/parca-dev/parca/pull/1414 to break when using LZ4_RAW instead of ZSTD encoding.

The cause of the issue was that we were not properly handling the special case where `lz4.(*CompressorHC).CompressBlock` returns `(0,nil)` because the data is not compressible:

> CompressBlock compresses the source buffer src into the destination dst.
>
> If compression is successful, the first return value is the size of the compressed data, which is always >0.
>
> If dst has length at least CompressBlockBound(len(src)), compression always succeeds. Otherwise, the first return value is zero. The error return is non-nil if the compressed data does not fit in dst, but it might fit in a larger buffer that is still smaller than CompressBlockBound(len(src)). The return value (0, nil) means the data is likely incompressible and a buffer of length CompressBlockBound(len(src)) should be passed in.

https://pkg.go.dev/github.com/pierrec/lz4/v4#Compressor.CompressBlock