### PR TITLE
Add ability to set a MAP as optional via tags

### DIFF
--- a/buffer_test.go
+++ b/buffer_test.go
@@ -201,7 +201,7 @@ func TestBuffer(t *testing.T) {
 							} {
 								t.Run(ordering.scenario, func(t *testing.T) {
 									schema := parquet.NewSchema("test", parquet.NewGroup(
-										map[string]parquet.Node{
+										parquet.GroupNodes{
 											"data": mod.function(parquet.Leaf(config.typ)),
 										},
 									))

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -200,9 +200,11 @@ func TestBuffer(t *testing.T) {
 								{scenario: "descending", sorting: parquet.Descending("data"), sortFunc: descending},
 							} {
 								t.Run(ordering.scenario, func(t *testing.T) {
-									schema := parquet.NewSchema("test", parquet.Group{
-										"data": mod.function(parquet.Leaf(config.typ)),
-									})
+									schema := parquet.NewSchema("test", parquet.NewGroup(
+										map[string]parquet.Node{
+											"data": mod.function(parquet.Leaf(config.typ)),
+										},
+									))
 
 									options := []parquet.RowGroupOption{
 										schema,

--- a/print_test.go
+++ b/print_test.go
@@ -13,196 +13,197 @@ func TestPrintSchema(t *testing.T) {
 		print string
 	}{
 		{
-			node: parquet.Group{"on": parquet.Leaf(parquet.BooleanType)},
+			node: parquet.NewGroup(
+				parquet.GroupNodes{"on": parquet.Leaf(parquet.BooleanType)}),
 			print: `message Test {
 	required boolean on;
 }`,
 		},
 
 		{
-			node: parquet.Group{"name": parquet.String()},
+			node: parquet.NewGroup(parquet.GroupNodes{"name": parquet.String()}),
 			print: `message Test {
 	required binary name (STRING);
 }`,
 		},
 
 		{
-			node: parquet.Group{"uuid": parquet.UUID()},
+			node: parquet.NewGroup(parquet.GroupNodes{"uuid": parquet.UUID()}),
 			print: `message Test {
 	required fixed_len_byte_array(16) uuid (UUID);
 }`,
 		},
 
 		{
-			node: parquet.Group{"enum": parquet.Enum()},
+			node: parquet.NewGroup(parquet.GroupNodes{"enum": parquet.Enum()}),
 			print: `message Test {
 	required binary enum (ENUM);
 }`,
 		},
 
 		{
-			node: parquet.Group{"json": parquet.JSON()},
+			node: parquet.NewGroup(parquet.GroupNodes{"json": parquet.JSON()}),
 			print: `message Test {
 	required binary json (JSON);
 }`,
 		},
 
 		{
-			node: parquet.Group{"bson": parquet.BSON()},
+			node: parquet.NewGroup(parquet.GroupNodes{"bson": parquet.BSON()}),
 			print: `message Test {
 	required binary bson (BSON);
 }`,
 		},
 
 		{
-			node: parquet.Group{"name": parquet.Optional(parquet.String())},
+			node: parquet.NewGroup(parquet.GroupNodes{"name": parquet.Optional(parquet.String())}),
 			print: `message Test {
 	optional binary name (STRING);
 }`,
 		},
 
 		{
-			node: parquet.Group{"name": parquet.Repeated(parquet.String())},
+			node: parquet.NewGroup(parquet.GroupNodes{"name": parquet.Repeated(parquet.String())}),
 			print: `message Test {
 	repeated binary name (STRING);
 }`,
 		},
 
 		{
-			node: parquet.Group{"age": parquet.Int(8)},
+			node: parquet.NewGroup(parquet.GroupNodes{"age": parquet.Int(8)}),
 			print: `message Test {
 	required int32 age (INT(8,true));
 }`,
 		},
 
 		{
-			node: parquet.Group{"age": parquet.Int(16)},
+			node: parquet.NewGroup(parquet.GroupNodes{"age": parquet.Int(16)}),
 			print: `message Test {
 	required int32 age (INT(16,true));
 }`,
 		},
 
 		{
-			node: parquet.Group{"age": parquet.Int(32)},
+			node: parquet.NewGroup(parquet.GroupNodes{"age": parquet.Int(32)}),
 			print: `message Test {
 	required int32 age (INT(32,true));
 }`,
 		},
 
 		{
-			node: parquet.Group{"age": parquet.Int(64)},
+			node: parquet.NewGroup(parquet.GroupNodes{"age": parquet.Int(64)}),
 			print: `message Test {
 	required int64 age (INT(64,true));
 }`,
 		},
 
 		{
-			node: parquet.Group{"age": parquet.Uint(8)},
+			node: parquet.NewGroup(parquet.GroupNodes{"age": parquet.Uint(8)}),
 			print: `message Test {
 	required int32 age (INT(8,false));
 }`,
 		},
 
 		{
-			node: parquet.Group{"age": parquet.Uint(16)},
+			node: parquet.NewGroup(parquet.GroupNodes{"age": parquet.Uint(16)}),
 			print: `message Test {
 	required int32 age (INT(16,false));
 }`,
 		},
 
 		{
-			node: parquet.Group{"age": parquet.Uint(32)},
+			node: parquet.NewGroup(parquet.GroupNodes{"age": parquet.Uint(32)}),
 			print: `message Test {
 	required int32 age (INT(32,false));
 }`,
 		},
 
 		{
-			node: parquet.Group{"age": parquet.Uint(64)},
+			node: parquet.NewGroup(parquet.GroupNodes{"age": parquet.Uint(64)}),
 			print: `message Test {
 	required int64 age (INT(64,false));
 }`,
 		},
 
 		{
-			node: parquet.Group{"ratio": parquet.Leaf(parquet.FloatType)},
+			node: parquet.NewGroup(parquet.GroupNodes{"ratio": parquet.Leaf(parquet.FloatType)}),
 			print: `message Test {
 	required float ratio;
 }`,
 		},
 
 		{
-			node: parquet.Group{"ratio": parquet.Leaf(parquet.DoubleType)},
+			node: parquet.NewGroup(parquet.GroupNodes{"ratio": parquet.Leaf(parquet.DoubleType)}),
 			print: `message Test {
 	required double ratio;
 }`,
 		},
 
 		{
-			node: parquet.Group{"cost": parquet.Decimal(0, 9, parquet.Int32Type)},
+			node: parquet.NewGroup(parquet.GroupNodes{"cost": parquet.Decimal(0, 9, parquet.Int32Type)}),
 			print: `message Test {
 	required int32 cost (DECIMAL(0,9));
 }`,
 		},
 
 		{
-			node: parquet.Group{"cost": parquet.Decimal(0, 18, parquet.Int64Type)},
+			node: parquet.NewGroup(parquet.GroupNodes{"cost": parquet.Decimal(0, 18, parquet.Int64Type)}),
 			print: `message Test {
 	required int64 cost (DECIMAL(0,18));
 }`,
 		},
 
 		{
-			node: parquet.Group{"date": parquet.Date()},
+			node: parquet.NewGroup(parquet.GroupNodes{"date": parquet.Date()}),
 			print: `message Test {
 	required int32 date (DATE);
 }`,
 		},
 
 		{
-			node: parquet.Group{"time": parquet.Time(parquet.Millisecond)},
+			node: parquet.NewGroup(parquet.GroupNodes{"time": parquet.Time(parquet.Millisecond)}),
 			print: `message Test {
 	required int32 time (TIME(isAdjustedToUTC=true,unit=MILLIS));
 }`,
 		},
 
 		{
-			node: parquet.Group{"time": parquet.Time(parquet.Microsecond)},
+			node: parquet.NewGroup(parquet.GroupNodes{"time": parquet.Time(parquet.Microsecond)}),
 			print: `message Test {
 	required int64 time (TIME(isAdjustedToUTC=true,unit=MICROS));
 }`,
 		},
 
 		{
-			node: parquet.Group{"time": parquet.Time(parquet.Nanosecond)},
+			node: parquet.NewGroup(parquet.GroupNodes{"time": parquet.Time(parquet.Nanosecond)}),
 			print: `message Test {
 	required int64 time (TIME(isAdjustedToUTC=true,unit=NANOS));
 }`,
 		},
 
 		{
-			node: parquet.Group{"timestamp": parquet.Timestamp(parquet.Millisecond)},
+			node: parquet.NewGroup(parquet.GroupNodes{"timestamp": parquet.Timestamp(parquet.Millisecond)}),
 			print: `message Test {
 	required int64 timestamp (TIMESTAMP(isAdjustedToUTC=true,unit=MILLIS));
 }`,
 		},
 
 		{
-			node: parquet.Group{"timestamp": parquet.Timestamp(parquet.Microsecond)},
+			node: parquet.NewGroup(parquet.GroupNodes{"timestamp": parquet.Timestamp(parquet.Microsecond)}),
 			print: `message Test {
 	required int64 timestamp (TIMESTAMP(isAdjustedToUTC=true,unit=MICROS));
 }`,
 		},
 
 		{
-			node: parquet.Group{"timestamp": parquet.Timestamp(parquet.Nanosecond)},
+			node: parquet.NewGroup(parquet.GroupNodes{"timestamp": parquet.Timestamp(parquet.Nanosecond)}),
 			print: `message Test {
 	required int64 timestamp (TIMESTAMP(isAdjustedToUTC=true,unit=NANOS));
 }`,
 		},
 
 		{
-			node: parquet.Group{"names": parquet.List(parquet.String())},
+			node: parquet.NewGroup(parquet.GroupNodes{"names": parquet.List(parquet.String())}),
 			print: `message Test {
 	required group names (LIST) {
 		repeated group list {
@@ -213,14 +214,14 @@ func TestPrintSchema(t *testing.T) {
 		},
 
 		{
-			node: parquet.Group{
+			node: parquet.NewGroup(parquet.GroupNodes{
 				"keys": parquet.List(
-					parquet.Group{
+					parquet.NewGroup(parquet.GroupNodes{
 						"key":   parquet.String(),
 						"value": parquet.String(),
-					},
+					}),
 				),
-			},
+			}),
 			print: `message Test {
 	required group keys (LIST) {
 		repeated group list {
@@ -234,12 +235,12 @@ func TestPrintSchema(t *testing.T) {
 		},
 
 		{
-			node: parquet.Group{
+			node: parquet.NewGroup(parquet.GroupNodes{
 				"pairs": parquet.Map(
 					parquet.String(),
 					parquet.String(),
 				),
-			},
+			}),
 			print: `message Test {
 	required group pairs (MAP) {
 		repeated group key_value {

--- a/schema.go
+++ b/schema.go
@@ -315,6 +315,7 @@ func structNodeOf(t reflect.Type) *structNode {
 		field.Node = makeNodeOf(fields[i].Type, fields[i].Name, []string{
 			fields[i].Tag.Get("parquet"),
 			fields[i].Tag.Get("parquet-key"),
+			fields[i].Tag.Get("parquet-value"),
 		})
 		s.fields[i] = field
 	}
@@ -521,16 +522,21 @@ func nodeOf(t reflect.Type, tag []string) Node {
 		}
 
 	case reflect.Map:
-		var valueTag, keyTag string
+		var mapTag, valueTag, keyTag string
 		if len(tag) > 0 {
-			valueTag = tag[0]
+			mapTag = tag[0]
 			if len(tag) > 1 {
 				keyTag = tag[1]
 			}
+			if len(tag) >= 2 {
+				valueTag = tag[2]
+			}
 		}
-		n = Map(
+
+		n = MapWith(
 			makeNodeOf(t.Key(), t.Name(), []string{keyTag}),
 			makeNodeOf(t.Elem(), t.Name(), []string{valueTag}),
+			groupWith(t, mapTag),
 		)
 
 	case reflect.Struct:

--- a/schema.go
+++ b/schema.go
@@ -82,8 +82,11 @@ type Schema struct {
 // and the data will not be written into the parquet file(s).
 // Note that a field with name "-" can still be generated using the tag "-,".
 //
-// Map key configuration can be pass using the `parquet-key` tag. This tag will follow the
-// same properties than the `parquet` tag.
+// The configuration of Parquet maps are done via two tags:
+//   - The `parquet-key` tag allows to configure the key of a map.
+//   - The `parquet-value` tag allows to configure the values of a map.
+//
+// When configuring a Parquet map, the `parquet` tag will configure map itself.
 //
 // For example, the following will set the int64 key of the map to be a timestamp:
 //

--- a/schema_test.go
+++ b/schema_test.go
@@ -139,6 +139,48 @@ func TestSchemaOf(t *testing.T) {
 	}
 }`,
 		},
+
+		{
+			value: new(struct {
+				A map[int64]string `parquet:",optional" parquet-value:",json"`
+			}),
+			print: `message {
+	optional group A (MAP) {
+		repeated group key_value {
+			required int64 key (INT(64,true));
+			required binary value (JSON);
+		}
+	}
+}`,
+		},
+
+		{
+			value: new(struct {
+				A map[int64]string `parquet:",optional"`
+			}),
+			print: `message {
+	optional group A (MAP) {
+		repeated group key_value {
+			required int64 key (INT(64,true));
+			required binary value (STRING);
+		}
+	}
+}`,
+		},
+
+		{
+			value: new(struct {
+				A map[int64]string `parquet:",optional" parquet-value:",json" parquet-key:",timestamp(microsecond)"`
+			}),
+			print: `message {
+	optional group A (MAP) {
+		repeated group key_value {
+			required int64 key (TIMESTAMP(isAdjustedToUTC=true,unit=MICROS));
+			required binary value (JSON);
+		}
+	}
+}`,
+		},
 	}
 
 	for _, test := range tests {

--- a/type.go
+++ b/type.go
@@ -1395,18 +1395,14 @@ func (t *timestampType) Decode(dst, src []byte, enc encoding.Encoding) ([]byte, 
 //
 // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists
 func List(of Node) Node {
-	l := listNode{
-		Group: Group{
-			nodes: map[string]Node{
-				"list": Repeated(Group{
-					nodes: map[string]Node{
-						"element": of,
-					},
-				}),
-			},
-		},
+	return listNode{
+		Group: NewGroup(GroupNodes{
+			"list": Repeated(NewGroup(GroupNodes{
+				"element": of,
+			})),
+
+		}),
 	}
-	return l
 }
 
 type listNode struct{ Group }


### PR DESCRIPTION
Fixes #280 

This change update the schema API with the following:
- The tag `parquet-value` is introduce and allows the configuration of the MAP values.
- The tag `parquet` will now configure the map (top level) itself.