### PR TITLE
optimize DELTA_LENGTH_BYTE_ARRAY decoding

### DIFF
--- a/encoding/delta/length_byte_array.go
+++ b/encoding/delta/length_byte_array.go
@@ -18,6 +18,10 @@ func (e *LengthByteArrayEncoding) Encoding() format.Encoding {
 }
 
 func (e *LengthByteArrayEncoding) EncodeByteArray(dst []byte, src []byte, offsets []uint32) ([]byte, error) {
+	if len(offsets) == 0 {
+		return dst[:0], nil
+	}
+
 	length := getInt32Buffer()
 	defer putInt32Buffer(length)
 
@@ -63,10 +67,4 @@ func (e *LengthByteArrayEncoding) wrap(err error) error {
 		err = encoding.Error(e, err)
 	}
 	return err
-}
-
-func encodeByteArrayLengths(lengths []int32, offsets []uint32) {
-	for i := range lengths {
-		lengths[i] = int32(offsets[i+1] - offsets[i])
-	}
 }

--- a/encoding/delta/length_byte_array_amd64.go
+++ b/encoding/delta/length_byte_array_amd64.go
@@ -1,0 +1,6 @@
+//go:build !purego
+
+package delta
+
+//go:noescape
+func decodeByteArrayLengths(offsets []uint32, lengths []int32) (lastOffset uint32, invalidLength int32)

--- a/encoding/delta/length_byte_array_amd64.go
+++ b/encoding/delta/length_byte_array_amd64.go
@@ -3,4 +3,7 @@
 package delta
 
 //go:noescape
+func encodeByteArrayLengths(lengths []int32, offsets []uint32)
+
+//go:noescape
 func decodeByteArrayLengths(offsets []uint32, lengths []int32) (lastOffset uint32, invalidLength int32)

--- a/encoding/delta/length_byte_array_amd64.s
+++ b/encoding/delta/length_byte_array_amd64.s
@@ -12,13 +12,14 @@ TEXT ·decodeByteArrayLengths(SB), NOSPLIT, $0-56
     XORQ DI, DI // invalidLength
     XORQ SI, SI
 
-    CMPQ BX, $4
-    JB test
+    CMPQ CX, $4
+    JL test
 
-    MOVQ CX, R9
-    SHRQ $2, R9
-    SHLQ $2, R9
+    MOVQ CX, R8
+    SHRQ $2, R8
+    SHLQ $2, R8
 
+    MOVL $0, (AX)
     PXOR X0, X0
     PXOR X3, X3
     // This loops computes the prefix sum of the lengths array in order to
@@ -48,12 +49,12 @@ loopSSE2:
     PADDD X2, X1
 
     PADDD X1, X0
-    MOVOU X0, (AX)(SI*4)
+    MOVOU X0, 4(AX)(SI*4)
 
     PSHUFD $0b11111111, X0, X0
 
     ADDQ $4, SI
-    CMPQ SI, R9
+    CMPQ SI, R8
     JNE loopSSE2
 
     // If any of the most significant bits of double words in the X3 register
@@ -63,11 +64,12 @@ loopSSE2:
     // TODO: we report the invalid length as -1, effectively losing the original
     // value due to the aggregation within X3. This is something that we might
     // want to address in the future to provide better error reporting.
-    MOVMSKPS X3, R9
-    MOVL $-1, R10
-    CMPL R9, $0
-    CMOVLNE R10, DI
+    MOVMSKPS X3, R8
+    MOVL $-1, R9
+    CMPL R8, $0
+    CMOVLNE R9, DI
 
+    MOVQ X0, DX
     JMP test
 loop:
     MOVL (BX)(SI*4), R8

--- a/encoding/delta/length_byte_array_amd64.s
+++ b/encoding/delta/length_byte_array_amd64.s
@@ -32,6 +32,9 @@ TEXT ·decodeByteArrayLengths(SB), NOSPLIT, $0-56
     // The X3 register also accumulates a mask of all length values, which is
     // checked after the loop to determine whether any of the lengths were
     // negative.
+    //
+    // The following article contains a description of the prefix sum algorithm
+    // used in this function: https://en.algorithmica.org/hpc/algorithms/prefix/
 loopSSE2:
     MOVOU (BX)(SI*4), X1
     POR X1, X3

--- a/encoding/delta/length_byte_array_amd64.s
+++ b/encoding/delta/length_byte_array_amd64.s
@@ -1,0 +1,83 @@
+//go:build !purego
+
+#include "textflag.h"
+
+// func decodeByteArrayLengths(offsets []uint32, length []int32) (lastOffset uint32, invalidLength int32)
+TEXT ·decodeByteArrayLengths(SB), NOSPLIT, $0-56
+    MOVQ offsets_base+0(FP), AX
+    MOVQ lengths_base+24(FP), BX
+    MOVQ lengths_len+32(FP), CX
+
+    XORQ DX, DX // lastOffset
+    XORQ DI, DI // invalidLength
+    XORQ SI, SI
+
+    CMPQ BX, $4
+    JB test
+
+    MOVQ CX, R9
+    SHRQ $2, R9
+    SHLQ $2, R9
+
+    PXOR X0, X0
+    PXOR X3, X3
+    // This loops computes the prefix sum of the lengths array in order to
+    // generate values of the offsets array.
+    //
+    // We stick to SSE2 to keep the code simple (the Go compiler appears to
+    // assume that SSE2 must be supported on AMD64) which already yields most
+    // of the performance that we could get on this subroutine if we were using
+    // AVX2.
+    //
+    // The X3 register also accumulates a mask of all length values, which is
+    // checked after the loop to determine whether any of the lengths were
+    // negative.
+loopSSE2:
+    MOVOU (BX)(SI*4), X1
+    POR X1, X3
+
+    MOVOA X1, X2
+    PSLLDQ $4, X2
+    PADDD X2, X1
+
+    MOVOA X1, X2
+    PSLLDQ $8, X2
+    PADDD X2, X1
+
+    PADDD X1, X0
+    MOVOU X0, (AX)(SI*4)
+
+    PSHUFD $0b11111111, X0, X0
+
+    ADDQ $4, SI
+    CMPQ SI, R9
+    JNE loopSSE2
+
+    // If any of the most significant bits of double words in the X3 register
+    // are set to 1, it indicates that one of the lengths was negative and
+    // therefore the prefix sum is invalid.
+    //
+    // TODO: we report the invalid length as -1, effectively losing the original
+    // value due to the aggregation within X3. This is something that we might
+    // want to address in the future to provide better error reporting.
+    MOVMSKPS X3, R9
+    MOVL $-1, R10
+    CMPL R9, $0
+    CMOVLNE R10, DI
+
+    JMP test
+loop:
+    MOVL (BX)(SI*4), R8
+    MOVL DX, (AX)(SI*4)
+    ADDL R8, DX
+    CMPL R8, $0
+    CMOVLLT R8, DI
+    INCQ SI
+test:
+    CMPQ SI, CX
+    JNE loop
+
+    MOVL DX, (AX)(SI*4)
+    MOVL DX, lastOffset+48(FP)
+    MOVL DI, invalidLength+52(FP)
+    RET

--- a/encoding/delta/length_byte_array_amd64.s
+++ b/encoding/delta/length_byte_array_amd64.s
@@ -22,7 +22,7 @@ TEXT ·decodeByteArrayLengths(SB), NOSPLIT, $0-56
     MOVL $0, (AX)
     PXOR X0, X0
     PXOR X3, X3
-    // This loops computes the prefix sum of the lengths array in order to
+    // This loop computes the prefix sum of the lengths array in order to
     // generate values of the offsets array.
     //
     // We stick to SSE2 to keep the code simple (the Go compiler appears to

--- a/encoding/delta/length_byte_array_purego.go
+++ b/encoding/delta/length_byte_array_purego.go
@@ -1,0 +1,18 @@
+//go:build purego || !amd64
+
+package delta
+
+func decodeByteArrayLengths(offsets []uint32, lengths []int32) (uint32, int32) {
+	lastOffset := uint32(0)
+
+	for i, n := range lengths {
+		if n < 0 {
+			return lastOffset, n
+		}
+		offsets[i] = lastOffset
+		lastOffset += uint32(n)
+	}
+
+	offsets[len(lengths)] = lastOffset
+	return lastOffset, 0
+}

--- a/encoding/delta/length_byte_array_purego.go
+++ b/encoding/delta/length_byte_array_purego.go
@@ -2,6 +2,12 @@
 
 package delta
 
+func encodeByteArrayLengths(lengths []int32, offsets []uint32) {
+	for i := range lengths {
+		lengths[i] = int32(offsets[i+1] - offsets[i])
+	}
+}
+
 func decodeByteArrayLengths(offsets []uint32, lengths []int32) (uint32, int32) {
 	lastOffset := uint32(0)
 

--- a/encoding/delta/length_byte_array_test.go
+++ b/encoding/delta/length_byte_array_test.go
@@ -1,0 +1,34 @@
+package delta
+
+import "testing"
+
+func TestDecodeByteArrayLengths(t *testing.T) {
+	lengths := make([]int32, 999)
+	offsets := make([]uint32, len(lengths)+1)
+
+	totalLength := uint32(0)
+	for i := range lengths {
+		lengths[i] = int32(i)
+		totalLength += uint32(i)
+	}
+
+	lastOffset, invalidLength := decodeByteArrayLengths(offsets, lengths)
+	if invalidLength != 0 {
+		t.Fatal("wrong invalid length:", invalidLength)
+	}
+	if lastOffset != totalLength {
+		t.Fatalf("wrong last offset: want=%d got=%d", lastOffset, totalLength)
+	}
+
+	expectOffset := uint32(0)
+	for i, offset := range offsets[:len(lengths)] {
+		if offset != expectOffset {
+			t.Fatalf("wrong offset at index %d: want=%d got=%d", i, expectOffset, offset)
+		}
+		expectOffset += uint32(lengths[i])
+	}
+
+	if offsets[len(lengths)] != lastOffset {
+		t.Fatalf("wrong last offset: want=%d got=%d", lastOffset, offsets[len(lengths)])
+	}
+}


### PR DESCRIPTION
Follow up to #289, this PR optimizes the decoding of DELTA_LENGTH_BYTE_ARRAY pages.

We get ~2x better throughput with this change compared to the parent branch:
```
name                                       old time/op    new time/op    delta
Decode/DELTA_LENGTH_BYTE_ARRAY/byte_array    24.0µs ± 0%    12.0µs ± 0%   -50.07%  (p=0.000 n=10+10)

name                                       old speed      new speed      delta
Decode/DELTA_LENGTH_BYTE_ARRAY/byte_array  4.53GB/s ± 0%  9.07GB/s ± 0%  +100.28%  (p=0.000 n=10+10)

name                                       old value/s    new value/s    delta
Decode/DELTA_LENGTH_BYTE_ARRAY/byte_array      416M ± 0%      834M ± 0%  +100.29%  (p=0.000 n=10+10)
```