### PR TITLE
optimize DELTA_LENGTH_BYTE_ARRAY encoding

### DIFF
--- a/encoding/delta/length_byte_array.go
+++ b/encoding/delta/length_byte_array.go
@@ -18,6 +18,10 @@ func (e *LengthByteArrayEncoding) Encoding() format.Encoding {
 }
 
 func (e *LengthByteArrayEncoding) EncodeByteArray(dst []byte, src []byte, offsets []uint32) ([]byte, error) {
+	if len(offsets) == 0 {
+		return dst[:0], nil
+	}
+
 	length := getInt32Buffer()
 	defer putInt32Buffer(length)
 
@@ -63,10 +67,4 @@ func (e *LengthByteArrayEncoding) wrap(err error) error {
 		err = encoding.Error(e, err)
 	}
 	return err
-}
-
-func encodeByteArrayLengths(lengths []int32, offsets []uint32) {
-	for i := range lengths {
-		lengths[i] = int32(offsets[i+1] - offsets[i])
-	}
 }

--- a/encoding/delta/length_byte_array_amd64.go
+++ b/encoding/delta/length_byte_array_amd64.go
@@ -3,4 +3,7 @@
 package delta
 
 //go:noescape
+func encodeByteArrayLengths(lengths []int32, offsets []uint32)
+
+//go:noescape
 func decodeByteArrayLengths(offsets []uint32, lengths []int32) (lastOffset uint32, invalidLength int32)

--- a/encoding/delta/length_byte_array_purego.go
+++ b/encoding/delta/length_byte_array_purego.go
@@ -2,6 +2,12 @@
 
 package delta
 
+func encodeByteArrayLengths(lengths []int32, offsets []uint32) {
+	for i := range lengths {
+		lengths[i] = int32(offsets[i+1] - offsets[i])
+	}
+}
+
 func decodeByteArrayLengths(offsets []uint32, lengths []int32) (uint32, int32) {
 	lastOffset := uint32(0)
 


### PR DESCRIPTION
Follow up to https://github.com/segmentio/parquet-go/pull/289, this PR optimizes the encoding of DELTA_LENGTH_BYTE_ARRAY pages.

```
name                                       old time/op    new time/op    delta
Encode/DELTA_LENGTH_BYTE_ARRAY/byte_array    18.2µs ± 0%    13.7µs ± 0%  -24.95%  (p=0.000 n=10+10)

name                                       old speed      new speed      delta
Encode/DELTA_LENGTH_BYTE_ARRAY/byte_array  5.97GB/s ± 0%  7.96GB/s ± 0%  +33.24%  (p=0.000 n=10+10)

name                                       old value/s    new value/s    delta
Encode/DELTA_LENGTH_BYTE_ARRAY/byte_array      549M ± 0%      731M ± 0%  +33.24%  (p=0.000 n=10+10)
```