### PR TITLE
optimize DELTA_BYTE_ARRAY decoding

### DIFF
--- a/encoding/delta/byte_array.go
+++ b/encoding/delta/byte_array.go
@@ -204,34 +204,3 @@ func binarySearchPrefixLength(base, data []byte) int {
 		return !bytes.Equal(base[:i+1], data[:i+1])
 	})
 }
-
-func decodeByteArray(dst, src []byte, prefix, suffix []int32, offsets []uint32) ([]byte, []uint32, error) {
-	_ = prefix[:len(suffix)]
-	_ = suffix[:len(prefix)]
-
-	var lastValue []byte
-	for i := range suffix {
-		n := int(suffix[i])
-		p := int(prefix[i])
-		if n < 0 {
-			return dst, offsets, errInvalidNegativeValueLength(n)
-		}
-		if n > len(src) {
-			return dst, offsets, errValueLengthOutOfBounds(n, len(src))
-		}
-		if p < 0 {
-			return dst, offsets, errInvalidNegativePrefixLength(p)
-		}
-		if p > len(lastValue) {
-			return dst, offsets, errPrefixLengthOutOfBounds(p, len(lastValue))
-		}
-		j := len(dst)
-		offsets = append(offsets, uint32(j))
-		dst = append(dst, lastValue[:p]...)
-		dst = append(dst, src[:n]...)
-		lastValue = dst[j:]
-		src = src[n:]
-	}
-
-	return dst, append(offsets, uint32(len(dst))), nil
-}

--- a/encoding/delta/byte_array_amd64.go
+++ b/encoding/delta/byte_array_amd64.go
@@ -48,20 +48,29 @@ func validatePrefixAndSuffixLengthValues(prefix, suffix []int32, maxLength int) 
 }
 
 //go:noescape
+func decodeByteArrayOffsets(offsets []uint32, prefix, suffix []int32)
+
+//go:noescape
 func decodeByteArrayAVX2(dst, src []byte, prefix, suffix []int32) int
 
-/*
-func decodeByteArray(dst, src []byte, prefix, suffix []int32) ([]byte, error) {
+func decodeByteArray(dst, src []byte, prefix, suffix []int32, offsets []uint32) ([]byte, []uint32, error) {
 	totalPrefixLength, totalSuffixLength, err := validatePrefixAndSuffixLengthValues(prefix, suffix, len(src))
 	if err != nil {
-		return dst, err
+		return dst, offsets, err
 	}
 
-	totalLength := plain.ByteArrayLengthSize*len(prefix) + totalPrefixLength + totalSuffixLength
+	totalLength := totalPrefixLength + totalSuffixLength
 	dst = resizeNoMemclr(dst, totalLength+padding)
+
+	if size := len(prefix) + 1; cap(offsets) < size {
+		offsets = make([]uint32, size)
+	} else {
+		offsets = offsets[:size]
+	}
 
 	_ = prefix[:len(suffix)]
 	_ = suffix[:len(prefix)]
+	decodeByteArrayOffsets(offsets, prefix, suffix)
 
 	var lastValue []byte
 	var i int
@@ -88,24 +97,18 @@ func decodeByteArray(dst, src []byte, prefix, suffix []int32) ([]byte, error) {
 	for k := range prefix {
 		p := int(prefix[k])
 		n := int(suffix[k])
-		plain.PutByteArrayLength(dst[i:], p+n)
-		i += plain.ByteArrayLengthSize
-		k := i
+		lastValueOffset := i
 		i += copy(dst[i:], lastValue[:p])
 		i += copy(dst[i:], src[j:j+n])
 		j += n
-		lastValue = dst[k:]
+		lastValue = dst[lastValueOffset:]
 	}
 
-	return dst[:totalLength], nil
+	return dst[:totalLength], offsets, nil
 }
-*/
 
 //go:noescape
-func decodeFixedLenByteArrayAVX2(dst, src []byte, prefix, suffix []int32) int
-
-//go:noescape
-func decodeFixedLenByteArrayAVX2x128bits(dst, src []byte, prefix, suffix []int32) int
+func decodeByteArrayAVX2x128bits(dst, src []byte, prefix, suffix []int32) int
 
 func decodeFixedLenByteArray(dst, src []byte, size int, prefix, suffix []int32) ([]byte, error) {
 	totalPrefixLength, totalSuffixLength, err := validatePrefixAndSuffixLengthValues(prefix, suffix, len(src))
@@ -134,9 +137,9 @@ func decodeFixedLenByteArray(dst, src []byte, size int, prefix, suffix []int32) 
 
 		if k > 0 && n >= padding {
 			if size == 16 {
-				i = decodeFixedLenByteArrayAVX2x128bits(dst, src, prefix[:k], suffix[:k])
+				i = decodeByteArrayAVX2x128bits(dst, src, prefix[:k], suffix[:k])
 			} else {
-				i = decodeFixedLenByteArrayAVX2(dst, src, prefix[:k], suffix[:k])
+				i = decodeByteArrayAVX2(dst, src, prefix[:k], suffix[:k])
 			}
 			j = len(src) - n
 			prefix = prefix[k:]

--- a/encoding/delta/byte_array_amd64.s
+++ b/encoding/delta/byte_array_amd64.s
@@ -122,73 +122,31 @@ done:
     MOVB R12, ok+72(FP)
     RET
 
-// func decodeByteArrayAVX2(dst, src []byte, prefix, suffix []int32) int
-TEXT ·decodeByteArrayAVX2(SB), NOSPLIT, $0-104
-    MOVQ dst_base+0(FP), AX
-    MOVQ src_base+24(FP), BX
-    MOVQ prefix_base+48(FP), CX
-    MOVQ suffix_base+72(FP), DX
-    MOVQ suffix_len+80(FP), DI
+// func decodeByteArrayOffsets(offsets []uint32, prefix, suffix []int32)
+TEXT ·decodeByteArrayOffsets(SB), NOSPLIT, $0-72
+    MOVQ offsets_base+0(FP), AX
+    MOVQ prefix_base+24(FP), BX
+    MOVQ suffix_base+48(FP), CX
+    MOVQ suffix_len+56(FP), DX
 
-    ADDQ $4, AX
     XORQ SI, SI
-    XORQ R8, R8
-    XORQ R9, R9
-    MOVQ AX, R10 // last value
-
+    XORQ R10, R10
     JMP test
 loop:
-    MOVLQZX (CX)(SI*4), R8 // prefix length
-    MOVLQZX (DX)(SI*4), R9 // suffix length
-    MOVQ R8, R11
-    ADDQ R9, R11
-    MOVL R11, -4(AX)
-prefix:
-    VMOVDQU (R10), X0
-    VMOVDQU X0, (AX)
-    CMPQ R8, $16
-    JA copyPrefix
-suffix:
-    VMOVDQU (BX), X1
-    VMOVDQU X1, (AX)(R8*1)
-    CMPQ R9, $16
-    JA copySuffix
-next:
-    MOVQ AX, R10
-    LEAQ 4(AX)(R11*1), AX
-    LEAQ 0(BX)(R9*1), BX
+    MOVL (BX)(SI*4), R8
+    MOVL (CX)(SI*4), R9
+    MOVL R10, (AX)(SI*4)
+    ADDL R8, R10
+    ADDL R9, R10
     INCQ SI
 test:
-    CMPQ SI, DI
+    CMPQ SI, DX
     JNE loop
-    MOVQ dst_base+0(FP), BX
-    SUBQ BX, AX
-    SUBQ $4, AX
-    MOVQ AX, ret+96(FP)
-    VZEROUPPER
+    MOVL R10, (AX)(SI*4)
     RET
-copyPrefix:
-    MOVQ $16, R12
-copyPrefixLoop:
-    VMOVDQU (R10)(R12*1), Y0
-    VMOVDQU Y0, (AX)(R12*1)
-    ADDQ $32, R12
-    CMPQ R12, R8
-    JB copyPrefixLoop
-    JMP suffix
-copySuffix:
-    MOVQ $16, R12
-    LEAQ (AX)(R8*1), R13
-copySuffixLoop:
-    VMOVDQU (BX)(R12*1), Y1
-    VMOVDQU Y1, (R13)(R12*1)
-    ADDQ $32, R12
-    CMPQ R12, R9
-    JB copySuffixLoop
-    JMP next
 
-// func decodeFixedLenByteArrayAVX2(dst, src []byte, prefix, suffix []int32) int
-TEXT ·decodeFixedLenByteArrayAVX2(SB), NOSPLIT, $0-104
+// func decodeByteArrayAVX2(dst, src []byte, prefix, suffix []int32) int
+TEXT ·decodeByteArrayAVX2(SB), NOSPLIT, $0-104
     MOVQ dst_base+0(FP), AX
     MOVQ src_base+24(FP), BX
     MOVQ prefix_base+48(FP), CX
@@ -248,8 +206,8 @@ copySuffixLoop:
     JB copySuffixLoop
     JMP next
 
-// func decodeFixedLenByteArrayAVX2x128bits(dst, src []byte, prefix, suffix []int32) int
-TEXT ·decodeFixedLenByteArrayAVX2x128bits(SB), NOSPLIT, $0-104
+// func decodeByteArrayAVX2x128bits(dst, src []byte, prefix, suffix []int32) int
+TEXT ·decodeByteArrayAVX2x128bits(SB), NOSPLIT, $0-104
     MOVQ dst_base+0(FP), AX
     MOVQ src_base+24(FP), BX
     MOVQ prefix_base+48(FP), CX

--- a/encoding/delta/byte_array_purego.go
+++ b/encoding/delta/byte_array_purego.go
@@ -2,6 +2,37 @@
 
 package delta
 
+func decodeByteArray(dst, src []byte, prefix, suffix []int32, offsets []uint32) ([]byte, []uint32, error) {
+	_ = prefix[:len(suffix)]
+	_ = suffix[:len(prefix)]
+
+	var lastValue []byte
+	for i := range suffix {
+		n := int(suffix[i])
+		p := int(prefix[i])
+		if n < 0 {
+			return dst, offsets, errInvalidNegativeValueLength(n)
+		}
+		if n > len(src) {
+			return dst, offsets, errValueLengthOutOfBounds(n, len(src))
+		}
+		if p < 0 {
+			return dst, offsets, errInvalidNegativePrefixLength(p)
+		}
+		if p > len(lastValue) {
+			return dst, offsets, errPrefixLengthOutOfBounds(p, len(lastValue))
+		}
+		j := len(dst)
+		offsets = append(offsets, uint32(j))
+		dst = append(dst, lastValue[:p]...)
+		dst = append(dst, src[:n]...)
+		lastValue = dst[j:]
+		src = src[n:]
+	}
+
+	return dst, append(offsets, uint32(len(dst))), nil
+}
+
 func decodeFixedLenByteArray(dst, src []byte, size int, prefix, suffix []int32) ([]byte, error) {
 	_ = prefix[:len(suffix)]
 	_ = suffix[:len(prefix)]


### PR DESCRIPTION
Follow up to https://github.com/segmentio/parquet-go/pull/289, this PR optimizes the decoding of DELTA_BYTE_ARRAY pages.

An interesting consequence of changing the in-memory representation of byte array values is we are able to merge the `decodeByteArrayAVX2` and `decodeFixedLenByteArrayAVX2` functions into one since the memory layout is now the same for variable and fixed length values. Less code to maintain, less opportunities for bugs, and more efficiency!

```
name                                old time/op   new time/op    delta
Decode/DELTA_BYTE_ARRAY/byte_array    131µs ± 0%      37µs ± 0%   -71.54%  (p=0.000 n=10+10)

name                                old speed     new speed      delta
Decode/DELTA_BYTE_ARRAY/byte_array  831MB/s ± 0%  2918MB/s ± 0%  +251.36%  (p=0.000 n=10+10)

name                                old value/s   new value/s    delta
Decode/DELTA_BYTE_ARRAY/byte_array    76.4M ± 0%    268.3M ± 0%  +251.35%  (p=0.000 n=10+10)
```