### PR TITLE
Refactor reading of parquet pages

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -2,6 +2,8 @@ package parquet
 
 import (
 	"sort"
+	"sync"
+	"sync/atomic"
 )
 
 // Buffer represents an in-memory group of parquet rows.
@@ -282,3 +284,158 @@ var (
 	_ PageWriter  = (*bufferWriter)(nil)
 	_ ValueWriter = (*bufferWriter)(nil)
 )
+
+type buffer struct {
+	data []byte
+	refc uintptr
+	pool *bufferPool
+}
+
+func newBuffer(data []byte) *buffer {
+	return &buffer{data: data, refc: 1}
+}
+
+func (b *buffer) ref() {
+	atomic.AddUintptr(&b.refc, +1)
+}
+
+func (b *buffer) unref() {
+	if atomic.AddUintptr(&b.refc, ^uintptr(0)) == 0 {
+		if b.pool != nil {
+			b.pool.put(b)
+		}
+	}
+}
+
+func (b *buffer) reset() {
+	b.data = b.data[:0]
+}
+
+func (b *buffer) resize(size int) {
+	if cap(b.data) < size {
+		const pageSize = 4096
+		minSize := 2 * cap(b.data)
+		bufferSize := ((size + (pageSize - 1)) / pageSize) * pageSize
+		if bufferSize < minSize {
+			bufferSize = minSize
+		}
+		b.data = make([]byte, size, bufferSize)
+	} else {
+		b.data = b.data[:size]
+	}
+}
+
+func (b *buffer) clone() (clone *buffer) {
+	if b.pool != nil {
+		clone = b.pool.get()
+	} else {
+		clone = &buffer{refc: 1}
+	}
+	clone.data = append(clone.data, b.data...)
+	return clone
+}
+
+type bufferRef struct {
+	buf *buffer
+	off int
+	len int
+}
+
+func makeBufferRef(buf *buffer) (ref bufferRef) {
+	if buf != nil {
+		buf.ref()
+		ref.buf = buf
+		ref.len = len(buf.data)
+	}
+	return ref
+}
+
+func (r *bufferRef) data() []byte {
+	if r.buf != nil {
+		i := r.off
+		j := r.off + r.len
+		return r.buf.data[i:j:j]
+	}
+	return nil
+}
+
+func (r *bufferRef) ref() bufferRef {
+	if r.buf != nil {
+		r.buf.ref()
+	}
+	return *r
+}
+
+func (r *bufferRef) unref() {
+	if r.buf != nil {
+		r.buf.unref()
+		r.buf = nil
+	}
+}
+
+func (r *bufferRef) slice(i, j int) bufferRef {
+	if r.buf != nil {
+		r.buf.ref()
+	}
+	return bufferRef{buf: r.buf, off: r.off + i, len: j - i}
+}
+
+func (r *bufferRef) clone() (clone bufferRef) {
+	clone.off = r.off
+	clone.len = r.len
+	if r.buf != nil {
+		clone.buf = r.buf.clone()
+	}
+	return clone
+}
+
+type bufferPool struct {
+	pool sync.Pool
+}
+
+func (p *bufferPool) get() *buffer {
+	b, _ := p.pool.Get().(*buffer)
+	if b == nil {
+		b = &buffer{pool: p}
+	} else {
+		b.reset()
+	}
+	b.ref()
+	return b
+}
+
+func (p *bufferPool) put(b *buffer) {
+	if b.pool != p {
+		panic("BUG: buffer returned to a different pool than the one it was allocated from")
+	}
+	p.pool.Put(b)
+}
+
+var (
+	levelsBufferPool           bufferPool
+	compressedPageBufferPool   bufferPool
+	uncompressedPageBufferPool bufferPool
+	pageOffsetsBufferPool      bufferPool
+	pageValuesBufferPool       [8]bufferPool
+)
+
+type bufferedPage struct {
+	Page
+	values  bufferRef
+	offsets bufferRef
+}
+
+func (p *bufferedPage) Slice(i, j int64) Page {
+	return &bufferedPage{
+		Page:    p.Page.Slice(i, j),
+		values:  p.values.ref(),
+		offsets: p.offsets.ref(),
+	}
+}
+
+func unref(page Page) {
+	if p, _ := page.(*bufferedPage); p != nil {
+		p.values.unref()
+		p.offsets.unref()
+	}
+}

--- a/column.go
+++ b/column.go
@@ -598,9 +598,9 @@ func (c *Column) decodeDataPage(header DataPageHeader, numValues int64, repetiti
 	newPage := pageType.NewPage(c.Index(), int(numValues), values)
 	switch {
 	case c.maxRepetitionLevel > 0:
-		newPage = newRepeatedPage(newPage.Buffer(), c.maxRepetitionLevel, c.maxDefinitionLevel, repetitionLevels, definitionLevels)
+		newPage = newRepeatedPage(newPage, c.maxRepetitionLevel, c.maxDefinitionLevel, repetitionLevels, definitionLevels)
 	case c.maxDefinitionLevel > 0:
-		newPage = newOptionalPage(newPage.Buffer(), c.maxDefinitionLevel, definitionLevels)
+		newPage = newOptionalPage(newPage, c.maxDefinitionLevel, definitionLevels)
 	}
 	return newPage, nil
 }

--- a/column.go
+++ b/column.go
@@ -10,6 +10,7 @@ import (
 	"github.com/segmentio/parquet-go/deprecated"
 	"github.com/segmentio/parquet-go/encoding"
 	"github.com/segmentio/parquet-go/format"
+	"github.com/segmentio/parquet-go/internal/unsafecast"
 )
 
 // Column represents a column in a parquet file.
@@ -486,97 +487,114 @@ func schemaRepetitionTypeOf(s *format.SchemaElement) format.FieldRepetitionType 
 	return format.Required
 }
 
-func (c *Column) decompress(data []byte, size int32) ([]byte, error) {
-	var page []byte
-	if size > 0 {
-		page = make([]byte, size)
+func (c *Column) decompress(compressedPageData []byte, uncompressedPageSize int32) (page *buffer, err error) {
+	page = uncompressedPageBufferPool.get()
+	if uncompressedPageSize > 0 {
+		page.resize(int(uncompressedPageSize))
 	}
-	return c.compression.Decode(page, data)
+	page.data, err = c.compression.Decode(page.data, compressedPageData)
+	if err != nil {
+		page.unref()
+		page = nil
+	}
+	return page, err
 }
 
 // DecodeDataPageV1 decodes a data page from the header, compressed data, and
 // optional dictionary passed as arguments.
-func (c *Column) DecodeDataPageV1(header DataPageHeaderV1, data []byte, dict Dictionary) (Page, error) {
-	return c.decodeDataPageV1(header, data, dict, -1)
+func (c *Column) DecodeDataPageV1(header DataPageHeaderV1, page []byte, dict Dictionary) (Page, error) {
+	return c.decodeDataPageV1(header, &buffer{data: page}, dict, -1)
 }
 
-func (c *Column) decodeDataPageV1(header DataPageHeaderV1, data []byte, dict Dictionary, size int32) (Page, error) {
+func (c *Column) decodeDataPageV1(header DataPageHeaderV1, page *buffer, dict Dictionary, size int32) (Page, error) {
+	var pageData = page.data
 	var err error
 
 	if isCompressed(c.compression) {
-		if data, err = c.decompress(data, size); err != nil {
+		if page, err = c.decompress(pageData, size); err != nil {
 			return nil, fmt.Errorf("decompressing data page v1: %w", err)
 		}
+		defer page.unref()
+		pageData = page.data
 	}
 
-	var numValues = header.NumValues()
-	var repetitionLevels []byte
-	var definitionLevels []byte
+	var numValues = int(header.NumValues())
+	var repetitionLevels *buffer
+	var definitionLevels *buffer
 
 	if c.maxRepetitionLevel > 0 {
 		encoding := lookupLevelEncoding(header.RepetitionLevelEncoding(), c.maxRepetitionLevel)
-		repetitionLevels, data, err = decodeLevelsV1(encoding, numValues, data)
+		repetitionLevels, pageData, err = decodeLevelsV1(encoding, numValues, pageData)
 		if err != nil {
 			return nil, fmt.Errorf("decoding repetition levels of data page v1: %w", err)
 		}
+		defer repetitionLevels.unref()
 	}
 
 	if c.maxDefinitionLevel > 0 {
 		encoding := lookupLevelEncoding(header.DefinitionLevelEncoding(), c.maxDefinitionLevel)
-		definitionLevels, data, err = decodeLevelsV1(encoding, numValues, data)
+		definitionLevels, pageData, err = decodeLevelsV1(encoding, numValues, pageData)
 		if err != nil {
 			return nil, fmt.Errorf("decoding definition levels of data page v1: %w", err)
 		}
+		defer definitionLevels.unref()
 
 		// Data pages v1 did not embed the number of null values,
 		// so we have to compute it from the definition levels.
-		numValues -= int64(countLevelsNotEqual(definitionLevels, c.maxDefinitionLevel))
+		numValues -= countLevelsNotEqual(definitionLevels.data, c.maxDefinitionLevel)
 	}
 
-	return c.decodeDataPage(header, numValues, repetitionLevels, definitionLevels, data, dict)
+	page = &buffer{data: pageData}
+	return c.decodeDataPage(header, numValues, repetitionLevels, definitionLevels, page, dict)
 }
 
 // DecodeDataPageV2 decodes a data page from the header, compressed data, and
 // optional dictionary passed as arguments.
-func (c *Column) DecodeDataPageV2(header DataPageHeaderV2, data []byte, dict Dictionary) (Page, error) {
-	return c.decodeDataPageV2(header, data, dict, -1)
+func (c *Column) DecodeDataPageV2(header DataPageHeaderV2, page []byte, dict Dictionary) (Page, error) {
+	return c.decodeDataPageV2(header, &buffer{data: page}, dict, -1)
 }
 
-func (c *Column) decodeDataPageV2(header DataPageHeaderV2, data []byte, dict Dictionary, size int32) (Page, error) {
-	var numValues = header.NumValues()
+func (c *Column) decodeDataPageV2(header DataPageHeaderV2, page *buffer, dict Dictionary, size int32) (Page, error) {
+	var numValues = int(header.NumValues())
+	var pageData = page.data
 	var err error
-	var repetitionLevels []byte
-	var definitionLevels []byte
+	var repetitionLevels *buffer
+	var definitionLevels *buffer
 
 	if c.maxRepetitionLevel > 0 {
 		encoding := lookupLevelEncoding(header.RepetitionLevelEncoding(), c.maxRepetitionLevel)
 		length := header.RepetitionLevelsByteLength()
-		repetitionLevels, data, err = decodeLevelsV2(encoding, numValues, data, length)
+		repetitionLevels, pageData, err = decodeLevelsV2(encoding, numValues, pageData, length)
 		if err != nil {
 			return nil, fmt.Errorf("decoding repetition levels of data page v2: %w", io.ErrUnexpectedEOF)
 		}
+		defer repetitionLevels.unref()
 	}
 
 	if c.maxDefinitionLevel > 0 {
 		encoding := lookupLevelEncoding(header.DefinitionLevelEncoding(), c.maxDefinitionLevel)
 		length := header.DefinitionLevelsByteLength()
-		definitionLevels, data, err = decodeLevelsV2(encoding, numValues, data, length)
+		definitionLevels, pageData, err = decodeLevelsV2(encoding, numValues, pageData, length)
 		if err != nil {
 			return nil, fmt.Errorf("decoding definition levels of data page v2: %w", io.ErrUnexpectedEOF)
 		}
+		defer definitionLevels.unref()
 	}
 
 	if isCompressed(c.compression) && header.IsCompressed() {
-		if data, err = c.decompress(data, size); err != nil {
+		if page, err = c.decompress(pageData, size); err != nil {
 			return nil, fmt.Errorf("decompressing data page v2: %w", err)
 		}
+		defer page.unref()
+	} else {
+		page = &buffer{data: pageData}
 	}
 
-	numValues -= header.NumNulls()
-	return c.decodeDataPage(header, numValues, repetitionLevels, definitionLevels, data, dict)
+	numValues -= int(header.NumNulls())
+	return c.decodeDataPage(header, numValues, repetitionLevels, definitionLevels, page, dict)
 }
 
-func (c *Column) decodeDataPage(header DataPageHeader, numValues int64, repetitionLevels, definitionLevels, data []byte, dict Dictionary) (Page, error) {
+func (c *Column) decodeDataPage(header DataPageHeader, numValues int, repetitionLevels, definitionLevels, page *buffer, dict Dictionary) (Page, error) {
 	pageEncoding := LookupEncoding(header.Encoding())
 	pageType := c.Type()
 
@@ -589,23 +607,64 @@ func (c *Column) decodeDataPage(header DataPageHeader, numValues int64, repetiti
 		pageType = indexedPageType{newIndexedType(pageType, dict)}
 	}
 
-	values := pageType.NewValues(nil, nil)
-	values, err := pageType.Decode(values, data, pageEncoding)
+	var vbuf, obuf *buffer
+	var pageValues []byte
+	var pageOffsets []uint32
+
+	pageKind := pageType.Kind()
+	if pageKind >= 0 && int(pageKind) < len(pageValuesBufferPool) {
+		vbuf = pageValuesBufferPool[pageKind].get()
+		defer vbuf.unref()
+		vbuf.resize(int(pageType.EstimateSize(numValues)))
+		pageValues = vbuf.data
+	}
+	if pageKind == ByteArray {
+		obuf = pageOffsetsBufferPool.get()
+		defer obuf.unref()
+		obuf.resize(4 * (numValues + 1))
+		pageOffsets = unsafecast.BytesToUint32(obuf.data)
+	}
+
+	values := pageType.NewValues(pageValues, pageOffsets)
+	values, err := pageType.Decode(values, page.data, pageEncoding)
+
+	pageValues, pageOffsets = values.Data()
+	if vbuf != nil {
+		vbuf.data = pageValues
+	}
+	if obuf != nil {
+		obuf.data = unsafecast.Uint32ToBytes(pageOffsets)
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	newPage := pageType.NewPage(c.Index(), int(numValues), values)
+	newPage := pageType.NewPage(c.Index(), numValues, values)
 	switch {
 	case c.maxRepetitionLevel > 0:
-		newPage = newRepeatedPage(newPage, c.maxRepetitionLevel, c.maxDefinitionLevel, repetitionLevels, definitionLevels)
+		newPage = newRepeatedPage(
+			newPage,
+			c.maxRepetitionLevel,
+			c.maxDefinitionLevel,
+			makeBufferRef(repetitionLevels),
+			makeBufferRef(definitionLevels),
+		)
 	case c.maxDefinitionLevel > 0:
-		newPage = newOptionalPage(newPage, c.maxDefinitionLevel, definitionLevels)
+		newPage = newOptionalPage(
+			newPage,
+			c.maxDefinitionLevel,
+			makeBufferRef(definitionLevels),
+		)
+	}
+	newPage = &bufferedPage{
+		Page:    newPage,
+		values:  makeBufferRef(vbuf),
+		offsets: makeBufferRef(obuf),
 	}
 	return newPage, nil
 }
 
-func decodeLevelsV1(enc encoding.Encoding, numValues int64, data []byte) ([]byte, []byte, error) {
+func decodeLevelsV1(enc encoding.Encoding, numValues int, data []byte) (*buffer, []byte, error) {
 	if len(data) < 4 {
 		return nil, data, io.ErrUnexpectedEOF
 	}
@@ -618,7 +677,7 @@ func decodeLevelsV1(enc encoding.Encoding, numValues int64, data []byte) ([]byte
 	return levels, data[j:], err
 }
 
-func decodeLevelsV2(enc encoding.Encoding, numValues int64, data []byte, length int64) ([]byte, []byte, error) {
+func decodeLevelsV2(enc encoding.Encoding, numValues int, data []byte, length int64) (*buffer, []byte, error) {
 	if length > int64(len(data)) {
 		return nil, data, io.ErrUnexpectedEOF
 	}
@@ -626,15 +685,18 @@ func decodeLevelsV2(enc encoding.Encoding, numValues int64, data []byte, length 
 	return levels, data[length:], err
 }
 
-func decodeLevels(enc encoding.Encoding, numValues int64, data []byte) ([]byte, error) {
-	levels := make([]byte, numValues)
-	levels, err := enc.DecodeLevels(levels, data)
-	if err == nil {
+func decodeLevels(enc encoding.Encoding, numValues int, data []byte) (levels *buffer, err error) {
+	levels = levelsBufferPool.get()
+	levels.data, err = enc.DecodeLevels(levels.data, data)
+	if err != nil {
+		levels.unref()
+		levels = nil
+	} else {
 		switch {
-		case len(levels) < int(numValues):
-			err = fmt.Errorf("decoding level expected %d values but got only %d", numValues, len(levels))
-		case len(levels) > int(numValues):
-			levels = levels[:numValues]
+		case len(levels.data) < numValues:
+			err = fmt.Errorf("decoding level expected %d values but got only %d", numValues, len(levels.data))
+		case len(levels.data) > numValues:
+			levels.data = levels.data[:numValues]
 		}
 	}
 	return levels, err
@@ -642,16 +704,20 @@ func decodeLevels(enc encoding.Encoding, numValues int64, data []byte) ([]byte, 
 
 // DecodeDictionary decodes a data page from the header and compressed data
 // passed as arguments.
-func (c *Column) DecodeDictionary(header DictionaryPageHeader, data []byte) (Dictionary, error) {
-	return c.decodeDictionary(header, data, -1)
+func (c *Column) DecodeDictionary(header DictionaryPageHeader, page []byte) (Dictionary, error) {
+	return c.decodeDictionary(header, &buffer{data: page}, -1)
 }
 
-func (c *Column) decodeDictionary(header DictionaryPageHeader, data []byte, size int32) (Dictionary, error) {
+func (c *Column) decodeDictionary(header DictionaryPageHeader, page *buffer, size int32) (Dictionary, error) {
+	pageData := page.data
+
 	if isCompressed(c.compression) {
 		var err error
-		if data, err = c.decompress(data, size); err != nil {
+		if page, err = c.decompress(pageData, size); err != nil {
 			return nil, fmt.Errorf("decompressing dictionary page: %w", err)
 		}
+		defer page.unref()
+		pageData = page.data
 	}
 
 	pageType := c.Type()
@@ -660,12 +726,13 @@ func (c *Column) decodeDictionary(header DictionaryPageHeader, data []byte, size
 		pageEncoding = format.Plain
 	}
 
+	numValues := int(header.NumValues())
 	values := pageType.NewValues(nil, nil)
-	values, err := pageType.Decode(values, data, LookupEncoding(pageEncoding))
+	values, err := pageType.Decode(values, pageData, LookupEncoding(pageEncoding))
 	if err != nil {
 		return nil, err
 	}
-	return pageType.NewDictionary(int(c.index), int(header.NumValues()), values), nil
+	return pageType.NewDictionary(int(c.index), numValues, values), nil
 }
 
 var (

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -248,7 +248,8 @@ func (col *optionalColumnBuffer) Page() Page {
 		col.reordered = false
 	}
 
-	return newOptionalPage(col.base.Page(), col.maxDefinitionLevel, col.definitionLevels)
+	definitionLevels := makeBufferRef(&buffer{data: col.definitionLevels})
+	return newOptionalPage(col.base.Page(), col.maxDefinitionLevel, definitionLevels)
 }
 
 func (col *optionalColumnBuffer) Reset() {
@@ -550,12 +551,14 @@ func (col *repeatedColumnBuffer) Page() Page {
 		col.reordered = false
 	}
 
+	repetitionLevels := makeBufferRef(&buffer{data: col.repetitionLevels})
+	definitionLevels := makeBufferRef(&buffer{data: col.definitionLevels})
 	return newRepeatedPage(
 		col.base.Page(),
 		col.maxRepetitionLevel,
 		col.maxDefinitionLevel,
-		col.repetitionLevels,
-		col.definitionLevels,
+		repetitionLevels,
+		definitionLevels,
 	)
 }
 

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -46,8 +46,8 @@ type ColumnBuffer interface {
 	// the original, mutations of either column will not modify the other.
 	Clone() ColumnBuffer
 
-	// Returns the column as a BufferedPage.
-	Page() BufferedPage
+	// Returns the column as a Page.
+	Page() Page
 
 	// Clears all rows written to the column.
 	Reset()
@@ -207,7 +207,7 @@ func (col *optionalColumnBuffer) Pages() Pages {
 	return onePage(col.Page())
 }
 
-func (col *optionalColumnBuffer) Page() BufferedPage {
+func (col *optionalColumnBuffer) Page() Page {
 	// No need for any cyclic sorting if the rows have not been reordered.
 	// This case is also important because the cyclic sorting modifies the
 	// buffer which makes it unsafe to read the buffer concurrently.
@@ -497,7 +497,7 @@ func (col *repeatedColumnBuffer) Pages() Pages {
 	return onePage(col.Page())
 }
 
-func (col *repeatedColumnBuffer) Page() BufferedPage {
+func (col *repeatedColumnBuffer) Page() Page {
 	if col.reordered {
 		if col.reordering == nil {
 			col.reordering = col.Clone().(*repeatedColumnBuffer)
@@ -757,7 +757,7 @@ func (col *booleanColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *booleanColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *booleanColumnBuffer) Page() BufferedPage { return &col.booleanPage }
+func (col *booleanColumnBuffer) Page() Page { return &col.booleanPage }
 
 func (col *booleanColumnBuffer) Reset() {
 	col.bits = col.bits[:0]
@@ -913,7 +913,7 @@ func (col *int32ColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *int32ColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *int32ColumnBuffer) Page() BufferedPage { return &col.int32Page }
+func (col *int32ColumnBuffer) Page() Page { return &col.int32Page }
 
 func (col *int32ColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1008,7 +1008,7 @@ func (col *int64ColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *int64ColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *int64ColumnBuffer) Page() BufferedPage { return &col.int64Page }
+func (col *int64ColumnBuffer) Page() Page { return &col.int64Page }
 
 func (col *int64ColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1102,7 +1102,7 @@ func (col *int96ColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *int96ColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *int96ColumnBuffer) Page() BufferedPage { return &col.int96Page }
+func (col *int96ColumnBuffer) Page() Page { return &col.int96Page }
 
 func (col *int96ColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1195,7 +1195,7 @@ func (col *floatColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *floatColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *floatColumnBuffer) Page() BufferedPage { return &col.floatPage }
+func (col *floatColumnBuffer) Page() Page { return &col.floatPage }
 
 func (col *floatColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1289,7 +1289,7 @@ func (col *doubleColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *doubleColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *doubleColumnBuffer) Page() BufferedPage { return &col.doublePage }
+func (col *doubleColumnBuffer) Page() Page { return &col.doublePage }
 
 func (col *doubleColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1401,7 +1401,7 @@ func (col *byteArrayColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *byteArrayColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *byteArrayColumnBuffer) Page() BufferedPage {
+func (col *byteArrayColumnBuffer) Page() Page {
 	if len(col.lengths) > 0 && orderOfUint32(col.offsets) < 1 { // unordered?
 		if cap(col.scratch) < len(col.values) {
 			col.scratch = make([]byte, 0, cap(col.values))
@@ -1561,7 +1561,7 @@ func (col *fixedLenByteArrayColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *fixedLenByteArrayColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *fixedLenByteArrayColumnBuffer) Page() BufferedPage { return &col.fixedLenByteArrayPage }
+func (col *fixedLenByteArrayColumnBuffer) Page() Page { return &col.fixedLenByteArrayPage }
 
 func (col *fixedLenByteArrayColumnBuffer) Reset() { col.data = col.data[:0] }
 
@@ -1677,7 +1677,7 @@ func (col *uint32ColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *uint32ColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *uint32ColumnBuffer) Page() BufferedPage { return &col.uint32Page }
+func (col *uint32ColumnBuffer) Page() Page { return &col.uint32Page }
 
 func (col *uint32ColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1771,7 +1771,7 @@ func (col *uint64ColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *uint64ColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *uint64ColumnBuffer) Page() BufferedPage { return &col.uint64Page }
+func (col *uint64ColumnBuffer) Page() Page { return &col.uint64Page }
 
 func (col *uint64ColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1869,7 +1869,7 @@ func (col *be128ColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *be128ColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *be128ColumnBuffer) Page() BufferedPage { return &col.be128Page }
+func (col *be128ColumnBuffer) Page() Page { return &col.be128Page }
 
 func (col *be128ColumnBuffer) Reset() { col.values = col.values[:0] }
 

--- a/convert.go
+++ b/convert.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"sync"
+
+	"github.com/segmentio/parquet-go/encoding"
 )
 
 // ConvertError is an error type returned by calls to Convert when the conversion
@@ -331,11 +333,13 @@ func (p missingPage) NumRows() int64                    { return p.numRows }
 func (p missingPage) NumValues() int64                  { return p.numValues }
 func (p missingPage) NumNulls() int64                   { return p.numNulls }
 func (p missingPage) Bounds() (min, max Value, ok bool) { return }
+func (p missingPage) Clone() Page                       { return p }
+func (p missingPage) Slice(i, j int64) Page             { return p }
 func (p missingPage) Size() int64                       { return 0 }
+func (p missingPage) RepetitionLevels() []byte          { return nil }
+func (p missingPage) DefinitionLevels() []byte          { return nil }
+func (p missingPage) Data() encoding.Values             { return p.typ.NewValues(nil, nil) }
 func (p missingPage) Values() ValueReader               { return &missingPageValues{page: p} }
-func (p missingPage) Buffer() BufferedPage {
-	return newErrorPage(p.Type(), p.Column(), "cannot buffer missing page")
-}
 
 type missingPageValues struct {
 	page missingPage

--- a/dictionary.go
+++ b/dictionary.go
@@ -75,11 +75,11 @@ type Dictionary interface {
 	// Resets the dictionary to its initial state, removing all values.
 	Reset()
 
-	// Returns a BufferedPage representing the content of the dictionary.
+	// Returns a Page representing the content of the dictionary.
 	//
 	// The returned page shares the underlying memory of the buffer, it remains
 	// valid to use until the dictionary's Reset method is called.
-	Page() BufferedPage
+	Page() Page
 
 	// See ColumnBuffer.writeValues for details on the use of unexported methods
 	// on interfaces.
@@ -211,7 +211,7 @@ func (d *booleanDictionary) Reset() {
 	d.table = [2]int32{-1, -1}
 }
 
-func (d *booleanDictionary) Page() BufferedPage {
+func (d *booleanDictionary) Page() Page {
 	return &d.booleanPage
 }
 
@@ -311,7 +311,7 @@ func (d *int32Dictionary) Reset() {
 	}
 }
 
-func (d *int32Dictionary) Page() BufferedPage {
+func (d *int32Dictionary) Page() Page {
 	return &d.int32Page
 }
 
@@ -398,7 +398,7 @@ func (d *int64Dictionary) Reset() {
 	}
 }
 
-func (d *int64Dictionary) Page() BufferedPage {
+func (d *int64Dictionary) Page() Page {
 	return &d.int64Page
 }
 
@@ -493,7 +493,7 @@ func (d *int96Dictionary) Reset() {
 	d.hashmap = nil
 }
 
-func (d *int96Dictionary) Page() BufferedPage {
+func (d *int96Dictionary) Page() Page {
 	return &d.int96Page
 }
 
@@ -580,7 +580,7 @@ func (d *floatDictionary) Reset() {
 	}
 }
 
-func (d *floatDictionary) Page() BufferedPage {
+func (d *floatDictionary) Page() Page {
 	return &d.floatPage
 }
 
@@ -667,7 +667,7 @@ func (d *doubleDictionary) Reset() {
 	}
 }
 
-func (d *doubleDictionary) Page() BufferedPage {
+func (d *doubleDictionary) Page() Page {
 	return &d.doublePage
 }
 
@@ -794,7 +794,7 @@ func (d *byteArrayDictionary) Reset() {
 	}
 }
 
-func (d *byteArrayDictionary) Page() BufferedPage {
+func (d *byteArrayDictionary) Page() Page {
 	return &d.byteArrayPage
 }
 
@@ -909,7 +909,7 @@ func (d *fixedLenByteArrayDictionary) Reset() {
 	d.hashmap = nil
 }
 
-func (d *fixedLenByteArrayDictionary) Page() BufferedPage {
+func (d *fixedLenByteArrayDictionary) Page() Page {
 	return &d.fixedLenByteArrayPage
 }
 
@@ -996,7 +996,7 @@ func (d *uint32Dictionary) Reset() {
 	}
 }
 
-func (d *uint32Dictionary) Page() BufferedPage {
+func (d *uint32Dictionary) Page() Page {
 	return &d.uint32Page
 }
 
@@ -1083,7 +1083,7 @@ func (d *uint64Dictionary) Reset() {
 	}
 }
 
-func (d *uint64Dictionary) Page() BufferedPage {
+func (d *uint64Dictionary) Page() Page {
 	return &d.uint64Page
 }
 
@@ -1201,7 +1201,7 @@ func (d *be128Dictionary) Reset() {
 	}
 }
 
-func (d *be128Dictionary) Page() BufferedPage {
+func (d *be128Dictionary) Page() Page {
 	return &d.be128Page
 }
 
@@ -1229,7 +1229,7 @@ func (t *indexedType) NewValues(values []byte, _ []uint32) encoding.Values {
 	return encoding.Int32ValuesFromBytes(values)
 }
 
-// indexedPage is an implementation of the BufferedPage interface which stores
+// indexedPage is an implementation of the Page interface which stores
 // indexes instead of plain value. The indexes reference the values in a
 // dictionary that the page was created for.
 type indexedPage struct {
@@ -1288,8 +1288,6 @@ func (page *indexedPage) Data() encoding.Values { return encoding.Int32Values(pa
 
 func (page *indexedPage) Values() ValueReader { return &indexedPageValues{page: page} }
 
-func (page *indexedPage) Buffer() BufferedPage { return page }
-
 func (page *indexedPage) Bounds() (min, max Value, ok bool) {
 	if ok = len(page.values) > 0; ok {
 		min, max = page.typ.dict.Bounds(page.values)
@@ -1299,7 +1297,7 @@ func (page *indexedPage) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *indexedPage) Clone() BufferedPage {
+func (page *indexedPage) Clone() Page {
 	return &indexedPage{
 		typ:         page.typ,
 		values:      append([]int32{}, page.values...),
@@ -1307,7 +1305,7 @@ func (page *indexedPage) Clone() BufferedPage {
 	}
 }
 
-func (page *indexedPage) Slice(i, j int64) BufferedPage {
+func (page *indexedPage) Slice(i, j int64) Page {
 	return &indexedPage{
 		typ:         page.typ,
 		values:      page.values[i:j],
@@ -1383,7 +1381,7 @@ func (col *indexedColumnBuffer) Dictionary() Dictionary { return col.typ.dict }
 
 func (col *indexedColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *indexedColumnBuffer) Page() BufferedPage { return &col.indexedPage }
+func (col *indexedColumnBuffer) Page() Page { return &col.indexedPage }
 
 func (col *indexedColumnBuffer) Reset() { col.values = col.values[:0] }
 

--- a/file.go
+++ b/file.go
@@ -531,7 +531,7 @@ func (f *filePages) ReadPage() (Page, error) {
 			seek := f.skip
 			f.skip = 0
 			if seek > 0 {
-				page = page.Buffer().Slice(seek, numRows)
+				page = page.Slice(seek, numRows)
 			}
 			return page, nil
 		}

--- a/file.go
+++ b/file.go
@@ -511,6 +511,8 @@ func (f *filePages) ReadPage() (Page, error) {
 			err = fmt.Errorf("cannot read values of type %s from page", header.Type)
 		}
 
+		data.unref()
+
 		if err != nil {
 			return nil, fmt.Errorf("decoding page %d of column %q: %w", f.index, f.columnPath(), err)
 		}
@@ -551,20 +553,23 @@ func (f *filePages) readDictionary() error {
 		return err
 	}
 
-	data := make([]byte, header.CompressedPageSize)
+	page := compressedPageBufferPool.get()
+	defer page.unref()
 
-	if _, err := io.ReadFull(rbuf, data); err != nil {
+	page.resize(int(header.CompressedPageSize))
+
+	if _, err := io.ReadFull(rbuf, page.data); err != nil {
 		return err
 	}
 
-	return f.readDictionaryPage(header, data)
+	return f.readDictionaryPage(header, page)
 }
 
-func (f *filePages) readDictionaryPage(header *format.PageHeader, data []byte) error {
+func (f *filePages) readDictionaryPage(header *format.PageHeader, page *buffer) error {
 	if header.DictionaryPageHeader == nil {
 		return ErrMissingPageHeader
 	}
-	d, err := f.chunk.column.decodeDictionary(DictionaryPageHeader{header.DictionaryPageHeader}, data, header.UncompressedPageSize)
+	d, err := f.chunk.column.decodeDictionary(DictionaryPageHeader{header.DictionaryPageHeader}, page, header.UncompressedPageSize)
 	if err != nil {
 		return err
 	}
@@ -572,7 +577,7 @@ func (f *filePages) readDictionaryPage(header *format.PageHeader, data []byte) e
 	return nil
 }
 
-func (f *filePages) readDataPageV1(header *format.PageHeader, data []byte) (Page, error) {
+func (f *filePages) readDataPageV1(header *format.PageHeader, page *buffer) (Page, error) {
 	if header.DataPageHeader == nil {
 		return nil, ErrMissingPageHeader
 	}
@@ -581,10 +586,10 @@ func (f *filePages) readDataPageV1(header *format.PageHeader, data []byte) (Page
 			return nil, err
 		}
 	}
-	return f.chunk.column.decodeDataPageV1(DataPageHeaderV1{header.DataPageHeader}, data, f.dictionary, header.UncompressedPageSize)
+	return f.chunk.column.decodeDataPageV1(DataPageHeaderV1{header.DataPageHeader}, page, f.dictionary, header.UncompressedPageSize)
 }
 
-func (f *filePages) readDataPageV2(header *format.PageHeader, data []byte) (Page, error) {
+func (f *filePages) readDataPageV2(header *format.PageHeader, page *buffer) (Page, error) {
 	if header.DataPageHeaderV2 == nil {
 		return nil, ErrMissingPageHeader
 	}
@@ -596,19 +601,22 @@ func (f *filePages) readDataPageV2(header *format.PageHeader, data []byte) (Page
 			return nil, err
 		}
 	}
-	return f.chunk.column.decodeDataPageV2(DataPageHeaderV2{header.DataPageHeaderV2}, data, f.dictionary, header.UncompressedPageSize)
+	return f.chunk.column.decodeDataPageV2(DataPageHeaderV2{header.DataPageHeaderV2}, page, f.dictionary, header.UncompressedPageSize)
 }
 
-func (f *filePages) readPage(header *format.PageHeader, reader *bufio.Reader) ([]byte, error) {
-	page := make([]byte, header.CompressedPageSize)
+func (f *filePages) readPage(header *format.PageHeader, reader *bufio.Reader) (*buffer, error) {
+	page := compressedPageBufferPool.get()
+	defer page.unref()
 
-	if _, err := io.ReadFull(reader, page); err != nil {
+	page.resize(int(header.CompressedPageSize))
+
+	if _, err := io.ReadFull(reader, page.data); err != nil {
 		return nil, err
 	}
 
 	if header.CRC != 0 {
 		headerChecksum := uint32(header.CRC)
-		bufferChecksum := crc32.ChecksumIEEE(page)
+		bufferChecksum := crc32.ChecksumIEEE(page.data)
 
 		// TODO: checksum validation is disabled until we figure out how the
 		// checksum of TestOpenFile/testdata/delta_length_byte_array.parquet was
@@ -638,6 +646,7 @@ func (f *filePages) readPage(header *format.PageHeader, reader *bufio.Reader) ([
 		}
 	}
 
+	page.ref()
 	return page, nil
 }
 

--- a/page.go
+++ b/page.go
@@ -317,7 +317,10 @@ func forEachPageSlice(page Page, wantSize int64, do func(Page) error) error {
 
 	for numPages > 0 {
 		lastRowIndex := rowIndex + ((numRows - rowIndex) / numPages)
-		if err := do(page.Slice(rowIndex, lastRowIndex)); err != nil {
+		pageSlice := page.Slice(rowIndex, lastRowIndex)
+		err := do(pageSlice)
+		unref(pageSlice)
+		if err != nil {
 			return err
 		}
 		rowIndex = lastRowIndex
@@ -374,10 +377,10 @@ func errPageBoundsOutOfRange(i, j, n int64) error {
 type optionalPage struct {
 	base               Page
 	maxDefinitionLevel byte
-	definitionLevels   []byte
+	definitionLevels   bufferRef
 }
 
-func newOptionalPage(base Page, maxDefinitionLevel byte, definitionLevels []byte) *optionalPage {
+func newOptionalPage(base Page, maxDefinitionLevel byte, definitionLevels bufferRef) *optionalPage {
 	return &optionalPage{
 		base:               base,
 		maxDefinitionLevel: maxDefinitionLevel,
@@ -391,21 +394,21 @@ func (page *optionalPage) Column() int { return page.base.Column() }
 
 func (page *optionalPage) Dictionary() Dictionary { return page.base.Dictionary() }
 
-func (page *optionalPage) NumRows() int64 { return int64(len(page.definitionLevels)) }
+func (page *optionalPage) NumRows() int64 { return int64(page.definitionLevels.len) }
 
-func (page *optionalPage) NumValues() int64 { return int64(len(page.definitionLevels)) }
+func (page *optionalPage) NumValues() int64 { return int64(page.definitionLevels.len) }
 
 func (page *optionalPage) NumNulls() int64 {
-	return int64(countLevelsNotEqual(page.definitionLevels, page.maxDefinitionLevel))
+	return int64(countLevelsNotEqual(page.definitionLevels.data(), page.maxDefinitionLevel))
 }
 
 func (page *optionalPage) Bounds() (min, max Value, ok bool) { return page.base.Bounds() }
 
-func (page *optionalPage) Size() int64 { return page.base.Size() + int64(len(page.definitionLevels)) }
+func (page *optionalPage) Size() int64 { return page.base.Size() + int64(page.definitionLevels.len) }
 
 func (page *optionalPage) RepetitionLevels() []byte { return nil }
 
-func (page *optionalPage) DefinitionLevels() []byte { return page.definitionLevels }
+func (page *optionalPage) DefinitionLevels() []byte { return page.definitionLevels.data() }
 
 func (page *optionalPage) Data() encoding.Values { return page.base.Data() }
 
@@ -420,17 +423,18 @@ func (page *optionalPage) Clone() Page {
 	return newOptionalPage(
 		page.base.Clone(),
 		page.maxDefinitionLevel,
-		append([]byte{}, page.definitionLevels...),
+		page.definitionLevels.clone(),
 	)
 }
 
 func (page *optionalPage) Slice(i, j int64) Page {
-	numNulls1 := int64(countLevelsNotEqual(page.definitionLevels[:i], page.maxDefinitionLevel))
-	numNulls2 := int64(countLevelsNotEqual(page.definitionLevels[i:j], page.maxDefinitionLevel))
+	definitionLevels := page.definitionLevels.data()
+	numNulls1 := int64(countLevelsNotEqual(definitionLevels[:i], page.maxDefinitionLevel))
+	numNulls2 := int64(countLevelsNotEqual(definitionLevels[i:j], page.maxDefinitionLevel))
 	return newOptionalPage(
 		page.base.Slice(i-numNulls1, j-(numNulls1+numNulls2)),
 		page.maxDefinitionLevel,
-		page.definitionLevels[i:j],
+		page.definitionLevels.slice(int(i), int(j)),
 	)
 }
 
@@ -438,11 +442,11 @@ type repeatedPage struct {
 	base               Page
 	maxRepetitionLevel byte
 	maxDefinitionLevel byte
-	definitionLevels   []byte
-	repetitionLevels   []byte
+	definitionLevels   bufferRef
+	repetitionLevels   bufferRef
 }
 
-func newRepeatedPage(base Page, maxRepetitionLevel, maxDefinitionLevel byte, repetitionLevels, definitionLevels []byte) *repeatedPage {
+func newRepeatedPage(base Page, maxRepetitionLevel, maxDefinitionLevel byte, repetitionLevels, definitionLevels bufferRef) *repeatedPage {
 	return &repeatedPage{
 		base:               base,
 		maxRepetitionLevel: maxRepetitionLevel,
@@ -458,23 +462,27 @@ func (page *repeatedPage) Column() int { return page.base.Column() }
 
 func (page *repeatedPage) Dictionary() Dictionary { return page.base.Dictionary() }
 
-func (page *repeatedPage) NumRows() int64 { return int64(countLevelsEqual(page.repetitionLevels, 0)) }
+func (page *repeatedPage) NumRows() int64 {
+	return int64(countLevelsEqual(page.repetitionLevels.data(), 0))
+}
 
-func (page *repeatedPage) NumValues() int64 { return int64(len(page.definitionLevels)) }
+func (page *repeatedPage) NumValues() int64 {
+	return int64(page.definitionLevels.len)
+}
 
 func (page *repeatedPage) NumNulls() int64 {
-	return int64(countLevelsNotEqual(page.definitionLevels, page.maxDefinitionLevel))
+	return int64(countLevelsNotEqual(page.definitionLevels.data(), page.maxDefinitionLevel))
 }
 
 func (page *repeatedPage) Bounds() (min, max Value, ok bool) { return page.base.Bounds() }
 
 func (page *repeatedPage) Size() int64 {
-	return int64(len(page.repetitionLevels)) + int64(len(page.definitionLevels)) + page.base.Size()
+	return int64(page.repetitionLevels.len) + int64(page.definitionLevels.len) + page.base.Size()
 }
 
-func (page *repeatedPage) RepetitionLevels() []byte { return page.repetitionLevels }
+func (page *repeatedPage) RepetitionLevels() []byte { return page.repetitionLevels.data() }
 
-func (page *repeatedPage) DefinitionLevels() []byte { return page.definitionLevels }
+func (page *repeatedPage) DefinitionLevels() []byte { return page.definitionLevels.data() }
 
 func (page *repeatedPage) Data() encoding.Values { return page.base.Data() }
 
@@ -490,8 +498,8 @@ func (page *repeatedPage) Clone() Page {
 		page.base.Clone(),
 		page.maxRepetitionLevel,
 		page.maxDefinitionLevel,
-		append([]byte{}, page.repetitionLevels...),
-		append([]byte{}, page.definitionLevels...),
+		page.repetitionLevels.clone(),
+		page.definitionLevels.clone(),
 	)
 }
 
@@ -507,11 +515,12 @@ func (page *repeatedPage) Slice(i, j int64) Page {
 		panic(errPageBoundsOutOfRange(i, j, numRows))
 	}
 
+	repetitionLevels := page.repetitionLevels.data()
 	rowIndex0 := 0
-	rowIndex1 := len(page.repetitionLevels)
-	rowIndex2 := len(page.repetitionLevels)
+	rowIndex1 := len(repetitionLevels)
+	rowIndex2 := len(repetitionLevels)
 
-	for k, def := range page.repetitionLevels {
+	for k, def := range repetitionLevels {
 		if def == 0 {
 			if rowIndex0 == int(i) {
 				rowIndex1 = k
@@ -521,7 +530,7 @@ func (page *repeatedPage) Slice(i, j int64) Page {
 		}
 	}
 
-	for k, def := range page.repetitionLevels[rowIndex1:] {
+	for k, def := range repetitionLevels[rowIndex1:] {
 		if def == 0 {
 			if rowIndex0 == int(j) {
 				rowIndex2 = rowIndex1 + k
@@ -531,8 +540,9 @@ func (page *repeatedPage) Slice(i, j int64) Page {
 		}
 	}
 
-	numNulls1 := countLevelsNotEqual(page.definitionLevels[:rowIndex1], page.maxDefinitionLevel)
-	numNulls2 := countLevelsNotEqual(page.definitionLevels[rowIndex1:rowIndex2], page.maxDefinitionLevel)
+	definitionLevels := page.definitionLevels.data()
+	numNulls1 := countLevelsNotEqual(definitionLevels[:rowIndex1], page.maxDefinitionLevel)
+	numNulls2 := countLevelsNotEqual(definitionLevels[rowIndex1:rowIndex2], page.maxDefinitionLevel)
 
 	i = int64(rowIndex1 - numNulls1)
 	j = int64(rowIndex2 - (numNulls1 + numNulls2))
@@ -541,8 +551,8 @@ func (page *repeatedPage) Slice(i, j int64) Page {
 		page.base.Slice(i, j),
 		page.maxRepetitionLevel,
 		page.maxDefinitionLevel,
-		page.repetitionLevels[rowIndex1:rowIndex2],
-		page.definitionLevels[rowIndex1:rowIndex2],
+		page.repetitionLevels.slice(int(rowIndex1), int(rowIndex2)),
+		page.definitionLevels.slice(int(rowIndex1), int(rowIndex2)),
 	)
 }
 

--- a/page.go
+++ b/page.go
@@ -41,7 +41,7 @@ type Page interface {
 	NumValues() int64
 	NumNulls() int64
 
-	// Returns the min and max values currently buffered in the writer.
+	// Returns the page's min and max values.
 	//
 	// The third value is a boolean indicating whether the page bounds were
 	// available. Page bounds may not be known if the page contained no values
@@ -95,24 +95,6 @@ type BufferedPage interface {
 	// multiple calls to this method, applications must treat the content as
 	// immutable.
 	Data() encoding.Values
-}
-
-// CompressedPage is an extension of the Page interface implemented by pages
-// that have been compressed to their on-file representation.
-type CompressedPage interface {
-	Page
-
-	// Returns a representation of the page header.
-	PageHeader() PageHeader
-
-	// Returns a reader exposing the content of the compressed page.
-	PageData() io.Reader
-
-	// Returns the size of the page data.
-	PageSize() int64
-
-	// CRC returns the IEEE CRC32 checksum of the page.
-	CRC() uint32
 }
 
 // PageReader is an interface implemented by types that support producing a

--- a/page_values.go
+++ b/page_values.go
@@ -16,12 +16,13 @@ type optionalPageValues struct {
 
 func (r *optionalPageValues) ReadValues(values []Value) (n int, err error) {
 	maxDefinitionLevel := r.page.maxDefinitionLevel
+	definitionLevels := r.page.definitionLevels.data()
 	columnIndex := ^int16(r.page.Column())
 
-	for n < len(values) && r.offset < len(r.page.definitionLevels) {
-		for n < len(values) && r.offset < len(r.page.definitionLevels) && r.page.definitionLevels[r.offset] != maxDefinitionLevel {
+	for n < len(values) && r.offset < len(definitionLevels) {
+		for n < len(values) && r.offset < len(definitionLevels) && definitionLevels[r.offset] != maxDefinitionLevel {
 			values[n] = Value{
-				definitionLevel: r.page.definitionLevels[r.offset],
+				definitionLevel: definitionLevels[r.offset],
 				columnIndex:     columnIndex,
 			}
 			r.offset++
@@ -30,7 +31,7 @@ func (r *optionalPageValues) ReadValues(values []Value) (n int, err error) {
 
 		i := n
 		j := r.offset
-		for i < len(values) && j < len(r.page.definitionLevels) && r.page.definitionLevels[j] == maxDefinitionLevel {
+		for i < len(values) && j < len(definitionLevels) && definitionLevels[j] == maxDefinitionLevel {
 			i++
 			j++
 		}
@@ -49,7 +50,7 @@ func (r *optionalPageValues) ReadValues(values []Value) (n int, err error) {
 		}
 	}
 
-	if r.offset == len(r.page.definitionLevels) {
+	if r.offset == len(definitionLevels) {
 		err = io.EOF
 	}
 	return n, err
@@ -63,13 +64,15 @@ type repeatedPageValues struct {
 
 func (r *repeatedPageValues) ReadValues(values []Value) (n int, err error) {
 	maxDefinitionLevel := r.page.maxDefinitionLevel
+	definitionLevels := r.page.definitionLevels.data()
+	repetitionLevels := r.page.repetitionLevels.data()
 	columnIndex := ^int16(r.page.Column())
 
-	for n < len(values) && r.offset < len(r.page.definitionLevels) {
-		for n < len(values) && r.offset < len(r.page.definitionLevels) && r.page.definitionLevels[r.offset] != maxDefinitionLevel {
+	for n < len(values) && r.offset < len(definitionLevels) {
+		for n < len(values) && r.offset < len(definitionLevels) && definitionLevels[r.offset] != maxDefinitionLevel {
 			values[n] = Value{
-				repetitionLevel: r.page.repetitionLevels[r.offset],
-				definitionLevel: r.page.definitionLevels[r.offset],
+				repetitionLevel: repetitionLevels[r.offset],
+				definitionLevel: definitionLevels[r.offset],
 				columnIndex:     columnIndex,
 			}
 			r.offset++
@@ -78,14 +81,14 @@ func (r *repeatedPageValues) ReadValues(values []Value) (n int, err error) {
 
 		i := n
 		j := r.offset
-		for i < len(values) && j < len(r.page.definitionLevels) && r.page.definitionLevels[j] == maxDefinitionLevel {
+		for i < len(values) && j < len(definitionLevels) && definitionLevels[j] == maxDefinitionLevel {
 			i++
 			j++
 		}
 
 		if n < i {
 			for j, err = r.values.ReadValues(values[n:i]); j > 0; j-- {
-				values[n].repetitionLevel = r.page.repetitionLevels[r.offset]
+				values[n].repetitionLevel = repetitionLevels[r.offset]
 				values[n].definitionLevel = maxDefinitionLevel
 				r.offset++
 				n++
@@ -97,7 +100,7 @@ func (r *repeatedPageValues) ReadValues(values []Value) (n int, err error) {
 		}
 	}
 
-	if r.offset == len(r.page.definitionLevels) {
+	if r.offset == len(definitionLevels) {
 		err = io.EOF
 	}
 	return n, err

--- a/row_group.go
+++ b/row_group.go
@@ -308,7 +308,10 @@ func (r *rowGroupRows) Reset() {
 
 func (r *rowGroupRows) Close() error {
 	var lastErr error
-	r.cancel()
+
+	if r.cancel != nil {
+		r.cancel()
+	}
 
 	for i := range r.columns {
 		if err := r.columns[i].close(); err != nil {

--- a/writer.go
+++ b/writer.go
@@ -1013,13 +1013,13 @@ func (c *writerColumn) WritePage(page Page) (numValues int64, err error) {
 				})
 				return numValues, err
 
-			case CompressedPage:
+				//case CompressedPage:
 				// Compressed pages are written as-is to the compressed page
 				// buffers; those pages should be coming from parquet files that
 				// are being copied into a new file, they are simply copied to
 				// amortize the cost of decoding and re-encoding the pages, which
 				// often includes costly compression steps.
-				return c.writeCompressedPage(p)
+				//return c.writeCompressedPage(p)
 			}
 		}
 	}
@@ -1174,6 +1174,8 @@ func (c *writerColumn) writeBufferedPage(page BufferedPage) (int64, error) {
 	return numValues, nil
 }
 
+// Disable for now, will bring back when we optimize page copies.
+/*
 func (c *writerColumn) writeCompressedPage(page CompressedPage) (int64, error) {
 	if page.Dictionary() == nil {
 		switch {
@@ -1235,6 +1237,7 @@ func (c *writerColumn) writeCompressedPage(page CompressedPage) (int64, error) {
 	c.recordPageStats(headerSize, pageHeader, page)
 	return page.NumValues(), nil
 }
+*/
 
 func (c *writerColumn) writeDictionaryPage(output io.Writer, dict Dictionary) (err error) {
 	buf := c.buffers

--- a/writer.go
+++ b/writer.go
@@ -729,12 +729,12 @@ func encodeLevels(dst, src []byte, maxLevel byte) ([]byte, error) {
 	return levelEncodingsRLE[bitWidth-1].EncodeLevels(dst, src)
 }
 
-func (wb *writerBuffers) encodeRepetitionLevels(page BufferedPage, maxRepetitionLevel byte) (err error) {
+func (wb *writerBuffers) encodeRepetitionLevels(page Page, maxRepetitionLevel byte) (err error) {
 	wb.repetitions, err = encodeLevels(wb.repetitions, page.RepetitionLevels(), maxRepetitionLevel)
 	return
 }
 
-func (wb *writerBuffers) encodeDefinitionLevels(page BufferedPage, maxDefinitionLevel byte) (err error) {
+func (wb *writerBuffers) encodeDefinitionLevels(page Page, maxDefinitionLevel byte) (err error) {
 	wb.definitions, err = encodeLevels(wb.definitions, page.DefinitionLevels(), maxDefinitionLevel)
 	return
 }
@@ -768,7 +768,7 @@ func (wb *writerBuffers) prependLevelsToDataPageV1(maxRepetitionLevel, maxDefini
 	}
 }
 
-func (wb *writerBuffers) encode(page BufferedPage, enc encoding.Encoding) (err error) {
+func (wb *writerBuffers) encode(page Page, enc encoding.Encoding) (err error) {
 	pageType := page.Type()
 	pageData := page.Data()
 	wb.page, err = pageType.Encode(wb.page[:0], pageData, enc)
@@ -814,7 +814,7 @@ type writerColumn struct {
 
 	filter struct {
 		bits  []byte
-		pages []BufferedPage
+		pages []Page
 	}
 
 	numRows        int64
@@ -888,7 +888,7 @@ func (c *writerColumn) flush() (err error) {
 	if c.numValues != 0 {
 		c.numValues = 0
 		defer c.columnBuffer.Reset()
-		_, err = c.writeBufferedPage(c.columnBuffer.Page())
+		_, err = c.writeDataPage(c.columnBuffer.Page())
 	}
 	return err
 }
@@ -1001,26 +1001,15 @@ func (c *writerColumn) WritePage(page Page) (numValues int64, err error) {
 		// optimize the write path by copying whole pages without decoding them
 		// into a sequence of values.
 		if c.numValues == 0 {
-			switch p := page.(type) {
-			case BufferedPage:
-				// Buffered pages may be larger than the target page size on the
-				// column, in which case multiple pages get written by slicing
-				// the original page into sub-pages.
-				err = forEachPageSlice(p, int64(c.bufferSize), func(p BufferedPage) error {
-					n, err := c.writeBufferedPage(p)
-					numValues += n
-					return err
-				})
-				return numValues, err
-
-				//case CompressedPage:
-				// Compressed pages are written as-is to the compressed page
-				// buffers; those pages should be coming from parquet files that
-				// are being copied into a new file, they are simply copied to
-				// amortize the cost of decoding and re-encoding the pages, which
-				// often includes costly compression steps.
-				//return c.writeCompressedPage(p)
-			}
+			// Buffered pages may be larger than the target page size on the
+			// column, in which case multiple pages get written by slicing
+			// the original page into sub-pages.
+			err = forEachPageSlice(page, int64(c.bufferSize), func(p Page) error {
+				n, err := c.writeDataPage(p)
+				numValues += n
+				return err
+			})
+			return numValues, err
 		}
 	}
 
@@ -1054,7 +1043,7 @@ func (c *writerColumn) writeBloomFilter(w io.Writer) error {
 	return err
 }
 
-func (c *writerColumn) writeBufferedPage(page BufferedPage) (int64, error) {
+func (c *writerColumn) writeDataPage(page Page) (int64, error) {
 	numValues := page.NumValues()
 	if numValues == 0 {
 		return 0, nil
@@ -1151,7 +1140,7 @@ func (c *writerColumn) writeBufferedPage(page BufferedPage) (int64, error) {
 		int64(len(buf.definitions)) +
 		int64(len(buf.page))
 
-	err := c.writePage(size, func(output io.Writer) (written int64, err error) {
+	err := c.writePageTo(size, func(output io.Writer) (written int64, err error) {
 		for _, data := range [...][]byte{
 			buf.header.Bytes(),
 			buf.repetitions,
@@ -1173,71 +1162,6 @@ func (c *writerColumn) writeBufferedPage(page BufferedPage) (int64, error) {
 	c.recordPageStats(int32(buf.header.Len()), pageHeader, page)
 	return numValues, nil
 }
-
-// Disable for now, will bring back when we optimize page copies.
-/*
-func (c *writerColumn) writeCompressedPage(page CompressedPage) (int64, error) {
-	if page.Dictionary() == nil {
-		switch {
-		case len(c.filter.bits) > 0:
-			// TODO: modify the Buffer method to accept some kind of buffer pool as
-			// argument so we can use a pre-allocated page buffer to load the page
-			// and reduce the memory footprint.
-			bufferedPage := page.Buffer()
-			// The compressed page must be decompressed here in order to generate
-			// the bloom filter. Note that we don't re-compress it which still saves
-			// most of the compute cost (compression algorithms are usually designed
-			// to make decompressing much cheaper than compressing since it happens
-			// more often).
-			if err := c.writePageToFilter(bufferedPage); err != nil {
-				return 0, err
-			}
-		case c.columnFilter != nil && c.dictionary == nil:
-			// When a column filter is configured but no page filter was allocated,
-			// we need to buffer the page in order to have access to the number of
-			// values and properly size the bloom filter when writing the row group.
-			c.filter.pages = append(c.filter.pages, page.Buffer())
-		}
-	}
-
-	pageHeader := &format.PageHeader{
-		UncompressedPageSize: int32(page.Size()),
-		CompressedPageSize:   int32(page.PageSize()),
-		CRC:                  int32(page.CRC()),
-	}
-
-	switch h := page.PageHeader().(type) {
-	case DataPageHeaderV1:
-		pageHeader.DataPageHeader = h.header
-	case DataPageHeaderV2:
-		pageHeader.DataPageHeaderV2 = h.header
-	default:
-		return 0, fmt.Errorf("writing compressed page type of unknown type: %s", h.PageType())
-	}
-
-	header := &c.buffers.header
-	header.Reset()
-	if err := c.header.encoder.Encode(pageHeader); err != nil {
-		return 0, err
-	}
-	headerSize := int32(header.Len())
-	compressedSize := int64(headerSize + pageHeader.CompressedPageSize)
-
-	err := c.writePage(compressedSize, func(output io.Writer) (int64, error) {
-		headerSize, err := header.WriteTo(output)
-		if err != nil {
-			return headerSize, err
-		}
-		dataSize, err := io.Copy(output, page.PageData())
-		return headerSize + dataSize, err
-	})
-	if err != nil {
-		return 0, err
-	}
-	c.recordPageStats(headerSize, pageHeader, page)
-	return page.NumValues(), nil
-}
-*/
 
 func (c *writerColumn) writeDictionaryPage(output io.Writer, dict Dictionary) (err error) {
 	buf := c.buffers
@@ -1281,14 +1205,14 @@ func (c *writerColumn) writeDictionaryPage(output io.Writer, dict Dictionary) (e
 	return nil
 }
 
-func (w *writerColumn) writePageToFilter(page BufferedPage) (err error) {
+func (w *writerColumn) writePageToFilter(page Page) (err error) {
 	pageType := page.Type()
 	pageData := page.Data()
 	w.filter.bits, err = pageType.Encode(w.filter.bits, pageData, w.columnFilter.Encoding())
 	return err
 }
 
-func (c *writerColumn) writePage(size int64, writeTo func(io.Writer) (int64, error)) error {
+func (c *writerColumn) writePageTo(size int64, writeTo func(io.Writer) (int64, error)) error {
 	buffer := c.pool.GetPageBuffer()
 	defer func() {
 		if buffer != nil {


### PR DESCRIPTION
I'm going to use this as the base branch to work on https://github.com/segmentio/parquet-go/issues/248. As a first step, I am removing optimizations that make the internal logic more complex. By simplifying the implementation, introducing changes to address the issue will be simpler.