### PR TITLE
Concurrent column page reader

### DIFF
--- a/page.go
+++ b/page.go
@@ -133,7 +133,7 @@ type Pages interface {
 // asynchronously in a separate goroutine.
 //
 // Performing page reads asynchronously is important when the application may
-// be reading pages from a high latency backend, and processing of the last
+// be reading pages from a high latency backend, and the last
 // page read may be processed while initiating reading of the next page.
 func AsyncPages(pages Pages) Pages {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/page.go
+++ b/page.go
@@ -130,7 +130,7 @@ type Pages interface {
 }
 
 // AsyncPages wraps the given Pages instance to perform page reads
-// asynchronoulsy in a separate goroutine.
+// asynchronously in a separate goroutine.
 //
 // Performing page reads asynchronously is important when the application may
 // be reading pages from a high latency backend, and processing of the last

--- a/row_group.go
+++ b/row_group.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"runtime"
 	"strings"
-	"sync"
 )
 
 // RowGroup is an interface representing a parquet row group. From the Parquet
@@ -259,6 +258,7 @@ type rowGroupRows struct {
 	seek     int64
 	inited   bool
 	closed   bool
+	cancel   context.CancelFunc
 }
 
 func (r *rowGroupRows) init() {
@@ -268,20 +268,17 @@ func (r *rowGroupRows) init() {
 	columnPaths := schema.Columns()
 
 	columns := r.rowGroup.ColumnChunks()
+	readers := make([]asyncPages, len(columns))
 	buffer := make([]Value, columnBufferSize*len(columns))
 	r.columns = make([]columnChunkReader, len(columns))
 
-	readers := make([]asyncPages, len(columns))
-	waitGroups := make([]sync.WaitGroup, len(columns))
+	ctx, cancel := context.WithCancel(context.Background())
 
 	for i, column := range columns {
 		columnPath := strings.Join(columnPaths[i], ".")
 
 		reader := &readers[i]
-		reader.base = column.Pages()
-		reader.seek = r.seek
-		reader.join = &waitGroups[i]
-		reader.init(context.Background(),
+		reader.init(ctx, column.Pages(),
 			"parquet.column", columnPath,
 			"parquet.schema", schemaName,
 		)
@@ -291,6 +288,7 @@ func (r *rowGroupRows) init() {
 		buffer = buffer[columnBufferSize:]
 	}
 
+	r.cancel = cancel
 	r.inited = true
 	// This finalizer is used to ensure that the goroutines started by calling
 	// init on the underlying page readers will be shutdown in the event that
@@ -310,6 +308,7 @@ func (r *rowGroupRows) Reset() {
 
 func (r *rowGroupRows) Close() error {
 	var lastErr error
+	r.cancel()
 
 	for i := range r.columns {
 		if err := r.columns[i].close(); err != nil {

--- a/row_group.go
+++ b/row_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime"
 	"strings"
 	"sync"
 )
@@ -291,6 +292,10 @@ func (r *rowGroupRows) init() {
 	}
 
 	r.inited = true
+	// This finalizer is used to ensure that the goroutines started by calling
+	// init on the underlying page readers will be shutdown in the event that
+	// Close isn't called and the rowGroupRows object is garbage collected.
+	runtime.SetFinalizer(r, func(r *rowGroupRows) { r.Close() })
 }
 
 func (r *rowGroupRows) Reset() {

--- a/row_group.go
+++ b/row_group.go
@@ -272,7 +272,6 @@ func (r *rowGroupRows) init() {
 
 	readers := make([]asyncPages, len(columns))
 	waitGroups := make([]sync.WaitGroup, len(columns))
-	background := context.Background()
 
 	for i, column := range columns {
 		columnPath := strings.Join(columnPaths[i], ".")
@@ -281,7 +280,7 @@ func (r *rowGroupRows) init() {
 		reader.base = column.Pages()
 		reader.seek = r.seek
 		reader.join = &waitGroups[i]
-		reader.init(background,
+		reader.init(context.Background(),
 			"parquet.column", columnPath,
 			"parquet.schema", schemaName,
 		)


### PR DESCRIPTION
This PR is an alternative to #300, which should be a more general way to address #248 

The implementation uses a separate goroutine to read column pages, allowing the processing to happen concurrently.

A potential downside is that we might read a bit more data than necessary, as we would likely consume two pages per column minimum, even tho only a single page might be needed (e.g. if just one row is being read). We can figure out how to optimize this later I think.

Goroutines introduce concurrency and complexity, but they also integrate well with the Go language, which I believe is the trade off we're working with here. Code extensibility and simplicity is important, using parallel I/O will be more complex and make it more difficult to integrate with existing Go code. 