### PR TITLE
remove parquet.BufferedPage specialization

### DIFF
--- a/column.go
+++ b/column.go
@@ -598,9 +598,9 @@ func (c *Column) decodeDataPage(header DataPageHeader, numValues int64, repetiti
 	newPage := pageType.NewPage(c.Index(), int(numValues), values)
 	switch {
 	case c.maxRepetitionLevel > 0:
-		newPage = newRepeatedPage(newPage.Buffer(), c.maxRepetitionLevel, c.maxDefinitionLevel, repetitionLevels, definitionLevels)
+		newPage = newRepeatedPage(newPage, c.maxRepetitionLevel, c.maxDefinitionLevel, repetitionLevels, definitionLevels)
 	case c.maxDefinitionLevel > 0:
-		newPage = newOptionalPage(newPage.Buffer(), c.maxDefinitionLevel, definitionLevels)
+		newPage = newOptionalPage(newPage, c.maxDefinitionLevel, definitionLevels)
 	}
 	return newPage, nil
 }

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -46,8 +46,8 @@ type ColumnBuffer interface {
 	// the original, mutations of either column will not modify the other.
 	Clone() ColumnBuffer
 
-	// Returns the column as a BufferedPage.
-	Page() BufferedPage
+	// Returns the column as a Page.
+	Page() Page
 
 	// Clears all rows written to the column.
 	Reset()
@@ -207,7 +207,7 @@ func (col *optionalColumnBuffer) Pages() Pages {
 	return onePage(col.Page())
 }
 
-func (col *optionalColumnBuffer) Page() BufferedPage {
+func (col *optionalColumnBuffer) Page() Page {
 	// No need for any cyclic sorting if the rows have not been reordered.
 	// This case is also important because the cyclic sorting modifies the
 	// buffer which makes it unsafe to read the buffer concurrently.
@@ -497,7 +497,7 @@ func (col *repeatedColumnBuffer) Pages() Pages {
 	return onePage(col.Page())
 }
 
-func (col *repeatedColumnBuffer) Page() BufferedPage {
+func (col *repeatedColumnBuffer) Page() Page {
 	if col.reordered {
 		if col.reordering == nil {
 			col.reordering = col.Clone().(*repeatedColumnBuffer)
@@ -757,7 +757,7 @@ func (col *booleanColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *booleanColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *booleanColumnBuffer) Page() BufferedPage { return &col.booleanPage }
+func (col *booleanColumnBuffer) Page() Page { return &col.booleanPage }
 
 func (col *booleanColumnBuffer) Reset() {
 	col.bits = col.bits[:0]
@@ -913,7 +913,7 @@ func (col *int32ColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *int32ColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *int32ColumnBuffer) Page() BufferedPage { return &col.int32Page }
+func (col *int32ColumnBuffer) Page() Page { return &col.int32Page }
 
 func (col *int32ColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1008,7 +1008,7 @@ func (col *int64ColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *int64ColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *int64ColumnBuffer) Page() BufferedPage { return &col.int64Page }
+func (col *int64ColumnBuffer) Page() Page { return &col.int64Page }
 
 func (col *int64ColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1102,7 +1102,7 @@ func (col *int96ColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *int96ColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *int96ColumnBuffer) Page() BufferedPage { return &col.int96Page }
+func (col *int96ColumnBuffer) Page() Page { return &col.int96Page }
 
 func (col *int96ColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1195,7 +1195,7 @@ func (col *floatColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *floatColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *floatColumnBuffer) Page() BufferedPage { return &col.floatPage }
+func (col *floatColumnBuffer) Page() Page { return &col.floatPage }
 
 func (col *floatColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1289,7 +1289,7 @@ func (col *doubleColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *doubleColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *doubleColumnBuffer) Page() BufferedPage { return &col.doublePage }
+func (col *doubleColumnBuffer) Page() Page { return &col.doublePage }
 
 func (col *doubleColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1401,7 +1401,7 @@ func (col *byteArrayColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *byteArrayColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *byteArrayColumnBuffer) Page() BufferedPage {
+func (col *byteArrayColumnBuffer) Page() Page {
 	if len(col.lengths) > 0 && orderOfUint32(col.offsets) < 1 { // unordered?
 		if cap(col.scratch) < len(col.values) {
 			col.scratch = make([]byte, 0, cap(col.values))
@@ -1561,7 +1561,7 @@ func (col *fixedLenByteArrayColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *fixedLenByteArrayColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *fixedLenByteArrayColumnBuffer) Page() BufferedPage { return &col.fixedLenByteArrayPage }
+func (col *fixedLenByteArrayColumnBuffer) Page() Page { return &col.fixedLenByteArrayPage }
 
 func (col *fixedLenByteArrayColumnBuffer) Reset() { col.data = col.data[:0] }
 
@@ -1677,7 +1677,7 @@ func (col *uint32ColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *uint32ColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *uint32ColumnBuffer) Page() BufferedPage { return &col.uint32Page }
+func (col *uint32ColumnBuffer) Page() Page { return &col.uint32Page }
 
 func (col *uint32ColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1771,7 +1771,7 @@ func (col *uint64ColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *uint64ColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *uint64ColumnBuffer) Page() BufferedPage { return &col.uint64Page }
+func (col *uint64ColumnBuffer) Page() Page { return &col.uint64Page }
 
 func (col *uint64ColumnBuffer) Reset() { col.values = col.values[:0] }
 
@@ -1869,7 +1869,7 @@ func (col *be128ColumnBuffer) Dictionary() Dictionary { return nil }
 
 func (col *be128ColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *be128ColumnBuffer) Page() BufferedPage { return &col.be128Page }
+func (col *be128ColumnBuffer) Page() Page { return &col.be128Page }
 
 func (col *be128ColumnBuffer) Reset() { col.values = col.values[:0] }
 

--- a/convert.go
+++ b/convert.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"sync"
+
+	"github.com/segmentio/parquet-go/encoding"
 )
 
 // ConvertError is an error type returned by calls to Convert when the conversion
@@ -331,11 +333,13 @@ func (p missingPage) NumRows() int64                    { return p.numRows }
 func (p missingPage) NumValues() int64                  { return p.numValues }
 func (p missingPage) NumNulls() int64                   { return p.numNulls }
 func (p missingPage) Bounds() (min, max Value, ok bool) { return }
+func (p missingPage) Clone() Page                       { return p }
+func (p missingPage) Slice(i, j int64) Page             { return p }
 func (p missingPage) Size() int64                       { return 0 }
+func (p missingPage) RepetitionLevels() []byte          { return nil }
+func (p missingPage) DefinitionLevels() []byte          { return nil }
+func (p missingPage) Data() encoding.Values             { return p.typ.NewValues(nil, nil) }
 func (p missingPage) Values() ValueReader               { return &missingPageValues{page: p} }
-func (p missingPage) Buffer() BufferedPage {
-	return newErrorPage(p.Type(), p.Column(), "cannot buffer missing page")
-}
 
 type missingPageValues struct {
 	page missingPage

--- a/dictionary.go
+++ b/dictionary.go
@@ -75,11 +75,11 @@ type Dictionary interface {
 	// Resets the dictionary to its initial state, removing all values.
 	Reset()
 
-	// Returns a BufferedPage representing the content of the dictionary.
+	// Returns a Page representing the content of the dictionary.
 	//
 	// The returned page shares the underlying memory of the buffer, it remains
 	// valid to use until the dictionary's Reset method is called.
-	Page() BufferedPage
+	Page() Page
 
 	// See ColumnBuffer.writeValues for details on the use of unexported methods
 	// on interfaces.
@@ -211,7 +211,7 @@ func (d *booleanDictionary) Reset() {
 	d.table = [2]int32{-1, -1}
 }
 
-func (d *booleanDictionary) Page() BufferedPage {
+func (d *booleanDictionary) Page() Page {
 	return &d.booleanPage
 }
 
@@ -311,7 +311,7 @@ func (d *int32Dictionary) Reset() {
 	}
 }
 
-func (d *int32Dictionary) Page() BufferedPage {
+func (d *int32Dictionary) Page() Page {
 	return &d.int32Page
 }
 
@@ -398,7 +398,7 @@ func (d *int64Dictionary) Reset() {
 	}
 }
 
-func (d *int64Dictionary) Page() BufferedPage {
+func (d *int64Dictionary) Page() Page {
 	return &d.int64Page
 }
 
@@ -493,7 +493,7 @@ func (d *int96Dictionary) Reset() {
 	d.hashmap = nil
 }
 
-func (d *int96Dictionary) Page() BufferedPage {
+func (d *int96Dictionary) Page() Page {
 	return &d.int96Page
 }
 
@@ -580,7 +580,7 @@ func (d *floatDictionary) Reset() {
 	}
 }
 
-func (d *floatDictionary) Page() BufferedPage {
+func (d *floatDictionary) Page() Page {
 	return &d.floatPage
 }
 
@@ -667,7 +667,7 @@ func (d *doubleDictionary) Reset() {
 	}
 }
 
-func (d *doubleDictionary) Page() BufferedPage {
+func (d *doubleDictionary) Page() Page {
 	return &d.doublePage
 }
 
@@ -794,7 +794,7 @@ func (d *byteArrayDictionary) Reset() {
 	}
 }
 
-func (d *byteArrayDictionary) Page() BufferedPage {
+func (d *byteArrayDictionary) Page() Page {
 	return &d.byteArrayPage
 }
 
@@ -909,7 +909,7 @@ func (d *fixedLenByteArrayDictionary) Reset() {
 	d.hashmap = nil
 }
 
-func (d *fixedLenByteArrayDictionary) Page() BufferedPage {
+func (d *fixedLenByteArrayDictionary) Page() Page {
 	return &d.fixedLenByteArrayPage
 }
 
@@ -996,7 +996,7 @@ func (d *uint32Dictionary) Reset() {
 	}
 }
 
-func (d *uint32Dictionary) Page() BufferedPage {
+func (d *uint32Dictionary) Page() Page {
 	return &d.uint32Page
 }
 
@@ -1083,7 +1083,7 @@ func (d *uint64Dictionary) Reset() {
 	}
 }
 
-func (d *uint64Dictionary) Page() BufferedPage {
+func (d *uint64Dictionary) Page() Page {
 	return &d.uint64Page
 }
 
@@ -1201,7 +1201,7 @@ func (d *be128Dictionary) Reset() {
 	}
 }
 
-func (d *be128Dictionary) Page() BufferedPage {
+func (d *be128Dictionary) Page() Page {
 	return &d.be128Page
 }
 
@@ -1229,7 +1229,7 @@ func (t *indexedType) NewValues(values []byte, _ []uint32) encoding.Values {
 	return encoding.Int32ValuesFromBytes(values)
 }
 
-// indexedPage is an implementation of the BufferedPage interface which stores
+// indexedPage is an implementation of the Page interface which stores
 // indexes instead of plain value. The indexes reference the values in a
 // dictionary that the page was created for.
 type indexedPage struct {
@@ -1288,8 +1288,6 @@ func (page *indexedPage) Data() encoding.Values { return encoding.Int32Values(pa
 
 func (page *indexedPage) Values() ValueReader { return &indexedPageValues{page: page} }
 
-func (page *indexedPage) Buffer() BufferedPage { return page }
-
 func (page *indexedPage) Bounds() (min, max Value, ok bool) {
 	if ok = len(page.values) > 0; ok {
 		min, max = page.typ.dict.Bounds(page.values)
@@ -1299,7 +1297,7 @@ func (page *indexedPage) Bounds() (min, max Value, ok bool) {
 	return min, max, ok
 }
 
-func (page *indexedPage) Clone() BufferedPage {
+func (page *indexedPage) Clone() Page {
 	return &indexedPage{
 		typ:         page.typ,
 		values:      append([]int32{}, page.values...),
@@ -1307,7 +1305,7 @@ func (page *indexedPage) Clone() BufferedPage {
 	}
 }
 
-func (page *indexedPage) Slice(i, j int64) BufferedPage {
+func (page *indexedPage) Slice(i, j int64) Page {
 	return &indexedPage{
 		typ:         page.typ,
 		values:      page.values[i:j],
@@ -1383,7 +1381,7 @@ func (col *indexedColumnBuffer) Dictionary() Dictionary { return col.typ.dict }
 
 func (col *indexedColumnBuffer) Pages() Pages { return onePage(col.Page()) }
 
-func (col *indexedColumnBuffer) Page() BufferedPage { return &col.indexedPage }
+func (col *indexedColumnBuffer) Page() Page { return &col.indexedPage }
 
 func (col *indexedColumnBuffer) Reset() { col.values = col.values[:0] }
 

--- a/file.go
+++ b/file.go
@@ -531,7 +531,7 @@ func (f *filePages) ReadPage() (Page, error) {
 			seek := f.skip
 			f.skip = 0
 			if seek > 0 {
-				page = page.Buffer().Slice(seek, numRows)
+				page = page.Slice(seek, numRows)
 			}
 			return page, nil
 		}

--- a/writer.go
+++ b/writer.go
@@ -729,12 +729,12 @@ func encodeLevels(dst, src []byte, maxLevel byte) ([]byte, error) {
 	return levelEncodingsRLE[bitWidth-1].EncodeLevels(dst, src)
 }
 
-func (wb *writerBuffers) encodeRepetitionLevels(page BufferedPage, maxRepetitionLevel byte) (err error) {
+func (wb *writerBuffers) encodeRepetitionLevels(page Page, maxRepetitionLevel byte) (err error) {
 	wb.repetitions, err = encodeLevels(wb.repetitions, page.RepetitionLevels(), maxRepetitionLevel)
 	return
 }
 
-func (wb *writerBuffers) encodeDefinitionLevels(page BufferedPage, maxDefinitionLevel byte) (err error) {
+func (wb *writerBuffers) encodeDefinitionLevels(page Page, maxDefinitionLevel byte) (err error) {
 	wb.definitions, err = encodeLevels(wb.definitions, page.DefinitionLevels(), maxDefinitionLevel)
 	return
 }
@@ -768,7 +768,7 @@ func (wb *writerBuffers) prependLevelsToDataPageV1(maxRepetitionLevel, maxDefini
 	}
 }
 
-func (wb *writerBuffers) encode(page BufferedPage, enc encoding.Encoding) (err error) {
+func (wb *writerBuffers) encode(page Page, enc encoding.Encoding) (err error) {
 	pageType := page.Type()
 	pageData := page.Data()
 	wb.page, err = pageType.Encode(wb.page[:0], pageData, enc)
@@ -814,7 +814,7 @@ type writerColumn struct {
 
 	filter struct {
 		bits  []byte
-		pages []BufferedPage
+		pages []Page
 	}
 
 	numRows        int64
@@ -888,7 +888,7 @@ func (c *writerColumn) flush() (err error) {
 	if c.numValues != 0 {
 		c.numValues = 0
 		defer c.columnBuffer.Reset()
-		_, err = c.writeBufferedPage(c.columnBuffer.Page())
+		_, err = c.writeDataPage(c.columnBuffer.Page())
 	}
 	return err
 }
@@ -1001,26 +1001,15 @@ func (c *writerColumn) WritePage(page Page) (numValues int64, err error) {
 		// optimize the write path by copying whole pages without decoding them
 		// into a sequence of values.
 		if c.numValues == 0 {
-			switch p := page.(type) {
-			case BufferedPage:
-				// Buffered pages may be larger than the target page size on the
-				// column, in which case multiple pages get written by slicing
-				// the original page into sub-pages.
-				err = forEachPageSlice(p, int64(c.bufferSize), func(p BufferedPage) error {
-					n, err := c.writeBufferedPage(p)
-					numValues += n
-					return err
-				})
-				return numValues, err
-
-				//case CompressedPage:
-				// Compressed pages are written as-is to the compressed page
-				// buffers; those pages should be coming from parquet files that
-				// are being copied into a new file, they are simply copied to
-				// amortize the cost of decoding and re-encoding the pages, which
-				// often includes costly compression steps.
-				//return c.writeCompressedPage(p)
-			}
+			// Buffered pages may be larger than the target page size on the
+			// column, in which case multiple pages get written by slicing
+			// the original page into sub-pages.
+			err = forEachPageSlice(page, int64(c.bufferSize), func(p Page) error {
+				n, err := c.writeDataPage(p)
+				numValues += n
+				return err
+			})
+			return numValues, err
 		}
 	}
 
@@ -1054,7 +1043,7 @@ func (c *writerColumn) writeBloomFilter(w io.Writer) error {
 	return err
 }
 
-func (c *writerColumn) writeBufferedPage(page BufferedPage) (int64, error) {
+func (c *writerColumn) writeDataPage(page Page) (int64, error) {
 	numValues := page.NumValues()
 	if numValues == 0 {
 		return 0, nil
@@ -1151,7 +1140,7 @@ func (c *writerColumn) writeBufferedPage(page BufferedPage) (int64, error) {
 		int64(len(buf.definitions)) +
 		int64(len(buf.page))
 
-	err := c.writePage(size, func(output io.Writer) (written int64, err error) {
+	err := c.writePageTo(size, func(output io.Writer) (written int64, err error) {
 		for _, data := range [...][]byte{
 			buf.header.Bytes(),
 			buf.repetitions,
@@ -1173,71 +1162,6 @@ func (c *writerColumn) writeBufferedPage(page BufferedPage) (int64, error) {
 	c.recordPageStats(int32(buf.header.Len()), pageHeader, page)
 	return numValues, nil
 }
-
-// Disable for now, will bring back when we optimize page copies.
-/*
-func (c *writerColumn) writeCompressedPage(page CompressedPage) (int64, error) {
-	if page.Dictionary() == nil {
-		switch {
-		case len(c.filter.bits) > 0:
-			// TODO: modify the Buffer method to accept some kind of buffer pool as
-			// argument so we can use a pre-allocated page buffer to load the page
-			// and reduce the memory footprint.
-			bufferedPage := page.Buffer()
-			// The compressed page must be decompressed here in order to generate
-			// the bloom filter. Note that we don't re-compress it which still saves
-			// most of the compute cost (compression algorithms are usually designed
-			// to make decompressing much cheaper than compressing since it happens
-			// more often).
-			if err := c.writePageToFilter(bufferedPage); err != nil {
-				return 0, err
-			}
-		case c.columnFilter != nil && c.dictionary == nil:
-			// When a column filter is configured but no page filter was allocated,
-			// we need to buffer the page in order to have access to the number of
-			// values and properly size the bloom filter when writing the row group.
-			c.filter.pages = append(c.filter.pages, page.Buffer())
-		}
-	}
-
-	pageHeader := &format.PageHeader{
-		UncompressedPageSize: int32(page.Size()),
-		CompressedPageSize:   int32(page.PageSize()),
-		CRC:                  int32(page.CRC()),
-	}
-
-	switch h := page.PageHeader().(type) {
-	case DataPageHeaderV1:
-		pageHeader.DataPageHeader = h.header
-	case DataPageHeaderV2:
-		pageHeader.DataPageHeaderV2 = h.header
-	default:
-		return 0, fmt.Errorf("writing compressed page type of unknown type: %s", h.PageType())
-	}
-
-	header := &c.buffers.header
-	header.Reset()
-	if err := c.header.encoder.Encode(pageHeader); err != nil {
-		return 0, err
-	}
-	headerSize := int32(header.Len())
-	compressedSize := int64(headerSize + pageHeader.CompressedPageSize)
-
-	err := c.writePage(compressedSize, func(output io.Writer) (int64, error) {
-		headerSize, err := header.WriteTo(output)
-		if err != nil {
-			return headerSize, err
-		}
-		dataSize, err := io.Copy(output, page.PageData())
-		return headerSize + dataSize, err
-	})
-	if err != nil {
-		return 0, err
-	}
-	c.recordPageStats(headerSize, pageHeader, page)
-	return page.NumValues(), nil
-}
-*/
 
 func (c *writerColumn) writeDictionaryPage(output io.Writer, dict Dictionary) (err error) {
 	buf := c.buffers
@@ -1281,14 +1205,14 @@ func (c *writerColumn) writeDictionaryPage(output io.Writer, dict Dictionary) (e
 	return nil
 }
 
-func (w *writerColumn) writePageToFilter(page BufferedPage) (err error) {
+func (w *writerColumn) writePageToFilter(page Page) (err error) {
 	pageType := page.Type()
 	pageData := page.Data()
 	w.filter.bits, err = pageType.Encode(w.filter.bits, pageData, w.columnFilter.Encoding())
 	return err
 }
 
-func (c *writerColumn) writePage(size int64, writeTo func(io.Writer) (int64, error)) error {
+func (c *writerColumn) writePageTo(size int64, writeTo func(io.Writer) (int64, error)) error {
 	buffer := c.pool.GetPageBuffer()
 	defer func() {
 		if buffer != nil {


### PR DESCRIPTION
Based on #297, this PR removes the `parquet.BufferedPage` interface. I found that the complexity cost of separating the _Page_ concept between `parquet.Page` and `parquet.BufferedPage` was off, and almost all the `parquet.Page` implementations we had in the package satisfied `parquet.BufferedPage`.

The PR merges `parquet.BufferedPage` into `parquet.Page`.