### PR TITLE
Optimize page buffer allocations

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -314,8 +314,12 @@ func (b *buffer) reset() {
 func (b *buffer) resize(size int) {
 	if cap(b.data) < size {
 		const pageSize = 4096
-		alignedBufferSize := ((size + (pageSize - 1)) / pageSize) * pageSize
-		b.data = make([]byte, size, alignedBufferSize)
+		minSize := 2 * cap(b.data)
+		bufferSize := ((size + (pageSize - 1)) / pageSize) * pageSize
+		if bufferSize < minSize {
+			bufferSize = minSize
+		}
+		b.data = make([]byte, size, bufferSize)
 	} else {
 		b.data = b.data[:size]
 	}

--- a/column.go
+++ b/column.go
@@ -487,10 +487,10 @@ func schemaRepetitionTypeOf(s *format.SchemaElement) format.FieldRepetitionType 
 	return format.Required
 }
 
-func (c *Column) decompress(compressedPageData []byte, compressedPageSize int32) (page *buffer, err error) {
+func (c *Column) decompress(compressedPageData []byte, uncompressedPageSize int32) (page *buffer, err error) {
 	page = uncompressedPageBufferPool.get()
-	if compressedPageSize > 0 {
-		page.resize(int(compressedPageSize))
+	if uncompressedPageSize > 0 {
+		page.resize(int(uncompressedPageSize))
 	}
 	page.data, err = c.compression.Decode(page.data, compressedPageData)
 	if err != nil {

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -248,7 +248,8 @@ func (col *optionalColumnBuffer) Page() Page {
 		col.reordered = false
 	}
 
-	return newOptionalPage(col.base.Page(), col.maxDefinitionLevel, col.definitionLevels)
+	definitionLevels := makeBufferRef(&buffer{data: col.definitionLevels})
+	return newOptionalPage(col.base.Page(), col.maxDefinitionLevel, definitionLevels)
 }
 
 func (col *optionalColumnBuffer) Reset() {
@@ -550,12 +551,14 @@ func (col *repeatedColumnBuffer) Page() Page {
 		col.reordered = false
 	}
 
+	repetitionLevels := makeBufferRef(&buffer{data: col.repetitionLevels})
+	definitionLevels := makeBufferRef(&buffer{data: col.definitionLevels})
 	return newRepeatedPage(
 		col.base.Page(),
 		col.maxRepetitionLevel,
 		col.maxDefinitionLevel,
-		col.repetitionLevels,
-		col.definitionLevels,
+		repetitionLevels,
+		definitionLevels,
 	)
 }
 

--- a/file.go
+++ b/file.go
@@ -511,6 +511,8 @@ func (f *filePages) ReadPage() (Page, error) {
 			err = fmt.Errorf("cannot read values of type %s from page", header.Type)
 		}
 
+		data.unref()
+
 		if err != nil {
 			return nil, fmt.Errorf("decoding page %d of column %q: %w", f.index, f.columnPath(), err)
 		}

--- a/page.go
+++ b/page.go
@@ -317,7 +317,10 @@ func forEachPageSlice(page Page, wantSize int64, do func(Page) error) error {
 
 	for numPages > 0 {
 		lastRowIndex := rowIndex + ((numRows - rowIndex) / numPages)
-		if err := do(page.Slice(rowIndex, lastRowIndex)); err != nil {
+		pageSlice := page.Slice(rowIndex, lastRowIndex)
+		err := do(pageSlice)
+		unref(pageSlice)
+		if err != nil {
 			return err
 		}
 		rowIndex = lastRowIndex

--- a/page.go
+++ b/page.go
@@ -374,10 +374,10 @@ func errPageBoundsOutOfRange(i, j, n int64) error {
 type optionalPage struct {
 	base               Page
 	maxDefinitionLevel byte
-	definitionLevels   []byte
+	definitionLevels   bufferRef
 }
 
-func newOptionalPage(base Page, maxDefinitionLevel byte, definitionLevels []byte) *optionalPage {
+func newOptionalPage(base Page, maxDefinitionLevel byte, definitionLevels bufferRef) *optionalPage {
 	return &optionalPage{
 		base:               base,
 		maxDefinitionLevel: maxDefinitionLevel,
@@ -391,21 +391,21 @@ func (page *optionalPage) Column() int { return page.base.Column() }
 
 func (page *optionalPage) Dictionary() Dictionary { return page.base.Dictionary() }
 
-func (page *optionalPage) NumRows() int64 { return int64(len(page.definitionLevels)) }
+func (page *optionalPage) NumRows() int64 { return int64(page.definitionLevels.len) }
 
-func (page *optionalPage) NumValues() int64 { return int64(len(page.definitionLevels)) }
+func (page *optionalPage) NumValues() int64 { return int64(page.definitionLevels.len) }
 
 func (page *optionalPage) NumNulls() int64 {
-	return int64(countLevelsNotEqual(page.definitionLevels, page.maxDefinitionLevel))
+	return int64(countLevelsNotEqual(page.definitionLevels.data(), page.maxDefinitionLevel))
 }
 
 func (page *optionalPage) Bounds() (min, max Value, ok bool) { return page.base.Bounds() }
 
-func (page *optionalPage) Size() int64 { return page.base.Size() + int64(len(page.definitionLevels)) }
+func (page *optionalPage) Size() int64 { return page.base.Size() + int64(page.definitionLevels.len) }
 
 func (page *optionalPage) RepetitionLevels() []byte { return nil }
 
-func (page *optionalPage) DefinitionLevels() []byte { return page.definitionLevels }
+func (page *optionalPage) DefinitionLevels() []byte { return page.definitionLevels.data() }
 
 func (page *optionalPage) Data() encoding.Values { return page.base.Data() }
 
@@ -420,17 +420,18 @@ func (page *optionalPage) Clone() Page {
 	return newOptionalPage(
 		page.base.Clone(),
 		page.maxDefinitionLevel,
-		append([]byte{}, page.definitionLevels...),
+		page.definitionLevels.clone(),
 	)
 }
 
 func (page *optionalPage) Slice(i, j int64) Page {
-	numNulls1 := int64(countLevelsNotEqual(page.definitionLevels[:i], page.maxDefinitionLevel))
-	numNulls2 := int64(countLevelsNotEqual(page.definitionLevels[i:j], page.maxDefinitionLevel))
+	definitionLevels := page.definitionLevels.data()
+	numNulls1 := int64(countLevelsNotEqual(definitionLevels[:i], page.maxDefinitionLevel))
+	numNulls2 := int64(countLevelsNotEqual(definitionLevels[i:j], page.maxDefinitionLevel))
 	return newOptionalPage(
 		page.base.Slice(i-numNulls1, j-(numNulls1+numNulls2)),
 		page.maxDefinitionLevel,
-		page.definitionLevels[i:j],
+		page.definitionLevels.slice(int(i), int(j)),
 	)
 }
 
@@ -438,11 +439,11 @@ type repeatedPage struct {
 	base               Page
 	maxRepetitionLevel byte
 	maxDefinitionLevel byte
-	definitionLevels   []byte
-	repetitionLevels   []byte
+	definitionLevels   bufferRef
+	repetitionLevels   bufferRef
 }
 
-func newRepeatedPage(base Page, maxRepetitionLevel, maxDefinitionLevel byte, repetitionLevels, definitionLevels []byte) *repeatedPage {
+func newRepeatedPage(base Page, maxRepetitionLevel, maxDefinitionLevel byte, repetitionLevels, definitionLevels bufferRef) *repeatedPage {
 	return &repeatedPage{
 		base:               base,
 		maxRepetitionLevel: maxRepetitionLevel,
@@ -458,23 +459,27 @@ func (page *repeatedPage) Column() int { return page.base.Column() }
 
 func (page *repeatedPage) Dictionary() Dictionary { return page.base.Dictionary() }
 
-func (page *repeatedPage) NumRows() int64 { return int64(countLevelsEqual(page.repetitionLevels, 0)) }
+func (page *repeatedPage) NumRows() int64 {
+	return int64(countLevelsEqual(page.repetitionLevels.data(), 0))
+}
 
-func (page *repeatedPage) NumValues() int64 { return int64(len(page.definitionLevels)) }
+func (page *repeatedPage) NumValues() int64 {
+	return int64(page.definitionLevels.len)
+}
 
 func (page *repeatedPage) NumNulls() int64 {
-	return int64(countLevelsNotEqual(page.definitionLevels, page.maxDefinitionLevel))
+	return int64(countLevelsNotEqual(page.definitionLevels.data(), page.maxDefinitionLevel))
 }
 
 func (page *repeatedPage) Bounds() (min, max Value, ok bool) { return page.base.Bounds() }
 
 func (page *repeatedPage) Size() int64 {
-	return int64(len(page.repetitionLevels)) + int64(len(page.definitionLevels)) + page.base.Size()
+	return int64(page.repetitionLevels.len) + int64(page.definitionLevels.len) + page.base.Size()
 }
 
-func (page *repeatedPage) RepetitionLevels() []byte { return page.repetitionLevels }
+func (page *repeatedPage) RepetitionLevels() []byte { return page.repetitionLevels.data() }
 
-func (page *repeatedPage) DefinitionLevels() []byte { return page.definitionLevels }
+func (page *repeatedPage) DefinitionLevels() []byte { return page.definitionLevels.data() }
 
 func (page *repeatedPage) Data() encoding.Values { return page.base.Data() }
 
@@ -490,8 +495,8 @@ func (page *repeatedPage) Clone() Page {
 		page.base.Clone(),
 		page.maxRepetitionLevel,
 		page.maxDefinitionLevel,
-		append([]byte{}, page.repetitionLevels...),
-		append([]byte{}, page.definitionLevels...),
+		page.repetitionLevels.clone(),
+		page.definitionLevels.clone(),
 	)
 }
 
@@ -507,11 +512,12 @@ func (page *repeatedPage) Slice(i, j int64) Page {
 		panic(errPageBoundsOutOfRange(i, j, numRows))
 	}
 
+	repetitionLevels := page.repetitionLevels.data()
 	rowIndex0 := 0
-	rowIndex1 := len(page.repetitionLevels)
-	rowIndex2 := len(page.repetitionLevels)
+	rowIndex1 := len(repetitionLevels)
+	rowIndex2 := len(repetitionLevels)
 
-	for k, def := range page.repetitionLevels {
+	for k, def := range repetitionLevels {
 		if def == 0 {
 			if rowIndex0 == int(i) {
 				rowIndex1 = k
@@ -521,7 +527,7 @@ func (page *repeatedPage) Slice(i, j int64) Page {
 		}
 	}
 
-	for k, def := range page.repetitionLevels[rowIndex1:] {
+	for k, def := range repetitionLevels[rowIndex1:] {
 		if def == 0 {
 			if rowIndex0 == int(j) {
 				rowIndex2 = rowIndex1 + k
@@ -531,8 +537,9 @@ func (page *repeatedPage) Slice(i, j int64) Page {
 		}
 	}
 
-	numNulls1 := countLevelsNotEqual(page.definitionLevels[:rowIndex1], page.maxDefinitionLevel)
-	numNulls2 := countLevelsNotEqual(page.definitionLevels[rowIndex1:rowIndex2], page.maxDefinitionLevel)
+	definitionLevels := page.definitionLevels.data()
+	numNulls1 := countLevelsNotEqual(definitionLevels[:rowIndex1], page.maxDefinitionLevel)
+	numNulls2 := countLevelsNotEqual(definitionLevels[rowIndex1:rowIndex2], page.maxDefinitionLevel)
 
 	i = int64(rowIndex1 - numNulls1)
 	j = int64(rowIndex2 - (numNulls1 + numNulls2))
@@ -541,8 +548,8 @@ func (page *repeatedPage) Slice(i, j int64) Page {
 		page.base.Slice(i, j),
 		page.maxRepetitionLevel,
 		page.maxDefinitionLevel,
-		page.repetitionLevels[rowIndex1:rowIndex2],
-		page.definitionLevels[rowIndex1:rowIndex2],
+		page.repetitionLevels.slice(int(rowIndex1), int(rowIndex2)),
+		page.definitionLevels.slice(int(rowIndex1), int(rowIndex2)),
 	)
 }
 

--- a/page_values.go
+++ b/page_values.go
@@ -16,12 +16,13 @@ type optionalPageValues struct {
 
 func (r *optionalPageValues) ReadValues(values []Value) (n int, err error) {
 	maxDefinitionLevel := r.page.maxDefinitionLevel
+	definitionLevels := r.page.definitionLevels.data()
 	columnIndex := ^int16(r.page.Column())
 
-	for n < len(values) && r.offset < len(r.page.definitionLevels) {
-		for n < len(values) && r.offset < len(r.page.definitionLevels) && r.page.definitionLevels[r.offset] != maxDefinitionLevel {
+	for n < len(values) && r.offset < len(definitionLevels) {
+		for n < len(values) && r.offset < len(definitionLevels) && definitionLevels[r.offset] != maxDefinitionLevel {
 			values[n] = Value{
-				definitionLevel: r.page.definitionLevels[r.offset],
+				definitionLevel: definitionLevels[r.offset],
 				columnIndex:     columnIndex,
 			}
 			r.offset++
@@ -30,7 +31,7 @@ func (r *optionalPageValues) ReadValues(values []Value) (n int, err error) {
 
 		i := n
 		j := r.offset
-		for i < len(values) && j < len(r.page.definitionLevels) && r.page.definitionLevels[j] == maxDefinitionLevel {
+		for i < len(values) && j < len(definitionLevels) && definitionLevels[j] == maxDefinitionLevel {
 			i++
 			j++
 		}
@@ -49,7 +50,7 @@ func (r *optionalPageValues) ReadValues(values []Value) (n int, err error) {
 		}
 	}
 
-	if r.offset == len(r.page.definitionLevels) {
+	if r.offset == len(definitionLevels) {
 		err = io.EOF
 	}
 	return n, err
@@ -63,13 +64,15 @@ type repeatedPageValues struct {
 
 func (r *repeatedPageValues) ReadValues(values []Value) (n int, err error) {
 	maxDefinitionLevel := r.page.maxDefinitionLevel
+	definitionLevels := r.page.definitionLevels.data()
+	repetitionLevels := r.page.repetitionLevels.data()
 	columnIndex := ^int16(r.page.Column())
 
-	for n < len(values) && r.offset < len(r.page.definitionLevels) {
-		for n < len(values) && r.offset < len(r.page.definitionLevels) && r.page.definitionLevels[r.offset] != maxDefinitionLevel {
+	for n < len(values) && r.offset < len(definitionLevels) {
+		for n < len(values) && r.offset < len(definitionLevels) && definitionLevels[r.offset] != maxDefinitionLevel {
 			values[n] = Value{
-				repetitionLevel: r.page.repetitionLevels[r.offset],
-				definitionLevel: r.page.definitionLevels[r.offset],
+				repetitionLevel: repetitionLevels[r.offset],
+				definitionLevel: definitionLevels[r.offset],
 				columnIndex:     columnIndex,
 			}
 			r.offset++
@@ -78,14 +81,14 @@ func (r *repeatedPageValues) ReadValues(values []Value) (n int, err error) {
 
 		i := n
 		j := r.offset
-		for i < len(values) && j < len(r.page.definitionLevels) && r.page.definitionLevels[j] == maxDefinitionLevel {
+		for i < len(values) && j < len(definitionLevels) && definitionLevels[j] == maxDefinitionLevel {
 			i++
 			j++
 		}
 
 		if n < i {
 			for j, err = r.values.ReadValues(values[n:i]); j > 0; j-- {
-				values[n].repetitionLevel = r.page.repetitionLevels[r.offset]
+				values[n].repetitionLevel = repetitionLevels[r.offset]
 				values[n].definitionLevel = maxDefinitionLevel
 				r.offset++
 				n++
@@ -97,7 +100,7 @@ func (r *repeatedPageValues) ReadValues(values []Value) (n int, err error) {
 		}
 	}
 
-	if r.offset == len(r.page.definitionLevels) {
+	if r.offset == len(definitionLevels) {
 		err = io.EOF
 	}
 	return n, err

--- a/row_group.go
+++ b/row_group.go
@@ -308,7 +308,10 @@ func (r *rowGroupRows) Reset() {
 
 func (r *rowGroupRows) Close() error {
 	var lastErr error
-	r.cancel()
+
+	if r.cancel != nil {
+		r.cancel()
+	}
 
 	for i := range r.columns {
 		if err := r.columns[i].close(); err != nil {


### PR DESCRIPTION
This PR addresses the performance regressions from #297.

I explored various solutions and landed on using reference counted buffers to help manage resources internally. I explored exposing a new API to customize memory management but overall it seemed that starting with an internal-only solution at first would be lower risk.

Overall, some benchmarks are a bit slower, some a bit faster, here is a comparison to the `main` branch:

```
name                                                     old time/op  new time/op  delta
MergeFiles/BOOLEAN/groups=2,rows=20000                   17.0µs ± 0%  17.4µs ± 0%   +2.20%  (p=0.000 n=8+10)
MergeFiles/INT32/groups=2,rows=20000                     7.05µs ± 2%  7.47µs ± 1%   +5.90%  (p=0.000 n=10+10)
MergeFiles/INT64/groups=2,rows=20000                     7.57µs ± 1%  8.01µs ± 1%   +5.80%  (p=0.000 n=10+10)
MergeFiles/INT96/groups=2,rows=20000                     28.4µs ± 2%  34.4µs ± 2%  +20.90%  (p=0.000 n=10+10)
MergeFiles/FLOAT/groups=2,rows=20000                     6.46µs ± 1%  6.60µs ± 0%   +2.23%  (p=0.000 n=10+9)
MergeFiles/DOUBLE/groups=2,rows=20000                    6.81µs ± 1%  7.06µs ± 0%   +3.70%  (p=0.000 n=10+10)
MergeFiles/BYTE_ARRAY/groups=2,rows=20000                52.1µs ± 0%  47.1µs ± 2%   -9.58%  (p=0.000 n=8+10)
MergeFiles/FIXED_LEN_BYTE_ARRAY/groups=2,rows=20000      34.8µs ± 1%  31.4µs ± 3%   -9.89%  (p=0.000 n=9+10)
MergeFiles/STRING/groups=2,rows=20000                    24.6µs ± 0%  21.2µs ± 2%  -13.81%  (p=0.000 n=10+10)
MergeFiles/STRING_(dict)/groups=2,rows=20000             4.92µs ± 0%  7.93µs ± 2%  +61.18%  (p=0.000 n=9+10)
MergeFiles/UUID/groups=2,rows=20000                      16.4µs ± 0%  16.9µs ± 0%   +3.05%  (p=0.000 n=9+10)
MergeFiles/DECIMAL/groups=2,rows=20000                   6.88µs ± 1%  7.03µs ± 1%   +2.16%  (p=0.000 n=10+9)
MergeFiles/AddressBook/groups=2,rows=20000                774µs ± 1%   809µs ± 1%   +4.57%  (p=0.000 n=10+10)
MergeFiles/one_optional_level/groups=2,rows=20000        22.5µs ± 1%  22.9µs ± 1%   +1.96%  (p=0.000 n=10+9)
MergeFiles/one_repeated_level/groups=2,rows=20000         179µs ± 2%   183µs ± 1%   +2.11%  (p=0.000 n=9+10)
MergeFiles/two_repeated_levels/groups=2,rows=20000        973µs ± 0%   993µs ± 1%   +2.00%  (p=0.000 n=8+10)
MergeFiles/three_repeated_levels/groups=2,rows=20000      973µs ± 1%   992µs ± 0%   +1.97%  (p=0.000 n=9+8)
MergeFiles/nested_lists/groups=2,rows=20000              1.16ms ± 1%  1.18ms ± 1%   +1.23%  (p=0.000 n=9+10)
MergeFiles/key-value_pairs/groups=2,rows=20000            307µs ± 1%   301µs ± 1%   -1.76%  (p=0.000 n=10+9)
MergeFiles/multiple_key-value_pairs/groups=2,rows=20000  1.01ms ± 1%  1.10ms ± 1%   +8.22%  (p=0.000 n=10+10)
MergeFiles/repeated_key-value_pairs/groups=2,rows=20000  1.55ms ± 2%  1.61ms ± 1%   +4.03%  (p=0.000 n=10+9)
MergeFiles/map_of_repeated_values/groups=2,rows=20000     890µs ± 2%   930µs ± 1%   +4.44%  (p=0.000 n=10+10)

name                                                     old row/s    new row/s    delta
MergeFiles/BOOLEAN/groups=2,rows=20000                    56.9M ± 0%   55.7M ± 0%   -2.16%  (p=0.000 n=8+10)
MergeFiles/INT32/groups=2,rows=20000                       137M ± 2%    130M ± 1%   -5.58%  (p=0.000 n=10+10)
MergeFiles/INT64/groups=2,rows=20000                       128M ± 1%    121M ± 1%   -5.48%  (p=0.000 n=10+10)
MergeFiles/INT96/groups=2,rows=20000                      34.1M ± 2%   28.2M ± 2%  -17.29%  (p=0.000 n=10+10)
MergeFiles/FLOAT/groups=2,rows=20000                       150M ± 1%    147M ± 0%   -2.18%  (p=0.000 n=10+9)
MergeFiles/DOUBLE/groups=2,rows=20000                      142M ± 1%    137M ± 0%   -3.56%  (p=0.000 n=10+10)
MergeFiles/BYTE_ARRAY/groups=2,rows=20000                 18.6M ± 0%   20.6M ± 2%  +10.61%  (p=0.000 n=8+10)
MergeFiles/FIXED_LEN_BYTE_ARRAY/groups=2,rows=20000       27.8M ± 1%   30.8M ± 2%  +10.99%  (p=0.000 n=9+10)
MergeFiles/STRING/groups=2,rows=20000                     39.4M ± 0%   45.7M ± 2%  +16.03%  (p=0.000 n=10+10)
MergeFiles/STRING_(dict)/groups=2,rows=20000               197M ± 0%    122M ± 2%  -37.95%  (p=0.000 n=9+10)
MergeFiles/UUID/groups=2,rows=20000                       59.1M ± 0%   57.3M ± 0%   -2.96%  (p=0.000 n=9+10)
MergeFiles/DECIMAL/groups=2,rows=20000                     141M ± 1%    138M ± 1%   -2.12%  (p=0.000 n=10+9)
MergeFiles/AddressBook/groups=2,rows=20000                1.25M ± 1%   1.20M ± 1%   -4.37%  (p=0.000 n=10+10)
MergeFiles/one_optional_level/groups=2,rows=20000         43.0M ± 1%   42.2M ± 1%   -1.92%  (p=0.000 n=10+9)
MergeFiles/one_repeated_level/groups=2,rows=20000         5.59M ± 2%   5.47M ± 1%   -2.07%  (p=0.000 n=9+10)
MergeFiles/two_repeated_levels/groups=2,rows=20000        1.03M ± 0%   1.01M ± 1%   -1.96%  (p=0.000 n=8+10)
MergeFiles/three_repeated_levels/groups=2,rows=20000      1.03M ± 1%   1.01M ± 0%   -1.93%  (p=0.000 n=9+8)
MergeFiles/nested_lists/groups=2,rows=20000                861k ± 1%    851k ± 1%   -1.21%  (p=0.000 n=9+10)
MergeFiles/key-value_pairs/groups=2,rows=20000            3.26M ± 1%   3.32M ± 1%   +1.79%  (p=0.000 n=10+9)
MergeFiles/multiple_key-value_pairs/groups=2,rows=20000    988k ± 1%    913k ± 1%   -7.58%  (p=0.000 n=10+10)
MergeFiles/repeated_key-value_pairs/groups=2,rows=20000    647k ± 2%    622k ± 1%   -3.89%  (p=0.000 n=10+9)
MergeFiles/map_of_repeated_values/groups=2,rows=20000     1.12M ± 2%   1.08M ± 1%   -4.27%  (p=0.000 n=10+10)
```