### PR TITLE
Handle Optional Map Fields By Adding Map case in nullIndexFuncOf

### DIFF
--- a/null.go
+++ b/null.go
@@ -77,6 +77,9 @@ func nullIndexFuncOf(t reflect.Type) nullIndexFunc {
 	case reflect.Slice:
 		return nullIndexSlice
 
+	case reflect.Map:
+		return nullIndexPointer
+
 	case reflect.Array:
 		if t.Elem().Kind() == reflect.Uint8 {
 			switch size := t.Len(); size {


### PR DESCRIPTION
The `optional` tag requires handling null value cases for the null index on optional columns.

This PR adds the necessary case statement to handle maps.

Fixes #302 