### PR TITLE
Add guard code in sparse array `offset()`

### DIFF
--- a/sparse/array.go
+++ b/sparse/array.go
@@ -55,6 +55,19 @@ func (a array) slice(i, j int) array {
 }
 
 func (a array) offset(off uintptr) array {
+	if a.off == 0 {
+		off = 0
+		a.len = 0
+	} else {
+		offsetSize := off / a.off
+		if a.len > offsetSize {
+			a.len -= offsetSize
+		} else {
+			off = 0
+			a.len = 0
+		}
+	}
+
 	return array{
 		ptr: unsafe.Add(a.ptr, off),
 		len: a.len,


### PR DESCRIPTION
This code was suggested by @vc42-2. We have tested it in an environment writing 66k rows/second. Without this change we would see this panic ~10-20 times an hour. This change has been running for ~2 hours with no GC crashes.

I have no idea if this fix is appropriate or not :), but I'd like to move the conversation forward on this issue. It is currently blocking the very nice performance improvements gained by moving to `GenericWriter`.

Fixes #299.

@vc42-2 Heads up that I submitted this fix. This is your code and I'd be glad to drop this PR in favor of your own.