### PR TITLE
Configurable read buffer

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ const (
 type FileConfig struct {
 	SkipPageIndex    bool
 	SkipBloomFilters bool
+	ReadBufferSize   int
 }
 
 // DefaultFileConfig returns a new FileConfig value initialized with the
@@ -39,6 +40,7 @@ func DefaultFileConfig() *FileConfig {
 	return &FileConfig{
 		SkipPageIndex:    DefaultSkipPageIndex,
 		SkipBloomFilters: DefaultSkipBloomFilters,
+		ReadBufferSize:   defaultReadBufferSize,
 	}
 }
 
@@ -311,6 +313,16 @@ func SkipPageIndex(skip bool) FileOption {
 // Defaults to false.
 func SkipBloomFilters(skip bool) FileOption {
 	return fileOption(func(config *FileConfig) { config.SkipBloomFilters = skip })
+}
+
+// ReadBufferSize is a file configuration option which controls the default
+// buffer sizes for reads made to the provided io.Reader. The default of 4096
+// is appropriate for disk based access but if your reader is backed by something
+// like network storage it can be advantageous to increase this value.
+//
+// Defaults to 4096.
+func ReadBufferSize(sz int) FileOption {
+	return fileOption(func(config *FileConfig) { config.ReadBufferSize = sz })
 }
 
 // PageBufferSize configures the size of column page buffers on parquet writers.

--- a/file.go
+++ b/file.go
@@ -701,7 +701,7 @@ func (f *filePages) columnPath() columnPath {
 }
 
 var (
-	bufioReaderPoolLock sync.RWMutex
+	bufioReaderPoolLock sync.Mutex
 	bufioReaderPool     = map[int]*sync.Pool{}
 )
 
@@ -723,15 +723,12 @@ func putBufioReader(rbuf *bufio.Reader) {
 }
 
 func getBufioReaderPool(size int) *sync.Pool {
-	bufioReaderPoolLock.RLock()
-	if pool := bufioReaderPool[size]; pool != nil {
-		bufioReaderPoolLock.RUnlock()
-		return pool
-	}
-	bufioReaderPoolLock.RUnlock()
-
 	bufioReaderPoolLock.Lock()
 	defer bufioReaderPoolLock.Unlock()
+
+	if pool := bufioReaderPool[size]; pool != nil {
+		return pool
+	}
 
 	pool := &sync.Pool{}
 	bufioReaderPool[size] = pool

--- a/file.go
+++ b/file.go
@@ -30,7 +30,7 @@ type File struct {
 	columnIndexes []format.ColumnIndex
 	offsetIndexes []format.OffsetIndex
 	rowGroups     []RowGroup
-	cfg           *FileConfig
+	config        *FileConfig
 }
 
 // OpenFile opens a parquet file and reads the content between offset 0 and the given
@@ -45,7 +45,7 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
-	f := &File{reader: r, size: size, cfg: c}
+	f := &File{reader: r, size: size, config: c}
 
 	if _, err := r.ReadAt(b[:4], 0); err != nil {
 		return nil, fmt.Errorf("reading magic header of parquet file: %w", err)
@@ -473,7 +473,7 @@ func (f *filePages) init(c *fileColumnChunk) {
 	f.chunk = c
 	f.baseOffset = c.chunk.MetaData.DataPageOffset
 	f.dataOffset = f.baseOffset
-	f.bufferSize = c.file.cfg.ReadBufferSize
+	f.bufferSize = c.file.config.ReadBufferSize
 
 	if c.chunk.MetaData.DictionaryPageOffset != 0 {
 		f.baseOffset = c.chunk.MetaData.DictionaryPageOffset

--- a/file.go
+++ b/file.go
@@ -14,9 +14,8 @@ import (
 )
 
 const (
-	defaultDictBufferSize  = 8192
-	defaultReadBufferSize  = 4096
-	defaultLevelBufferSize = 1024
+	defaultDictBufferSize = 8192
+	defaultReadBufferSize = 4096
 )
 
 // File represents a parquet file. The layout of a Parquet file can be found


### PR DESCRIPTION
The default read buffer size is standard for disk access, but we are using this library with object storage backing the parquet.File. With object storage hundreds of tiny reads of 4096 is obviously a non-starter so we built a [simple buffer](https://github.com/grafana/tempo/blob/main/pkg/io/buffered.go). Unfortunately this buffer often overreads by quite a bit and for performance sensitive accesses we have found that simply increasing `defaultBufferSize` in this library beats our buffer in nearly every case.

This PR makes the `defaultBufferSize` configurable to allow those who are backing their `parquet.File`s with unconventional storage some control over how it is accessed. It also removes `defaultLevelBufferSize` because it was unused. No issue with re-adding if it's there for a reason I don't understand.

Finally, I was unable to write a convincing test for this configuration option. Any advice on how to proceed would be appreciated.
