### PR TITLE
fix issue 299

### DIFF
--- a/column_buffer_go18.go
+++ b/column_buffer_go18.go
@@ -315,9 +315,17 @@ func writeRowsFuncOfStruct(t reflect.Type, schema *Schema, path columnPath) writ
 	}
 
 	return func(buffers []ColumnBuffer, rows sparse.Array, levels columnLevels) error {
-		for _, column := range columns {
-			if err := column.writeRows(buffers, rows.Offset(column.offset), levels); err != nil {
-				return err
+		if rows.Len() == 0 {
+			for _, column := range columns {
+				if err := column.writeRows(buffers, rows, levels); err != nil {
+					return err
+				}
+			}
+		} else {
+			for _, column := range columns {
+				if err := column.writeRows(buffers, rows.Offset(column.offset), levels); err != nil {
+					return err
+				}
 			}
 		}
 		return nil

--- a/sparse/array.go
+++ b/sparse/array.go
@@ -55,6 +55,9 @@ func (a array) slice(i, j int) array {
 }
 
 func (a array) offset(off uintptr) array {
+	if a.ptr == nil {
+		panic("offset of nil array")
+	}
 	return array{
 		ptr: unsafe.Add(a.ptr, off),
 		len: a.len,


### PR DESCRIPTION
Fixes #299 
Fixes #309 

This PR addresses the misuse of `unsafe.Pointer` resulting in referencing invalid memory locations which caused occasional crashes of the program during garbage collection.

Following suggestions in https://github.com/segmentio/parquet-go/issues/299, I made the following changes:
- I added a check that `sparse.array.offset` is never called on an array where the base pointer would be nil. The new check actually triggered a panic when running the parquet-go tests.
- I added a missing check for `rows.Len() == 0` when writing Go struct values to column buffers, which addressed the panic triggered by the new check and I believe should address the GC crashes as well.