### PR TITLE
Optional Repeated Elements Panics on Deconstruct

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -14,12 +14,7 @@ type AddressBook2 struct {
 	Extra             string    `parquet:"extra"`
 }
 
-type AddressBook3 struct {
-	Owner    string     `parquet:"owner,zstd"`
-	Contacts []Contact2 `parquet:"contacts"`
-}
-
-type Contact2 struct {
+type Contact3 struct {
 	Name         string   `parquet:"name"`
 	PhoneNumbers []string `parquet:"phoneNumbers,zstd"`
 	Addresses    []string `parquet:"addresses,zstd"`
@@ -27,8 +22,13 @@ type Contact2 struct {
 
 type AddressBook4 struct {
 	Owner    string     `parquet:"owner,zstd"`
-	Contacts []Contact2 `parquet:"contacts"`
+	Contacts []Contact3 `parquet:"contacts"`
 	Extra    string     `parquet:"extra"`
+}
+
+type AddressBook5 struct {
+	Owner    string     `parquet:"owner,zstd"`
+	Contacts []Contact3 `parquet:"contacts"`
 }
 
 type SimpleNumber struct {
@@ -171,9 +171,9 @@ var conversionTests = [...]struct {
 
 	{
 		scenario: "handle nested repeated elements during conversion",
-		from: AddressBook3{
+		from: AddressBook5{
 			Owner: "Julien Le Dem",
-			Contacts: []Contact2{
+			Contacts: []Contact3{
 				{
 					Name: "Dmitriy Ryaboy",
 					PhoneNumbers: []string{
@@ -205,7 +205,7 @@ var conversionTests = [...]struct {
 		},
 		to: AddressBook4{
 			Owner: "Julien Le Dem",
-			Contacts: []Contact2{
+			Contacts: []Contact3{
 				{
 					Name: "Dmitriy Ryaboy",
 					PhoneNumbers: []string{

--- a/node.go
+++ b/node.go
@@ -152,7 +152,7 @@ func Optional(node Node) Node { return &optionalNode{node} }
 type optionalNode struct{ Node }
 
 func (opt *optionalNode) Optional() bool       { return true }
-func (opt *optionalNode) Repeated() bool       { return false }
+func (opt *optionalNode) Repeated() bool       { return opt.Node.Repeated() }
 func (opt *optionalNode) Required() bool       { return false }
 func (opt *optionalNode) GoType() reflect.Type { return reflect.PtrTo(opt.Node.GoType()) }
 
@@ -161,7 +161,7 @@ func Repeated(node Node) Node { return &repeatedNode{node} }
 
 type repeatedNode struct{ Node }
 
-func (rep *repeatedNode) Optional() bool       { return false }
+func (rep *repeatedNode) Optional() bool       { return rep.Node.Optional() }
 func (rep *repeatedNode) Repeated() bool       { return true }
 func (rep *repeatedNode) Required() bool       { return false }
 func (rep *repeatedNode) GoType() reflect.Type { return reflect.SliceOf(rep.Node.GoType()) }

--- a/row.go
+++ b/row.go
@@ -378,10 +378,10 @@ type deconstructFunc func(Row, levels, reflect.Value) Row
 
 func deconstructFuncOf(columnIndex int16, node Node) (int16, deconstructFunc) {
 	switch {
-	case node.Optional():
-		return deconstructFuncOfOptional(columnIndex, node)
 	case node.Repeated():
 		return deconstructFuncOfRepeated(columnIndex, node)
+	case node.Optional():
+		return deconstructFuncOfOptional(columnIndex, node)
 	case isList(node):
 		return deconstructFuncOfList(columnIndex, node)
 	case isMap(node):
@@ -519,10 +519,10 @@ type reconstructFunc func(reflect.Value, levels, Row) (Row, error)
 
 func reconstructFuncOf(columnIndex int16, node Node) (int16, reconstructFunc) {
 	switch {
-	case node.Optional():
-		return reconstructFuncOfOptional(columnIndex, node)
 	case node.Repeated():
 		return reconstructFuncOfRepeated(columnIndex, node)
+	case node.Optional():
+		return reconstructFuncOfOptional(columnIndex, node)
 	case isList(node):
 		return reconstructFuncOfList(columnIndex, node)
 	case isMap(node):

--- a/row_test.go
+++ b/row_test.go
@@ -25,7 +25,7 @@ type AddressBook3 struct {
 
 type Contact2 struct {
 	Name         string   `parquet:"name"`
-	PhoneNumbers []string `parquet:"phoneNumbers,optional,zstd"`
+	PhoneNumbers []string `parquet:"phoneNumbers,optional"`
 }
 
 func TestNestedDeconstructReconstruct(t *testing.T) {

--- a/row_test.go
+++ b/row_test.go
@@ -28,7 +28,7 @@ type Contact2 struct {
 	PhoneNumbers []string `parquet:"phoneNumbers,optional,zstd"`
 }
 
-func TestNestedDeconstrcutReconstruct(t *testing.T) {
+func TestNestedDeconstructReconstruct(t *testing.T) {
 	var conversionTests = [...]struct {
 		scenario string
 		input    interface{}

--- a/value.go
+++ b/value.go
@@ -201,6 +201,7 @@ func ValueOf(v interface{}) Value {
 }
 
 func makeValue(k Kind, v reflect.Value) Value {
+
 	switch k {
 	case Boolean:
 		return makeValueBoolean(v.Bool())


### PR DESCRIPTION
Simple scenario where deconstruct/reconstruct panics unexpectedly.  This should be a valid configuration according to the Parquet spec, but our implementation does not support optional repeated elements strongly yet.

```
--- FAIL: TestNestedDeconstrcutReconstruct (0.00s)
    --- FAIL: TestNestedDeconstrcutReconstruct/handle_nested_repeated_elements (0.00s)
panic: cannot create parquet value of type BYTE_ARRAY from go value of type []string [recovered]
        panic: cannot create parquet value of type BYTE_ARRAY from go value of type []string

goroutine 21 [running]:
testing.tRunner.func1.2({0x102c0d140, 0x140000a03c0})
        /opt/homebrew/Cellar/go/1.19/libexec/src/testing/testing.go:1396 +0x1c8
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.19/libexec/src/testing/testing.go:1399 +0x378
panic({0x102c0d140, 0x140000a03c0})
        /opt/homebrew/Cellar/go/1.19/libexec/src/runtime/panic.go:884 +0x204
github.com/segmentio/parquet-go.makeValue(0x6?, {0x102c05980?, 0x140000b2100?, 0x102cd8cc0?})
        /Users/abraithwaite/Projects/parquet-go/value.go:267 +0x920
github.com/segmentio/parquet-go.deconstructFuncOfLeaf.func1({0x140000a6600, 0x2, 0x2}, {0x88?, 0xc8?, 0xae?}, {0x102c05980?, 0x140000b2100?, 0x102b041a2?})
        /Users/abraithwaite/Projects/parquet-go/row.go:495 +0x68
github.com/segmentio/parquet-go.deconstructFuncOfOptional.func1({0x140000a6600?, 0x2?, 0x2?}, {0x8?, 0x1?, 0xb?}, {0x102c05980?, 0x140000b2100?, 0x14000119cd8?})
        /Users/abraithwaite/Projects/parquet-go/row.go:395 +0xdc
github.com/segmentio/parquet-go.deconstructFuncOfGroup.func1({0x140000b0108?, 0x140000a63d0?, 0xd9bb1a010c810607?}, {0x0?, 0x80?, 0xd?}, {0x102c77660?, 0x140000b20f0?, 0x102c773e0?})
        /Users/abraithwaite/Projects/parquet-go/row.go:473 +0x12c
github.com/segmentio/parquet-go.deconstructFuncOfRepeated.func1({0x140000b0108?, 0x1, 0x1}, {0xa0?, 0x0, 0x0}, {0x102c03600?, 0x140000a63d0?, 0x102c7bee0?})
        /Users/abraithwaite/Projects/parquet-go/row.go:411 +0x194
github.com/segmentio/parquet-go.deconstructFuncOfGroup.func1({0x0?, 0x140000a4180?, 0x102be4619?}, {0x88?, 0xfc?, 0xcf?}, {0x102c773e0?, 0x140000a63c0?, 0x102cffc88?})
        /Users/abraithwaite/Projects/parquet-go/row.go:473 +0x12c
github.com/segmentio/parquet-go.(*Schema).Deconstruct(0x140000a4180, {0x0?, 0x0, 0x0}, {0x102c773e0?, 0x140000a63c0?})
        /Users/abraithwaite/Projects/parquet-go/schema.go:232 +0x18c
github.com/segmentio/parquet-go_test.TestNestedDeconstrcutReconstruct.func1(0x14000092820)
        /Users/abraithwaite/Projects/parquet-go/row_test.go:62 +0x58
testing.tRunner(0x14000092820, 0x140000a0240)
        /opt/homebrew/Cellar/go/1.19/libexec/src/testing/testing.go:1446 +0x10c
created by testing.(*T).Run
        /opt/homebrew/Cellar/go/1.19/libexec/src/testing/testing.go:1493 +0x300
exit status 2
FAIL    github.com/segmentio/parquet-go 0.659s
```