### PR TITLE
reuse definition and repetition buffers

### DIFF
--- a/column.go
+++ b/column.go
@@ -646,21 +646,30 @@ func (c *Column) decodeDataPage(header DataPageHeader, numValues int, repetition
 			newPage,
 			c.maxRepetitionLevel,
 			c.maxDefinitionLevel,
-			makeBufferRef(repetitionLevels),
-			makeBufferRef(definitionLevels),
+			repetitionLevels.data,
+			definitionLevels.data,
 		)
 	case c.maxDefinitionLevel > 0:
 		newPage = newOptionalPage(
 			newPage,
 			c.maxDefinitionLevel,
-			makeBufferRef(definitionLevels),
+			definitionLevels.data,
 		)
 	}
+
+	bufferRef(vbuf)
+	bufferRef(obuf)
+	bufferRef(repetitionLevels)
+	bufferRef(definitionLevels)
+
 	newPage = &bufferedPage{
-		Page:    newPage,
-		values:  makeBufferRef(vbuf),
-		offsets: makeBufferRef(obuf),
+		Page:             newPage,
+		values:           vbuf,
+		offsets:          obuf,
+		repetitionLevels: repetitionLevels,
+		definitionLevels: definitionLevels,
 	}
+
 	return newPage, nil
 }
 

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -248,8 +248,7 @@ func (col *optionalColumnBuffer) Page() Page {
 		col.reordered = false
 	}
 
-	definitionLevels := makeBufferRef(&buffer{data: col.definitionLevels})
-	return newOptionalPage(col.base.Page(), col.maxDefinitionLevel, definitionLevels)
+	return newOptionalPage(col.base.Page(), col.maxDefinitionLevel, col.definitionLevels)
 }
 
 func (col *optionalColumnBuffer) Reset() {
@@ -551,14 +550,12 @@ func (col *repeatedColumnBuffer) Page() Page {
 		col.reordered = false
 	}
 
-	repetitionLevels := makeBufferRef(&buffer{data: col.repetitionLevels})
-	definitionLevels := makeBufferRef(&buffer{data: col.definitionLevels})
 	return newRepeatedPage(
 		col.base.Page(),
 		col.maxRepetitionLevel,
 		col.maxDefinitionLevel,
-		repetitionLevels,
-		definitionLevels,
+		col.repetitionLevels,
+		col.definitionLevels,
 	)
 }
 

--- a/page_values.go
+++ b/page_values.go
@@ -16,7 +16,7 @@ type optionalPageValues struct {
 
 func (r *optionalPageValues) ReadValues(values []Value) (n int, err error) {
 	maxDefinitionLevel := r.page.maxDefinitionLevel
-	definitionLevels := r.page.definitionLevels.data()
+	definitionLevels := r.page.definitionLevels
 	columnIndex := ^int16(r.page.Column())
 
 	for n < len(values) && r.offset < len(definitionLevels) {
@@ -64,8 +64,8 @@ type repeatedPageValues struct {
 
 func (r *repeatedPageValues) ReadValues(values []Value) (n int, err error) {
 	maxDefinitionLevel := r.page.maxDefinitionLevel
-	definitionLevels := r.page.definitionLevels.data()
-	repetitionLevels := r.page.repetitionLevels.data()
+	definitionLevels := r.page.definitionLevels
+	repetitionLevels := r.page.repetitionLevels
 	columnIndex := ^int16(r.page.Column())
 
 	for n < len(values) && r.offset < len(definitionLevels) {


### PR DESCRIPTION
While investigating profiles of file merge benchmarks I noticed that the buffers for definition and repetition levels were not properly reused internally. This PR address the issue.

Contributes to #226 

```
name                                                     old time/op  new time/op  delta
MergeFiles/BOOLEAN/groups=2,rows=20000                   17.0µs ± 1%  17.0µs ± 1%     ~     (p=0.383 n=10+10)
MergeFiles/INT32/groups=2,rows=20000                     7.14µs ± 1%  7.15µs ± 1%     ~     (p=0.842 n=10+9)
MergeFiles/INT64/groups=2,rows=20000                     7.71µs ± 0%  7.72µs ± 1%     ~     (p=0.645 n=9+10)
MergeFiles/INT96/groups=2,rows=20000                     35.0µs ± 4%  34.0µs ± 2%   -2.96%  (p=0.003 n=10+10)
MergeFiles/FLOAT/groups=2,rows=20000                     6.29µs ± 2%  6.24µs ± 1%     ~     (p=0.127 n=10+10)
MergeFiles/DOUBLE/groups=2,rows=20000                    6.78µs ± 2%  6.70µs ± 1%   -1.17%  (p=0.000 n=10+9)
MergeFiles/BYTE_ARRAY/groups=2,rows=20000                12.0µs ± 2%  12.1µs ± 1%   +1.11%  (p=0.017 n=10+9)
MergeFiles/FIXED_LEN_BYTE_ARRAY/groups=2,rows=20000      7.65µs ± 2%  7.57µs ± 1%   -1.14%  (p=0.006 n=10+10)
MergeFiles/STRING/groups=2,rows=20000                    8.11µs ± 2%  8.07µs ± 1%     ~     (p=0.218 n=10+10)
MergeFiles/STRING_(dict)/groups=2,rows=20000             7.53µs ± 5%  7.33µs ± 3%   -2.66%  (p=0.006 n=9+10)
MergeFiles/UUID/groups=2,rows=20000                      16.1µs ± 3%  15.8µs ± 0%   -1.84%  (p=0.000 n=10+9)
MergeFiles/DECIMAL/groups=2,rows=20000                   6.73µs ± 1%  6.63µs ± 1%   -1.47%  (p=0.000 n=9+8)
MergeFiles/AddressBook/groups=2,rows=20000                197µs ± 4%   180µs ± 1%   -8.74%  (p=0.000 n=10+10)
MergeFiles/one_optional_level/groups=2,rows=20000        11.3µs ± 2%  10.3µs ± 1%   -8.21%  (p=0.000 n=10+10)
MergeFiles/one_repeated_level/groups=2,rows=20000         103µs ± 4%    99µs ± 5%   -4.45%  (p=0.002 n=10+10)
MergeFiles/two_repeated_levels/groups=2,rows=20000        114µs ± 4%   101µs ± 2%  -11.15%  (p=0.000 n=10+10)
MergeFiles/three_repeated_levels/groups=2,rows=20000      113µs ± 3%   101µs ± 1%  -10.57%  (p=0.000 n=10+10)
MergeFiles/nested_lists/groups=2,rows=20000               266µs ± 3%   240µs ± 2%   -9.66%  (p=0.000 n=9+9)
MergeFiles/key-value_pairs/groups=2,rows=20000            289µs ± 4%   268µs ± 3%   -7.19%  (p=0.000 n=10+10)
MergeFiles/multiple_key-value_pairs/groups=2,rows=20000   869µs ± 4%   789µs ± 5%   -9.27%  (p=0.000 n=10+10)
MergeFiles/repeated_key-value_pairs/groups=2,rows=20000   303µs ± 5%   275µs ± 3%   -9.35%  (p=0.000 n=9+10)
MergeFiles/map_of_repeated_values/groups=2,rows=20000     125µs ± 4%   109µs ± 3%  -13.12%  (p=0.000 n=10+10)

name                                                     old row/s    new row/s    delta
MergeFiles/BOOLEAN/groups=2,rows=20000                    56.9M ± 1%   57.1M ± 1%     ~     (p=0.393 n=10+10)
MergeFiles/INT32/groups=2,rows=20000                       135M ± 1%    135M ± 1%     ~     (p=0.780 n=10+9)
MergeFiles/INT64/groups=2,rows=20000                       125M ± 0%    125M ± 1%     ~     (p=0.661 n=9+10)
MergeFiles/INT96/groups=2,rows=20000                      27.7M ± 4%   28.5M ± 2%   +3.02%  (p=0.003 n=10+10)
MergeFiles/FLOAT/groups=2,rows=20000                       154M ± 2%    155M ± 1%     ~     (p=0.123 n=10+10)
MergeFiles/DOUBLE/groups=2,rows=20000                      143M ± 2%    144M ± 1%   +1.17%  (p=0.000 n=10+9)
MergeFiles/BYTE_ARRAY/groups=2,rows=20000                 80.9M ± 2%   80.1M ± 1%   -1.10%  (p=0.017 n=10+9)
MergeFiles/FIXED_LEN_BYTE_ARRAY/groups=2,rows=20000        126M ± 2%    128M ± 1%   +1.15%  (p=0.007 n=10+10)
MergeFiles/STRING/groups=2,rows=20000                      119M ± 2%    120M ± 1%     ~     (p=0.218 n=10+10)
MergeFiles/STRING_(dict)/groups=2,rows=20000               128M ± 6%    132M ± 3%   +3.38%  (p=0.003 n=10+10)
MergeFiles/UUID/groups=2,rows=20000                       58.3M ± 2%   59.4M ± 0%   +1.86%  (p=0.000 n=10+9)
MergeFiles/DECIMAL/groups=2,rows=20000                     144M ± 1%    146M ± 1%   +1.49%  (p=0.000 n=9+8)
MergeFiles/AddressBook/groups=2,rows=20000                1.86M ± 4%   2.03M ± 1%   +9.52%  (p=0.000 n=10+10)
MergeFiles/one_optional_level/groups=2,rows=20000         85.8M ± 2%   93.5M ± 1%   +8.94%  (p=0.000 n=10+10)
MergeFiles/one_repeated_level/groups=2,rows=20000         6.39M ± 4%   6.69M ± 5%   +4.70%  (p=0.002 n=10+10)
MergeFiles/two_repeated_levels/groups=2,rows=20000        1.76M ± 4%   1.98M ± 2%  +12.52%  (p=0.000 n=10+10)
MergeFiles/three_repeated_levels/groups=2,rows=20000      1.77M ± 3%   1.98M ± 1%  +11.79%  (p=0.000 n=10+10)
MergeFiles/nested_lists/groups=2,rows=20000               1.12M ± 4%   1.25M ± 2%  +11.16%  (p=0.000 n=10+9)
MergeFiles/key-value_pairs/groups=2,rows=20000            3.05M ± 4%   3.21M ± 3%   +5.30%  (p=0.000 n=10+10)
MergeFiles/multiple_key-value_pairs/groups=2,rows=20000   1.01M ± 3%   1.12M ± 5%  +10.22%  (p=0.000 n=10+10)
MergeFiles/repeated_key-value_pairs/groups=2,rows=20000   1.19M ± 4%   1.31M ± 3%  +10.30%  (p=0.000 n=9+10)
MergeFiles/map_of_repeated_values/groups=2,rows=20000     1.37M ± 4%   1.58M ± 2%  +15.03%  (p=0.000 n=10+10)
```