### PR TITLE
README: Fix type references in README for reading pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ for {
     }
 
     switch page := p.Values().(type) {
-    case parquet.Int32Page:
+    case parquet.Int32Reader:
         values := make([]int32, page.NumValues())
         _, err := page.ReadInt32s(values)
         ...
-    case parquet.Int64Page:
+    case parquet.Int64Reader:
         values := make([]int64, page.NumValues())
         _, err := page.ReadInt64s(values)
         ...


### PR DESCRIPTION
~The types (`parquet.<Type>Page`) are not currently exported.  Is the intent to export them?  If so we can toss this PR and make that change instead.~

Updated references in readme to correct reader interface types.