### PR TITLE
improve type error message

### DIFF
--- a/column_buffer_go18.go
+++ b/column_buffer_go18.go
@@ -67,7 +67,7 @@ func writeRowsFuncOf(t reflect.Type, schema *Schema, path columnPath) writeRowsF
 		return writeRowsFuncOfMap(t, schema, path)
 	}
 
-	panic("cannot convert Go values of type " + t.String() + " to parquet value")
+	panic("cannot convert Go values of type " + typeNameOf(t) + " to parquet value")
 }
 
 func writeRowsFuncOfRequired(t reflect.Type, schema *Schema, path columnPath) writeRowsFunc {

--- a/null.go
+++ b/null.go
@@ -97,7 +97,7 @@ func nullIndexFuncOf(t reflect.Type) nullIndexFunc {
 		return nullIndexStruct
 	}
 
-	panic("cannot convert Go values of type " + t.String() + " to parquet value")
+	panic("cannot convert Go values of type " + typeNameOf(t) + " to parquet value")
 }
 
 func nullIndexFuncOfByteArray(n int) nullIndexFunc {

--- a/parquet.go
+++ b/parquet.go
@@ -7,6 +7,8 @@
 // Or see the Parquet documentation: https://parquet.apache.org/docs/
 package parquet
 
+import "reflect"
+
 func atLeastOne(size int) int {
 	return atLeast(size, 1)
 }
@@ -30,4 +32,13 @@ func max(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func typeNameOf(t reflect.Type) string {
+	s1 := t.String()
+	s2 := t.Kind().String()
+	if s1 == s2 {
+		return s1
+	}
+	return s1 + " (" + s2 + ")"
 }


### PR DESCRIPTION
Adding the `reflect.Kind` to the type name in error messages will be useful to better understand misuse of the library.