### PR TITLE
close rowGroupCursors when Popped due to io.EOF in mergedRowGroupRows

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -120,7 +120,12 @@ func (r *mergedRowGroupRows) ReadRows(rows []Row) (n int, err error) {
 				r.err = err
 				return n, err
 			}
+			c := r.cursors[0]
 			heap.Pop(r)
+			if err := c.close(); err != nil {
+				r.err = err
+				return n, err
+			}
 		} else {
 			heap.Fix(r, 0)
 		}


### PR DESCRIPTION
This commit fixes a potential goroutine leak. mergeRowGroupRows cursors, when
initialized, might spawn a goroutine (e.g. asyncPages.readPages). Previously,
when a cursor returned io.EOF, this cursor was popped from the min-heap but
never closed, resulting in leaked goroutines.

cc @achille-roussel @Pryz 