### PR TITLE
fixes for Go Report Card

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -219,7 +219,7 @@ func (buf *Buffer) WriteRows(rows []Row) (int, error) {
 
 	for columnIndex, values := range buf.colbuf {
 		if _, err := buf.columns[columnIndex].WriteValues(values); err != nil {
-			// TOOD: an error at this stage will leave the buffer in an invalid
+			// TODO: an error at this stage will leave the buffer in an invalid
 			// state since the row was partially written. Applications are not
 			// expected to continue using the buffer after getting an error,
 			// maybe we can enforce it?

--- a/convert_test.go
+++ b/convert_test.go
@@ -244,10 +244,10 @@ var conversionTests = [...]struct {
 			Name: "New Contact",
 			Contact: SimpleContact{
 				Numbers: []SimpleNumber{
-					SimpleNumber{
+					{
 						Number: nil,
 					},
-					SimpleNumber{
+					{
 						Number: newInt64(1329),
 					},
 				},
@@ -257,10 +257,10 @@ var conversionTests = [...]struct {
 			Name: "New Contact",
 			Contact: SimpleContact{
 				Numbers: []SimpleNumber{
-					SimpleNumber{
+					{
 						Number: nil,
 					},
-					SimpleNumber{
+					{
 						Number: newInt64(1329),
 					},
 				},

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -113,7 +113,7 @@ func testDictionary(t *testing.T, typ parquet.Type, numValues int) {
 
 		lowerBound, upperBound := dict.Bounds(indexes[i:j])
 		if !parquet.DeepEqual(lowerBound, minValue) {
-			t.Errorf("wrong lower bound betwen indexes %d and %d: want=%#v got=%#v", i, j, minValue, lowerBound)
+			t.Errorf("wrong lower bound between indexes %d and %d: want=%#v got=%#v", i, j, minValue, lowerBound)
 		}
 		if !parquet.DeepEqual(upperBound, maxValue) {
 			t.Errorf("wrong upper bound between indexes %d and %d: want=%#v got=%#v", i, j, maxValue, upperBound)

--- a/internal/bytealg/bytealg_amd64.go
+++ b/internal/bytealg/bytealg_amd64.go
@@ -7,7 +7,7 @@ import "golang.org/x/sys/cpu"
 var (
 	hasAVX2 = cpu.X86.HasAVX2
 	// These use AVX-512 instructions in the countByte algorithm relies
-	// operations that are avilable in the AVX512BW extension:
+	// operations that are available in the AVX512BW extension:
 	// * VPCMPUB
 	// * KMOVQ
 	//

--- a/value_go18.go
+++ b/value_go18.go
@@ -7,7 +7,7 @@ import (
 	"unsafe"
 )
 
-// This function exists for backward compatiblity with the Go 1.17 build which
+// This function exists for backward compatibility with the Go 1.17 build which
 // has a different implementation.
 //
 // TODO: remove when we drop support for Go versions prior to 1.18.

--- a/writer_go18_test.go
+++ b/writer_go18_test.go
@@ -163,7 +163,7 @@ func TestIssue279(t *testing.T) {
 	row := T{
 		T1: &T1{
 			TA: []*T2{
-				&T2{
+				{
 					Id:   43,
 					Name: "john",
 				},
@@ -254,16 +254,16 @@ func TestIssue302(t *testing.T) {
 				b := new(bytes.Buffer)
 				w := parquet.NewGenericWriter[T](b)
 				expect := []T{
-					T{
+					{
 						M: M{
 							"Holden": 1,
 							"Naomi":  2,
 						},
 					},
-					T{
+					{
 						M: nil,
 					},
-					T{
+					{
 						M: M{
 							"Naomi":  1,
 							"Holden": 2,


### PR DESCRIPTION
Fix lint errors reported by https://goreportcard.com/report/github.com/segmentio/parquet-go
