### PR TITLE
schema: handle interfaces like pointers

### DIFF
--- a/buffer_go18_test.go
+++ b/buffer_go18_test.go
@@ -186,3 +186,16 @@ func TestIssue343(t *testing.T) {
 	// must not panic
 	_ = parquet.NewGenericBuffer[any]()
 }
+
+func TestIssue346(t *testing.T) {
+	type TestType struct {
+		Key int
+	}
+
+	schema := parquet.SchemaOf(TestType{})
+	buffer := parquet.NewGenericBuffer[any](schema)
+
+	data := make([]any, 1)
+	data[0] = TestType{Key: 0}
+	_, _ = buffer.Write(data)
+}

--- a/schema.go
+++ b/schema.go
@@ -221,7 +221,7 @@ func (s *Schema) GoType() reflect.Type { return s.root.GoType() }
 // parquet schema.
 func (s *Schema) Deconstruct(row Row, value interface{}) Row {
 	v := reflect.ValueOf(value)
-	for v.Kind() == reflect.Ptr {
+	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
 		if v.IsNil() {
 			v = reflect.Value{}
 			break
@@ -405,7 +405,7 @@ func (s *structNode) Fields() []Field {
 // reflect.Value if one of the fields was a nil pointer instead of panicking.
 func fieldByIndex(v reflect.Value, index []int) reflect.Value {
 	for _, i := range index {
-		if v = v.Field(i); v.Kind() == reflect.Ptr {
+		if v = v.Field(i); v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
 			if v.IsNil() {
 				v = reflect.Value{}
 				break


### PR DESCRIPTION
When a schema is defined, and we're instantiating a generic buffer using `any`, we need to dereference the `any` (`interface{}`) type to get the underlying element to be written (which should also match the schema given).  Currently there's no verification that they match.  It may be a good idea to add an additional check somehow.

There are a handful of other `reflect.Ptr` references in various code blocks which don't also handle `reflect.Interface`, so it may take time to go through and decide which ones need to be handled in addition to these two.

Looking into #347 more also, as that may help better inform the choices here.

Fixes #346 