### PR TITLE
buffer_go18: enforce schema presence at instantiation

### DIFF
--- a/buffer_go18.go
+++ b/buffer_go18.go
@@ -22,7 +22,8 @@ type GenericBuffer[T any] struct {
 // The type parameter T should be a map, struct, or any. Any other types will
 // cause a panic at runtime. Type checking is a lot more effective when the
 // generic parameter is a struct type, using map and interface types is somewhat
-// similar to using a Writer.
+// similar to using a Writer.  If using an interface type for the type parameter,
+// then providing a schema at instantiation is required.
 //
 // If the option list may explicitly declare a schema, it must be compatible
 // with the schema generated from T.
@@ -35,6 +36,10 @@ func NewGenericBuffer[T any](options ...RowGroupOption) *GenericBuffer[T] {
 	t := typeOf[T]()
 	if config.Schema == nil && t != nil {
 		config.Schema = schemaOf(dereference(t))
+	}
+
+	if config.Schema == nil {
+		panic("generic buffer must be instantiated with schema or concrete type.")
 	}
 
 	buf := &GenericBuffer[T]{

--- a/buffer_go18_test.go
+++ b/buffer_go18_test.go
@@ -182,11 +182,6 @@ func TestIssue327(t *testing.T) {
 	})
 }
 
-func TestIssue343(t *testing.T) {
-	// must not panic
-	_ = parquet.NewGenericBuffer[any]()
-}
-
 func TestIssue346(t *testing.T) {
 	type TestType struct {
 		Key int

--- a/buffer_go18_test.go
+++ b/buffer_go18_test.go
@@ -199,3 +199,24 @@ func TestIssue346(t *testing.T) {
 	data[0] = TestType{Key: 0}
 	_, _ = buffer.Write(data)
 }
+
+func TestIssue347(t *testing.T) {
+	type TestType struct {
+		Key int
+	}
+
+	// instantiating with concrete type shouldn't panic
+	_ = parquet.NewGenericBuffer[TestType]()
+
+	// instantiating with schema and interface type parameter shouldn't panic
+	schema := parquet.SchemaOf(TestType{})
+	_ = parquet.NewGenericBuffer[any](schema)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("instantiating generic buffer without schema and with interface " +
+				"type parameter should panic")
+		}
+	}()
+	_ = parquet.NewGenericBuffer[any]()
+}

--- a/writer_go18.go
+++ b/writer_go18.go
@@ -78,6 +78,10 @@ func NewGenericWriter[T any](output io.Writer, options ...WriterOption) *Generic
 		config.Schema = schema
 	}
 
+	if config.Schema == nil {
+		panic("generic writer must be instantiated with schema or concrete type.")
+	}
+
 	return &GenericWriter[T]{
 		base: Writer{
 			output: output,

--- a/writer_go18_test.go
+++ b/writer_go18_test.go
@@ -293,3 +293,25 @@ func TestIssue302(t *testing.T) {
 		t.Run(test.name, test.fn)
 	}
 }
+
+func TestIssue347Writer(t *testing.T) {
+	type TestType struct {
+		Key int
+	}
+
+	b := new(bytes.Buffer)
+	// instantiating with concrete type shouldn't panic
+	_ = parquet.NewGenericWriter[TestType](b)
+
+	// instantiating with schema and interface type parameter shouldn't panic
+	schema := parquet.SchemaOf(TestType{})
+	_ = parquet.NewGenericWriter[any](b, schema)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("instantiating generic buffer without schema and with interface " +
+				"type parameter should panic")
+		}
+	}()
+	_ = parquet.NewGenericWriter[any](b)
+}


### PR DESCRIPTION
We could infer the schema from the first element in a slice lazily in some cases, but error handling in subsequent calls to functions that depend on the schema may be difficult in the cases where the generic buffer was instantiated with an interface type parameter.

If there's a compelling use case for that, we may add the functionality down the road.

Fixes #347 