### PR TITLE
Feature: Leveled buffers

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -1,7 +1,6 @@
 package parquet
 
 import (
-	"fmt"
 	"math/bits"
 	"sort"
 	"sync"
@@ -396,7 +395,6 @@ func levelledPoolIndex(sz int) int {
 	i = 32 - bits.LeadingZeros32(uint32(i)) // log2
 	if i >= totalPools {
 		i = totalPools - 1
-		fmt.Println("this happened", sz)
 	}
 	if i < 0 {
 		i = 0

--- a/buffer.go
+++ b/buffer.go
@@ -307,16 +307,6 @@ func (b *buffer) unref() {
 	}
 }
 
-func (b *buffer) clone() (clone *buffer) {
-	if b.pool != nil {
-		clone = b.pool.get(len(b.data))
-	} else {
-		clone = &buffer{refc: 1}
-	}
-	clone.data = append(clone.data, b.data...)
-	return clone
-}
-
 // slice of sync.pools is used for levelled buffering.
 // the table below shows the pools used for different buffer sizes. the first range of
 // values are the sizes for which the pool will be used on get. the second range

--- a/buffer.go
+++ b/buffer.go
@@ -348,11 +348,11 @@ func (b *buffer) clone() (clone *buffer) {
 // ...
 // [14] -> 16MB
 // [15] -> 32MB
-const totalPools = 16
+const numPoolBuckets = 16
 const basePoolIncrement = 1024
 
 type bufferPool struct {
-	pool [totalPools]sync.Pool
+	pool [numPoolBuckets]sync.Pool
 }
 
 // get returns a buffer from the levelled buffer pool. sz is used to choose the appropriate pool
@@ -394,8 +394,8 @@ func (p *bufferPool) put(b *buffer) {
 func levelledPoolIndex(sz int) int {
 	i := sz / basePoolIncrement
 	i = 32 - bits.LeadingZeros32(uint32(i)) // log2
-	if i >= totalPools {
-		i = totalPools - 1
+	if i >= numPoolBuckets {
+		i = numPoolBuckets - 1
 	}
 	if i < 0 {
 		i = 0

--- a/buffer.go
+++ b/buffer.go
@@ -361,7 +361,7 @@ func (p *bufferPool) get(sz int) *buffer {
 	b, _ := p.pool[i].Get().(*buffer)
 	if b == nil {
 		// align size to the pool
-		poolSize := basePoolIncrement * (2 ^ i)
+		poolSize := basePoolIncrement << i
 		if poolSize > sz {
 			sz = poolSize
 		}

--- a/buffer.go
+++ b/buffer.go
@@ -341,9 +341,15 @@ func (p *bufferPool) get(sz int) *buffer {
 			pool: p,
 		}
 	}
-	// the above guarantees that the buffer is at least sz bytes long
+	// if the buffer comes from the largest pool it may not be big enough
+	if cap(b.data) < sz {
+		p.pool[i].Put(b)
+		b = &buffer{
+			data: make([]byte, 0, sz),
+			pool: p,
+		}
+	}
 	b.data = b.data[:sz]
-
 	b.ref()
 	return b
 }

--- a/buffer.go
+++ b/buffer.go
@@ -307,17 +307,15 @@ func (b *buffer) unref() {
 	}
 }
 
-// slice of sync.pools is used for levelled buffering.
-// the table below shows the pools used for different buffer sizes. the first range of
-// values are the sizes for which the pool will be used on get. the second range
-// are the sizes of the buffers that are placed into the pool on put. when allocating a new buffer
-// from a given pool we always choose the min of the put range to guarantee that all gets
-// will have an adequately sized buffer.
+// bufferPool holds a slice of sync.pools used for levelled buffering.
+// the table below shows the pools used for different buffer sizes when both getting
+// and putting a buffer. when allocating a new buffer from a given pool we always choose the
+// min of the put range to guarantee that all gets will have an adequately sized buffer.
 //
-// [pool] : <get range>  : <put range>
-// [0]    : 0    -> 1023 : 1024 -> 2047
-// [1]    : 1024 -> 2047 : 2048 -> 4095
-// [2]    : 2048 -> 4095 : 4096 -> 8191
+// [pool] : <get range>  : <put range>  : <alloc size>
+// [0]    : 0    -> 1023 : 1024 -> 2047 : 1024
+// [1]    : 1024 -> 2047 : 2048 -> 4095 : 2048
+// [2]    : 2048 -> 4095 : 4096 -> 8191 : 4096
 // ...
 const numPoolBuckets = 16
 const basePoolIncrement = 1024

--- a/buffer.go
+++ b/buffer.go
@@ -357,12 +357,13 @@ type bufferPool struct {
 
 // get returns a buffer from the levelled buffer pool. sz is used to choose the appropriate pool
 func (p *bufferPool) get(sz int) *buffer {
-	b, _ := p.pool[levelledPoolIndex(sz)].Get().(*buffer)
+	i := levelledPoolIndex(sz)
+	b, _ := p.pool[i].Get().(*buffer)
 	if b == nil {
-		// don't allocate less then our min pool size so the buffer will be correctly
-		// placed in the smallest pool on put
-		if sz < basePoolIncrement {
-			sz = basePoolIncrement
+		// align size to the pool
+		poolSize := basePoolIncrement * (2 ^ i)
+		if poolSize > sz {
+			sz = poolSize
 		}
 		b = &buffer{
 			data: make([]byte, 0, sz),

--- a/buffer_internal_test.go
+++ b/buffer_internal_test.go
@@ -1,0 +1,57 @@
+package parquet
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestBufferAlwaysCorrectSize(t *testing.T) {
+	var p bufferPool
+	for i := 0; i < 1000; i++ {
+		sz := rand.Intn(1024 * 1024)
+		buff := p.get(sz)
+		if len(buff.data) != sz {
+			t.Errorf("Expected buffer of size %d, got %d", sz, len(buff.data))
+		}
+		p.put(buff)
+	}
+}
+
+func TestLevelledPoolIndex(t *testing.T) {
+	tcs := []struct {
+		sz       int
+		expected int
+	}{
+		{
+			sz:       1023,
+			expected: 0,
+		},
+		{
+			sz:       1024,
+			expected: 1,
+		},
+		{
+			sz:       -1,
+			expected: 0,
+		},
+		{
+			sz:       16*1024*1024 - 1,
+			expected: 14,
+		},
+		{
+			sz:       16 * 1024 * 1024,
+			expected: 15,
+		},
+		{
+			sz:       math.MaxInt,
+			expected: 15,
+		},
+	}
+
+	for _, tc := range tcs {
+		if actual := levelledPoolIndex(tc.sz); actual != tc.expected {
+			t.Errorf("Expected index %d for size %d, got %d", tc.expected, tc.sz, actual)
+		}
+	}
+}

--- a/column.go
+++ b/column.go
@@ -489,9 +489,6 @@ func schemaRepetitionTypeOf(s *format.SchemaElement) format.FieldRepetitionType 
 
 func (c *Column) decompress(compressedPageData []byte, uncompressedPageSize int32) (page *buffer, err error) {
 	page = uncompressedPageBufferPool.get(int(uncompressedPageSize))
-	if uncompressedPageSize > 0 {
-		page.resize(int(uncompressedPageSize))
-	}
 	page.data, err = c.compression.Decode(page.data, compressedPageData)
 	if err != nil {
 		page.unref()
@@ -630,13 +627,11 @@ func (c *Column) decodeDataPage(header DataPageHeader, numValues int, repetition
 	if pageKind >= 0 && int(pageKind) < len(pageValuesBufferPool) {
 		vbuf = pageValuesBufferPool[pageKind].get(int(pageType.EstimateSize(numValues)))
 		defer vbuf.unref()
-		vbuf.resize(int(pageType.EstimateSize(numValues)))
 		pageValues = vbuf.data
 	}
 	if pageKind == ByteArray {
 		obuf = pageOffsetsBufferPool.get(4 * (numValues + 1))
 		defer obuf.unref()
-		obuf.resize(4 * (numValues + 1))
 		pageOffsets = unsafecast.BytesToUint32(obuf.data)
 	}
 

--- a/column.go
+++ b/column.go
@@ -702,7 +702,7 @@ func decodeLevelsV2(enc encoding.Encoding, numValues int, data []byte, length in
 }
 
 func decodeLevels(enc encoding.Encoding, numValues int, data []byte) (levels *buffer, err error) {
-	levels = levelsBufferPool.get(len(data) * 32)
+	levels = levelsBufferPool.get(numValues)
 	levels.data, err = enc.DecodeLevels(levels.data, data)
 	if err != nil {
 		levels.unref()

--- a/column.go
+++ b/column.go
@@ -636,7 +636,7 @@ func (c *Column) decodeDataPage(header DataPageHeader, numValues int, repetition
 	if pageKind == ByteArray {
 		obuf = pageOffsetsBufferPool.get(4 * (numValues + 1))
 		defer obuf.unref()
-		obuf.resize(4 * (numValues + 1)) // jpe - wut?
+		obuf.resize(4 * (numValues + 1))
 		pageOffsets = unsafecast.BytesToUint32(obuf.data)
 	}
 

--- a/column.go
+++ b/column.go
@@ -488,7 +488,7 @@ func schemaRepetitionTypeOf(s *format.SchemaElement) format.FieldRepetitionType 
 }
 
 func (c *Column) decompress(compressedPageData []byte, uncompressedPageSize int32) (page *buffer, err error) {
-	page = uncompressedPageBufferPool.get()
+	page = uncompressedPageBufferPool.get(int(uncompressedPageSize))
 	if uncompressedPageSize > 0 {
 		page.resize(int(uncompressedPageSize))
 	}
@@ -628,15 +628,15 @@ func (c *Column) decodeDataPage(header DataPageHeader, numValues int, repetition
 
 	pageKind := pageType.Kind()
 	if pageKind >= 0 && int(pageKind) < len(pageValuesBufferPool) {
-		vbuf = pageValuesBufferPool[pageKind].get()
+		vbuf = pageValuesBufferPool[pageKind].get(int(pageType.EstimateSize(numValues)))
 		defer vbuf.unref()
 		vbuf.resize(int(pageType.EstimateSize(numValues)))
 		pageValues = vbuf.data
 	}
 	if pageKind == ByteArray {
-		obuf = pageOffsetsBufferPool.get()
+		obuf = pageOffsetsBufferPool.get(4 * (numValues + 1))
 		defer obuf.unref()
-		obuf.resize(4 * (numValues + 1))
+		obuf.resize(4 * (numValues + 1)) // jpe - wut?
 		pageOffsets = unsafecast.BytesToUint32(obuf.data)
 	}
 
@@ -707,7 +707,7 @@ func decodeLevelsV2(enc encoding.Encoding, numValues int, data []byte, length in
 }
 
 func decodeLevels(enc encoding.Encoding, numValues int, data []byte) (levels *buffer, err error) {
-	levels = levelsBufferPool.get()
+	levels = levelsBufferPool.get(len(data) * 8)
 	levels.data, err = enc.DecodeLevels(levels.data, data)
 	if err != nil {
 		levels.unref()

--- a/column.go
+++ b/column.go
@@ -702,7 +702,7 @@ func decodeLevelsV2(enc encoding.Encoding, numValues int, data []byte, length in
 }
 
 func decodeLevels(enc encoding.Encoding, numValues int, data []byte) (levels *buffer, err error) {
-	levels = levelsBufferPool.get(len(data) * 8)
+	levels = levelsBufferPool.get(len(data) * 32)
 	levels.data, err = enc.DecodeLevels(levels.data, data)
 	if err != nil {
 		levels.unref()

--- a/file.go
+++ b/file.go
@@ -567,7 +567,7 @@ func (f *filePages) readDictionary() error {
 		return err
 	}
 
-	page := compressedPageBufferPool.get()
+	page := compressedPageBufferPool.get(int(header.CompressedPageSize))
 	defer page.unref()
 
 	page.resize(int(header.CompressedPageSize))
@@ -619,7 +619,7 @@ func (f *filePages) readDataPageV2(header *format.PageHeader, page *buffer) (Pag
 }
 
 func (f *filePages) readPage(header *format.PageHeader, reader *bufio.Reader) (*buffer, error) {
-	page := compressedPageBufferPool.get()
+	page := compressedPageBufferPool.get(int(header.CompressedPageSize))
 	defer page.unref()
 
 	page.resize(int(header.CompressedPageSize))

--- a/file.go
+++ b/file.go
@@ -570,8 +570,6 @@ func (f *filePages) readDictionary() error {
 	page := compressedPageBufferPool.get(int(header.CompressedPageSize))
 	defer page.unref()
 
-	page.resize(int(header.CompressedPageSize))
-
 	if _, err := io.ReadFull(rbuf, page.data); err != nil {
 		return err
 	}
@@ -621,8 +619,6 @@ func (f *filePages) readDataPageV2(header *format.PageHeader, page *buffer) (Pag
 func (f *filePages) readPage(header *format.PageHeader, reader *bufio.Reader) (*buffer, error) {
 	page := compressedPageBufferPool.get(int(header.CompressedPageSize))
 	defer page.unref()
-
-	page.resize(int(header.CompressedPageSize))
 
 	if _, err := io.ReadFull(reader, page.data); err != nil {
 		return nil, err


### PR DESCRIPTION
This PR introduces leveled buffering to the pools in buffer.go. Each pool internally is divided into 16 different pools. The smallest pool is guaranteed to have buffers in size from 1024->2047. The next is 2048->4095, etc. When a buffer is requested the appropriate subpool is used to guarantee that the buffer will be large enough. This prevents all buffers in the pools to trend towards max requested size. The largest pool contains buffers of 32MB and larger. This is the one sub pool that does not guarantee that it will return a buffer of the appropriate size and a resize may be necessary.

We have seen a total heap reduction of ~25% in the components we tested.

Also, fixed a bug where `resize()` would drop a buffer.