### PR TITLE
internal/debug: add build directive to disable runtime.SetFinalizer

### DIFF
--- a/internal/debug/finalizer_off.go
+++ b/internal/debug/finalizer_off.go
@@ -1,0 +1,6 @@
+//go:build debug
+
+package debug
+
+// SetFinalizer is a no-op when the debug tag is specified.
+func SetFinalizer(interface{}, interface{}) {}

--- a/internal/debug/finalizer_on.go
+++ b/internal/debug/finalizer_on.go
@@ -1,0 +1,7 @@
+//go:build !debug
+
+package debug
+
+import "runtime"
+
+func SetFinalizer(obj, finalizer interface{}) { runtime.SetFinalizer(obj, finalizer) }

--- a/page.go
+++ b/page.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"runtime"
 
 	"github.com/segmentio/parquet-go/deprecated"
 	"github.com/segmentio/parquet-go/encoding"
 	"github.com/segmentio/parquet-go/internal/bitpack"
+	"github.com/segmentio/parquet-go/internal/debug"
 )
 
 // Page values represent sequences of parquet values. From the Parquet
@@ -129,7 +129,7 @@ func AsyncPages(pages Pages) Pages {
 	// If the pages object gets garbage collected without Close being called,
 	// this finalizer would ensure that the goroutine is stopped and doesn't
 	// leak.
-	runtime.SetFinalizer(p, func(p *asyncPages) { p.Close() })
+	debug.SetFinalizer(p, func(p *asyncPages) { p.Close() })
 	return p
 }
 

--- a/row_group.go
+++ b/row_group.go
@@ -3,7 +3,8 @@ package parquet
 import (
 	"fmt"
 	"io"
-	"runtime"
+
+	"github.com/segmentio/parquet-go/internal/debug"
 )
 
 // RowGroup is an interface representing a parquet row group. From the Parquet
@@ -294,7 +295,7 @@ func (r *rowGroupRows) init() {
 	// This finalizer is used to ensure that the goroutines started by calling
 	// init on the underlying page readers will be shutdown in the event that
 	// Close isn't called and the rowGroupRows object is garbage collected.
-	runtime.SetFinalizer(r, func(r *rowGroupRows) { r.Close() })
+	debug.SetFinalizer(r, func(r *rowGroupRows) { r.Close() })
 }
 
 func (r *rowGroupRows) clear() {


### PR DESCRIPTION
This commit adds a build directive to disable runtime.SetFinalizer if the
`debug` tag is specified. The use-case is to disable cleaning up resources so
that users can detect leaked goroutines more easily, since Finalizers are
currently used to close asyncPages and rowGroupRows if not done so before.

cc @achille-roussel 