### PR TITLE
Collapse Buffer Pools to 1

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -380,11 +380,7 @@ func levelledPoolIndex(sz int) int {
 }
 
 var (
-	levelsBufferPool           bufferPool
-	compressedPageBufferPool   bufferPool
-	uncompressedPageBufferPool bufferPool
-	pageOffsetsBufferPool      bufferPool
-	pageValuesBufferPool       [8]bufferPool
+	bytesPool bufferPool
 )
 
 type bufferedPage struct {

--- a/column.go
+++ b/column.go
@@ -493,7 +493,7 @@ func schemaRepetitionTypeOf(s *format.SchemaElement) format.FieldRepetitionType 
 }
 
 func (c *Column) decompress(compressedPageData []byte, uncompressedPageSize int32) (page *buffer, err error) {
-	page = uncompressedPageBufferPool.get(int(uncompressedPageSize))
+	page = bytesPool.get(int(uncompressedPageSize))
 	page.data, err = c.compression.Decode(page.data, compressedPageData)
 	if err != nil {
 		page.unref()
@@ -628,14 +628,13 @@ func (c *Column) decodeDataPage(header DataPageHeader, numValues int, repetition
 	var pageValues []byte
 	var pageOffsets []uint32
 
+	vbuf = bytesPool.get(int(pageType.EstimateSize(numValues)))
+	defer vbuf.unref()
+	pageValues = vbuf.data
+
 	pageKind := pageType.Kind()
-	if pageKind >= 0 && int(pageKind) < len(pageValuesBufferPool) {
-		vbuf = pageValuesBufferPool[pageKind].get(int(pageType.EstimateSize(numValues)))
-		defer vbuf.unref()
-		pageValues = vbuf.data
-	}
 	if pageKind == ByteArray {
-		obuf = pageOffsetsBufferPool.get(4 * (numValues + 1))
+		obuf = bytesPool.get(4 * (numValues + 1))
 		defer obuf.unref()
 		pageOffsets = unsafecast.BytesToUint32(obuf.data)
 	}
@@ -707,7 +706,7 @@ func decodeLevelsV2(enc encoding.Encoding, numValues int, data []byte, length in
 }
 
 func decodeLevels(enc encoding.Encoding, numValues int, data []byte) (levels *buffer, err error) {
-	levels = levelsBufferPool.get(numValues)
+	levels = bytesPool.get(numValues)
 	levels.data, err = enc.DecodeLevels(levels.data, data)
 	if err != nil {
 		levels.unref()

--- a/file.go
+++ b/file.go
@@ -567,7 +567,7 @@ func (f *filePages) readDictionary() error {
 		return err
 	}
 
-	page := compressedPageBufferPool.get(int(header.CompressedPageSize))
+	page := bytesPool.get(int(header.CompressedPageSize))
 	defer page.unref()
 
 	if _, err := io.ReadFull(rbuf, page.data); err != nil {
@@ -617,7 +617,7 @@ func (f *filePages) readDataPageV2(header *format.PageHeader, page *buffer) (Pag
 }
 
 func (f *filePages) readPage(header *format.PageHeader, reader *bufio.Reader) (*buffer, error) {
-	page := compressedPageBufferPool.get(int(header.CompressedPageSize))
+	page := bytesPool.get(int(header.CompressedPageSize))
 	defer page.unref()
 
 	if _, err := io.ReadFull(reader, page.data); err != nil {


### PR DESCRIPTION
Previously we reduced overall memory consumption of parquet-go by [leveling our buffer pools](https://github.com/segmentio/parquet-go/pull/354). This PR collapses all buffer pools into 1 to reduce memory consumption even further. 

I believe that they were broken out into individual pools to help consolidate buffers of similar sizes in different pools. However, with the leveling change sharing pools should reduce overall consumption. In practice we are seeing roughly 5% reduction in working set on the most heavily impacted processes.