### PR TITLE
do not zero bufferedPages when they are released

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -418,12 +418,6 @@ func (p *bufferedPage) Release() {
 	bufferUnref(p.offsets)
 	bufferUnref(p.definitionLevels)
 	bufferUnref(p.repetitionLevels)
-
-	p.Page = nil
-	p.values = nil
-	p.offsets = nil
-	p.definitionLevels = nil
-	p.repetitionLevels = nil
 }
 
 func bufferRef(buf *buffer) {


### PR DESCRIPTION
Follow up to #380, we change mistakenly inherited the logic of zeroing out the page, which was only valid to do where the `Retain` function did not exist.

Since an application may call `Retain` multiple times, zeroing the fields on the first `Release` call may invalidate shared references to the page.