### PR TITLE
set byte slice capacity when growing output buffers

### DIFF
--- a/encoding/bitpacked/bitpacked.go
+++ b/encoding/bitpacked/bitpacked.go
@@ -44,7 +44,7 @@ func encodeLevels(dst, src []byte, bitWidth uint) ([]byte, error) {
 	c := n + 1
 
 	if cap(dst) < c {
-		dst = make([]byte, c)
+		dst = make([]byte, c, 2*c)
 	} else {
 		dst = dst[:c]
 		for i := range dst {
@@ -80,7 +80,7 @@ func decodeLevels(dst, src []byte, bitWidth uint) ([]byte, error) {
 	}
 
 	if cap(dst) < numValues {
-		dst = make([]byte, numValues)
+		dst = make([]byte, numValues, 2*numValues)
 	} else {
 		dst = dst[:numValues]
 		for i := range dst {

--- a/encoding/bytestreamsplit/bytestreamsplit.go
+++ b/encoding/bytestreamsplit/bytestreamsplit.go
@@ -52,7 +52,7 @@ func (e *Encoding) DecodeDouble(dst []float64, src []byte) ([]float64, error) {
 
 func resize(buf []byte, size int) []byte {
 	if cap(buf) < size {
-		buf = make([]byte, size)
+		buf = make([]byte, size, 2*size)
 	} else {
 		buf = buf[:size]
 	}

--- a/encoding/delta/length_byte_array.go
+++ b/encoding/delta/length_byte_array.go
@@ -46,7 +46,7 @@ func (e *LengthByteArrayEncoding) DecodeByteArray(dst []byte, src []byte, offset
 	}
 
 	if size := len(length.values) + 1; cap(offsets) < size {
-		offsets = make([]uint32, size)
+		offsets = make([]uint32, size, 2*size)
 	} else {
 		offsets = offsets[:size]
 	}


### PR DESCRIPTION
I have a theory that #372 might be caused by growing memory allocations in small increments due to calling `make` with only the slice size and leaving the capacity allocation up to the runtime.

This PR modifies the `encoding` packages to always create slices with twice the capacity as the target size to ensure that we have room for growth when the memory areas are reused.

@mdisibio let me know if the change helps address the issue that you originally reported!