### PR TITLE
search: add comments to search.go

### DIFF
--- a/search.go
+++ b/search.go
@@ -121,8 +121,7 @@ func binarySearch(index ColumnIndex, value Value, cmp func(Value, Value) int) in
 		}
 	}
 
-	// If value may exist somewhere in the column
-	// e.g. we got to idx 0 or idx n-1
+	// last page check, if it wasn't explicitly found above
 	if curIdx < n {
 
 		// check current nextIdx for value

--- a/search.go
+++ b/search.go
@@ -94,6 +94,27 @@ func binarySearch(index ColumnIndex, value Value, cmp func(Value, Value) int) in
 		// search above this page
 		case greaterThanMax > 0:
 			curIdx = nextIdx
+		case smallerThanMin == 0:
+			// this case is hit when winValue == value of nextIdx
+			// we must check below this index to find if there's
+			// another page before this.
+			// e.g. searching for first page 3 is in:
+			// [1,2,3]
+			// [3,4,5]
+			// [6,7,8]
+
+			// if the page proceeding this has a maxValue matching the value we're
+			// searching, continue the search.
+			// otherwise, we can return early
+			//
+			// cases covered by else block
+			// if cmp(value, index.MaxValue(nextIdx-1)) < 0: the value is only in this page
+			// if cmp(value, index.MaxValue(nextIdx-1)) > 0: we've got a sorting problem with overlapping pages
+			if nextIdx-1 > curIdx && cmp(value, index.MaxValue(nextIdx-1)) == 0 {
+				topIdx = nextIdx
+			} else {
+				return nextIdx
+			}
 		// if present at all, value will be in this page
 		default:
 			return nextIdx

--- a/search_test.go
+++ b/search_test.go
@@ -1,8 +1,6 @@
 package parquet_test
 
 import (
-	"fmt"
-	"math"
 	"testing"
 
 	"github.com/segmentio/parquet-go"
@@ -34,11 +32,24 @@ func TestSearchBinary(t *testing.T) {
 	testSearch(t, [][]int32{
 		{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 		{10, 10, 10, 10},
-		{21, 22, 23, 24, 25},
-		{30},
-		{31},
+		{21, 22, 24, 25, 30},
+		{30, 30},
+		{30, 31},
 		{32},
 		{42, 43, 44, 45, 46, 47, 48, 49},
+	}, [][]int{
+		{10, 1},
+		{0, 0},
+		{9, 0},
+		// non-existant, but would be in this page
+		{23, 2},
+		// ensure we find the first page
+		{30, 2},
+		{31, 4},
+		// out of bounds
+		{99, 7},
+		// out of bounds
+		{-1, 7},
 	})
 }
 
@@ -47,12 +58,23 @@ func TestSearchLinear(t *testing.T) {
 		{10, 10, 10, 10},
 		{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 		{21, 22, 23, 24, 25},
-		{19, 18, 17, 16, 15, 14, 13, 12, 11},
+		{19, 18, 17, 16, 14, 13, 12, 11},
 		{42, 43, 44, 45, 46, 47, 48, 49},
+	}, [][]int{
+		{10, 0},
+		{0, 1},
+		{9, 1},
+		{48, 4},
+		// non-existant, but could be in this page
+		{15, 3},
+		// out of bounds
+		{99, 5},
+		// out of bounds
+		{-1, 5},
 	})
 }
 
-func testSearch(t *testing.T, pages [][]int32) {
+func testSearch(t *testing.T, pages [][]int32, expectIndex [][]int) {
 	indexer := parquet.Int32Type.NewColumnIndexer(0)
 
 	for _, values := range pages {
@@ -77,22 +99,12 @@ func testSearch(t *testing.T, pages [][]int32) {
 	formatIndex := indexer.ColumnIndex()
 	columnIndex := parquet.NewColumnIndex(parquet.Int32, &formatIndex)
 
-	for i, values := range pages {
-		t.Run(fmt.Sprintf("page#%02d", i), func(t *testing.T) {
-			for _, value := range values {
-				v := parquet.ValueOf(value)
-				j := parquet.Search(columnIndex, v, parquet.Int32Type)
+	for _, values := range expectIndex {
+		v := parquet.ValueOf(values[0])
+		j := parquet.Search(columnIndex, v, parquet.Int32Type)
 
-				if i != j {
-					t.Errorf("searching for value %v: got=%d want=%d", v, j, i)
-				}
-			}
-
-			for _, test := range []int32{math.MinInt32, math.MaxInt32} {
-				if page := parquet.Search(columnIndex, parquet.ValueOf(test), parquet.Int32Type); page != len(pages) {
-					t.Errorf("search for non-existing value %v: got=%d want=%d", test, page, len(pages))
-				}
-			}
-		})
+		if values[1] != j {
+			t.Errorf("searching for value %v: got=%d want=%d", v, j, values[1])
+		}
 	}
 }


### PR DESCRIPTION
I was going through this function to check my understanding of page indexes while thinking about granules in TraceDB.

I believe that granules in other databases like clickhouse and frostdb are the equivlant of column pages in parquet.  The page index is the sparse index over the pages (granules) wherein the data being searched for is contained.

This check on the binary search mostly confirms that suspicion, if I'm not mistaken.  Please correct me if I'm misunderstaneding something.

Also, as part of this, I found what is possibly an optimization to avoid skipping ahead a page, by comparing the current value to the max in the current page, instead of letting the binary search check the next page, then falling through to the final if-block.

It may or may not be a bug also, if, for example, the following happens:

you have pages:

    [1,2,3]
    [3,4,5]
    [6,7,8]

Searching for 3 in this case would not return the first page and instead return the second, missing values of 3 in the first page.

I'll have to look at writing a test for this, but the current search test will pass creating this scenario without altering the test somewhat (since it's only looking for presence, not the expected index)