### PR TITLE
add configuration option to limit the number of rows per row group

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -657,7 +657,7 @@ func (w *writer) writeRowGroup(rowGroupSchema *Schema, rowGroupSortingColumns []
 }
 
 func (w *writer) WriteRows(rows []Row) (int, error) {
-	return w.writeRows(len(rows), func(i, j int) (int, error) {
+	return w.writeRows(len(rows), func(start, end int) (int, error) {
 		defer func() {
 			for i, values := range w.values {
 				clearValues(values)
@@ -669,7 +669,7 @@ func (w *writer) WriteRows(rows []Row) (int, error) {
 		// partially functional state. Applications are not expected to continue
 		// using the writer after getting an error, but maybe we could ensure that
 		// we are preventing further use as well?
-		for _, row := range rows[i:j] {
+		for _, row := range rows[start:end] {
 			for _, value := range row {
 				columnIndex := value.Column()
 				w.values[columnIndex] = append(w.values[columnIndex], value)
@@ -684,7 +684,7 @@ func (w *writer) WriteRows(rows []Row) (int, error) {
 			}
 		}
 
-		return j - i, nil
+		return end - start, nil
 	})
 }
 

--- a/writer.go
+++ b/writer.go
@@ -211,9 +211,11 @@ func (w *Writer) ReadRowsFrom(rows RowReader) (written int64, err error) {
 func (w *Writer) Schema() *Schema { return w.schema }
 
 type writer struct {
-	buffer *bufio.Writer
-	writer offsetTrackingWriter
-	values [][]Value
+	buffer  *bufio.Writer
+	writer  offsetTrackingWriter
+	values  [][]Value
+	numRows int64
+	maxRows int64
 
 	createdBy string
 	metadata  []format.KeyValue
@@ -240,6 +242,7 @@ func newWriter(output io.Writer, config *WriterConfig) *writer {
 		w.buffer = bufio.NewWriterSize(output, config.WriteBufferSize)
 		w.writer.Reset(w.buffer)
 	}
+	w.maxRows = config.MaxRowsPerRowGroup
 	w.createdBy = config.CreatedBy
 	w.metadata = make([]format.KeyValue, 0, len(config.KeyValueMetadata))
 	for k, v := range config.KeyValueMetadata {
@@ -550,6 +553,7 @@ func (w *writer) writeRowGroup(rowGroupSchema *Schema, rowGroupSortingColumns []
 	}
 
 	defer func() {
+		w.numRows = 0
 		for _, c := range w.columns {
 			c.reset()
 		}
@@ -653,33 +657,65 @@ func (w *writer) writeRowGroup(rowGroupSchema *Schema, rowGroupSortingColumns []
 }
 
 func (w *writer) WriteRows(rows []Row) (int, error) {
-	defer func() {
-		for i, values := range w.values {
-			clearValues(values)
-			w.values[i] = values[:0]
-		}
-	}()
+	return w.writeRows(len(rows), func(i, j int) (int, error) {
+		defer func() {
+			for i, values := range w.values {
+				clearValues(values)
+				w.values[i] = values[:0]
+			}
+		}()
 
-	// TODO: if an error occurs in this method the writer may be left in an
-	// partially functional state. Applications are not expected to continue
-	// using the writer after getting an error, but maybe we could ensure that
-	// we are preventing further use as well?
-	for _, row := range rows {
-		for _, value := range row {
-			columnIndex := value.Column()
-			w.values[columnIndex] = append(w.values[columnIndex], value)
-		}
-	}
-
-	for i, values := range w.values {
-		if len(values) > 0 {
-			if err := w.columns[i].writeRows(values); err != nil {
-				return 0, err
+		// TODO: if an error occurs in this method the writer may be left in an
+		// partially functional state. Applications are not expected to continue
+		// using the writer after getting an error, but maybe we could ensure that
+		// we are preventing further use as well?
+		for _, row := range rows[i:j] {
+			for _, value := range row {
+				columnIndex := value.Column()
+				w.values[columnIndex] = append(w.values[columnIndex], value)
 			}
 		}
+
+		for i, values := range w.values {
+			if len(values) > 0 {
+				if err := w.columns[i].writeRows(values); err != nil {
+					return 0, err
+				}
+			}
+		}
+
+		return j - i, nil
+	})
+}
+
+func (w *writer) writeRows(numRows int, write func(i, j int) (int, error)) (int, error) {
+	written := 0
+
+	for written < numRows {
+		remain := w.maxRows - w.numRows
+		length := numRows - written
+
+		if remain == 0 {
+			remain = w.maxRows
+
+			if err := w.flush(); err != nil {
+				return written, err
+			}
+		}
+
+		if remain < int64(length) {
+			length = int(remain)
+		}
+
+		n, err := write(written, written+length)
+		written += n
+		w.numRows += int64(n)
+		if err != nil {
+			return written, err
+		}
 	}
 
-	return len(rows), nil
+	return written, nil
 }
 
 // The WriteValues method is intended to work in pair with WritePage to allow

--- a/writer_go18.go
+++ b/writer_go18.go
@@ -149,7 +149,7 @@ func (w *GenericWriter[T]) Reset(output io.Writer) {
 
 func (w *GenericWriter[T]) Write(rows []T) (int, error) {
 	return w.base.writer.writeRows(len(rows), func(i, j int) (int, error) {
-		n, err := w.write(w, rows[i:j])
+		n, err := w.write(w, rows[i:j:j])
 		if err != nil {
 			return n, err
 		}

--- a/writer_go18.go
+++ b/writer_go18.go
@@ -148,22 +148,24 @@ func (w *GenericWriter[T]) Reset(output io.Writer) {
 }
 
 func (w *GenericWriter[T]) Write(rows []T) (int, error) {
-	n, err := w.write(w, rows)
-	if err != nil {
-		return n, err
-	}
+	return w.base.writer.writeRows(len(rows), func(i, j int) (int, error) {
+		n, err := w.write(w, rows[i:j])
+		if err != nil {
+			return n, err
+		}
 
-	for _, c := range w.base.writer.columns {
-		c.numValues = int32(c.columnBuffer.NumValues())
+		for _, c := range w.base.writer.columns {
+			c.numValues = int32(c.columnBuffer.NumValues())
 
-		if c.numValues > 0 && c.numValues >= c.maxValues {
-			if err := c.flush(); err != nil {
-				return 0, err
+			if c.numValues > 0 && c.numValues >= c.maxValues {
+				if err := c.flush(); err != nil {
+					return 0, err
+				}
 			}
 		}
-	}
 
-	return n, nil
+		return n, nil
+	})
 }
 
 func (w *GenericWriter[T]) WriteRows(rows []Row) (int, error) {


### PR DESCRIPTION
Fixes #375 

This PR adds a new `MaxRowsPerRowGroup` writer option to automatically flush row groups when the configured limit of rows per row group has been reached.