### PR TITLE
fix error message of parquet.ErrTooManyRowGroups

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -52,7 +52,7 @@ var (
 
 	// ErrTooManyRowGroups is returned when attempting to generate a parquet
 	// file with more than MaxRowGroups row groups.
-	ErrTooManyRowGroups = errors.New("the limit of 65535 row groups has been reached")
+	ErrTooManyRowGroups = errors.New("the limit of 32767 row groups has been reached")
 )
 
 type errno int


### PR DESCRIPTION
Related to #382

The error message was misleading, the maximum number of row groups is 2^15-1 since the `ordinal` value is a signed 16 bits integer.