### PR TITLE
Run tests on main, display status of main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Test
 on:
-- pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# segmentio/parquet-go [![build status](https://github.com/segmentio/parquet-go/actions/workflows/test.yml/badge.svg)](https://github.com/segmentio/parquet-go/actions) [![Go Report Card](https://goreportcard.com/badge/github.com/segmentio/parquet-go)](https://goreportcard.com/report/github.com/segmentio/parquet-go) [![Go Reference](https://pkg.go.dev/badge/github.com/segmentio/parquet-go.svg)](https://pkg.go.dev/github.com/segmentio/parquet-go)
+# segmentio/parquet-go [![build status](https://github.com/segmentio/parquet-go/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/segmentio/parquet-go/actions) [![Go Report Card](https://goreportcard.com/badge/github.com/segmentio/parquet-go)](https://goreportcard.com/report/github.com/segmentio/parquet-go) [![Go Reference](https://pkg.go.dev/badge/github.com/segmentio/parquet-go.svg)](https://pkg.go.dev/github.com/segmentio/parquet-go)
 
 High-performance Go library to manipulate parquet files.
 


### PR DESCRIPTION
This configures the "Test" workflow to run on pull requests to `main` and on commits pushed to `main`.  Previously, this workflow was only run on pull requests, so there wasn't really a definitive indicator of whether `main` was in good shape.  

The badge displayed on the [pkg docs](https://pkg.go.dev/github.com/segmentio/parquet-go#section-readme) and readme previously showed the status of the test results for whatever pull request might have been most recently run.  The change here proposes showing the results for the latest run on the `main` branch instead.

Fixes #402.