### PR TITLE
all: run 'go fmt ./...'

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -36,7 +36,6 @@ type Buffer struct {
 //		buffer := parquet.NewBuffer(config)
 //		...
 //	}
-//
 func NewBuffer(options ...RowGroupOption) *Buffer {
 	config, err := NewRowGroupConfig(options...)
 	if err != nil {

--- a/column_buffer_go18.go
+++ b/column_buffer_go18.go
@@ -245,19 +245,18 @@ type columnBufferWriter struct {
 // writeRowsFunc is the type of functions that apply rows to a set of column
 // buffers.
 //
-// - w is the columnBufferWriter holding the column buffers where the rows are
-//   written.
+//   - w is the columnBufferWriter holding the column buffers where the rows are
+//     written.
 //
 // - rows is the array of Go values to write to the column buffers.
 //
 // - size is the size of Go values in the rows array (in bytes).
 //
-// - offset is the byte offset of the value being written in each element of the
-//   rows array.
+//   - offset is the byte offset of the value being written in each element of the
+//     rows array.
 //
-// - levels is used to track the column index, repetition and definition levels
-//   of values when writing optional or repeated columns.
-//
+//   - levels is used to track the column index, repetition and definition levels
+//     of values when writing optional or repeated columns.
 type writeRowsFunc func(w *columnBufferWriter, rows array, size, offset uintptr, levels columnLevels) error
 
 // writeRowsFuncOf generates a writeRowsFunc function for the given Go type and

--- a/config.go
+++ b/config.go
@@ -28,7 +28,6 @@ const (
 //		SkipPageIndex:    true,
 //		SkipBloomFilters: true,
 //	})
-//
 type FileConfig struct {
 	SkipPageIndex    bool
 	SkipBloomFilters bool
@@ -82,7 +81,6 @@ func (c *FileConfig) Validate() error {
 //	reader := parquet.NewReader(output, schema, &parquet.ReaderConfig{
 //		// ...
 //	})
-//
 type ReaderConfig struct {
 	Schema *Schema
 }
@@ -131,7 +129,6 @@ func (c *ReaderConfig) Validate() error {
 //	writer := parquet.NewWriter(output, schema, &parquet.WriterConfig{
 //		CreatedBy: "my test program",
 //	})
-//
 type WriterConfig struct {
 	CreatedBy            string
 	ColumnPageBuffers    PageBufferPool
@@ -226,7 +223,6 @@ func (c *WriterConfig) Validate() error {
 //	buffer := parquet.NewBuffer(&parquet.RowGroupConfig{
 //		ColumnBufferSize: 8 * 1024 * 1024,
 //	})
-//
 type RowGroupConfig struct {
 	ColumnBufferSize int
 	SortingColumns   []SortingColumn

--- a/file.go
+++ b/file.go
@@ -135,19 +135,19 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 // Only leaf columns have indexes, the returned indexes are arranged using the
 // following layout:
 //
-//	+ -------------- +
+//	+--------------- +
 //	| col 0: chunk 0 |
-//	+ -------------- +
+//	+--------------- +
 //	| col 1: chunk 0 |
-//	+ -------------- +
+//	+--------------- +
 //	| ...            |
-//	+ -------------- +
+//	+--------------- +
 //	| col 0: chunk 1 |
-//	+ -------------- +
+//	+--------------- +
 //	| col 1: chunk 1 |
-//	+ -------------- +
+//	+--------------- +
 //	| ...            |
-//	+ -------------- +
+//	+--------------- +
 //
 // This method is useful in combination with the SkipPageIndex option to delay
 // reading the page index section until after the file was opened. Note that in

--- a/reader.go
+++ b/reader.go
@@ -27,8 +27,6 @@ import (
 //	if err := reader.Close(); err != nil {
 //		...
 //	}
-//
-//
 type Reader struct {
 	seen     reflect.Type
 	file     reader
@@ -59,7 +57,6 @@ type Reader struct {
 //		reader := parquet.NewReader(input, config)
 //		...
 //	}
-//
 func NewReader(input io.ReaderAt, options ...ReaderOption) *Reader {
 	c, err := NewReaderConfig(options...)
 	if err != nil {

--- a/schema.go
+++ b/schema.go
@@ -57,7 +57,8 @@ type Schema struct {
 //	date      | for int32 types use the DATE logical type
 //	timestamp | for int64 types use the TIMESTAMP logical type with millisecond precision
 //
-// The date logical type is an int32 value of the number of days since the unix epoch
+// The date logical type is an int32 value of the number of days since the
+// unix epoch.
 //
 // The decimal tag must be followed by two integer parameters, the first integer
 // representing the scale and the second the precision; for example:
@@ -391,7 +392,6 @@ func (f *structField) Value(base reflect.Value) reflect.Value {
 			return fieldByIndex(base, f.index)
 		}
 	}
-	return reflect.Value{}
 }
 
 func structFieldString(f reflect.StructField) string {

--- a/search.go
+++ b/search.go
@@ -56,7 +56,6 @@ func Search(index ColumnIndex, value Value, typ Type) int {
 //	pageIndex := parquet.Find(columnIndex, value,
 //		parquet.CompareNullsFirst(typ.Compare),
 //	)
-//
 func Find(index ColumnIndex, value Value, cmp func(Value, Value) int) int {
 	switch {
 	case index.IsAscending():

--- a/sort.go
+++ b/sort.go
@@ -10,7 +10,6 @@ package parquet
 //		Descending: true,
 //		NullsFirst: true,
 //	})
-//
 type SortConfig struct {
 	MaxRepetitionLevel int
 	MaxDefinitionLevel int

--- a/value.go
+++ b/value.go
@@ -444,19 +444,19 @@ func (v Value) AppendBytes(b []byte) []byte {
 //
 // The following formatting options are supported:
 //
-//		%c	prints the column index
-//		%+c	prints the column index, prefixed with "C:"
-//		%d	prints the definition level
-//		%+d	prints the definition level, prefixed with "D:"
-//		%r	prints the repetition level
-//		%+r	prints the repetition level, prefixed with "R:"
-//		%q	prints the quoted representation of v
-//		%+q	prints the quoted representation of v, prefixed with "V:"
-//		%s	prints the string representation of v
-//		%+s	prints the string representation of v, prefixed with "V:"
-//		%v	same as %s
-//		%+v	prints a verbose representation of v
-//		%#v	prints a Go value representation of v
+//	%c	prints the column index
+//	%+c	prints the column index, prefixed with "C:"
+//	%d	prints the definition level
+//	%+d	prints the definition level, prefixed with "D:"
+//	%r	prints the repetition level
+//	%+r	prints the repetition level, prefixed with "R:"
+//	%q	prints the quoted representation of v
+//	%+q	prints the quoted representation of v, prefixed with "V:"
+//	%s	prints the string representation of v
+//	%+s	prints the string representation of v, prefixed with "V:"
+//	%v	same as %s
+//	%+v	prints a verbose representation of v
+//	%#v	prints a Go value representation of v
 //
 // Format satisfies the fmt.Formatter interface.
 func (v Value) Format(w fmt.State, r rune) {

--- a/writer.go
+++ b/writer.go
@@ -64,7 +64,6 @@ type Writer struct {
 //		writer := parquet.NewWriter(output, config)
 //		...
 //	}
-//
 func NewWriter(output io.Writer, options ...WriterOption) *Writer {
 	config, err := NewWriterConfig(options...)
 	if err != nil {

--- a/writer_go18.go
+++ b/writer_go18.go
@@ -12,29 +12,29 @@ import (
 //
 // Using this type over Writer has multiple advantages:
 //
-// - By leveraging type information, the Go compiler can provide greater
-//   guarantees that the code is correct. For example, the parquet.Writer.Write
-//   method accepts an argument of type interface{}, which delays type checking
-//   until runtime. The parquet.GenericWriter[T].Write method ensures at
-//   compile time that the values it receives will be of type T, reducing the
-//   risk of introducing errors.
+//   - By leveraging type information, the Go compiler can provide greater
+//     guarantees that the code is correct. For example, the parquet.Writer.Write
+//     method accepts an argument of type interface{}, which delays type checking
+//     until runtime. The parquet.GenericWriter[T].Write method ensures at
+//     compile time that the values it receives will be of type T, reducing the
+//     risk of introducing errors.
 //
-// - Since type information is known at compile time, the implementation of
-//   parquet.GenericWriter[T] can make safe assumptions, removing the need for
-//   runtime validation of how the parameters are passed to its methods.
-//   Optimizations relying on type information are more effective, some of the
-//   writer's state can be precomputed at initialization, which was not possible
-//   with parquet.Writer.
+//   - Since type information is known at compile time, the implementation of
+//     parquet.GenericWriter[T] can make safe assumptions, removing the need for
+//     runtime validation of how the parameters are passed to its methods.
+//     Optimizations relying on type information are more effective, some of the
+//     writer's state can be precomputed at initialization, which was not possible
+//     with parquet.Writer.
 //
-// - The parquet.GenericWriter[T].Write method uses a data-oriented design,
-//   accepting an slice of T instead of a single value, creating more
-//   opportunities to amortize the runtime cost of abstractions.
-//   This optimization is not available for parquet.Writer because its Write
-//   method's argument would be of type []interface{}, which would require
-//   conversions back and forth from concrete types to empty interfaces (since
-//   a []T cannot be interpreted as []interface{} in Go), would make the API
-//   more difficult to use and waste compute resources in the type conversions,
-//   defeating the purpose of the optimization in the first place.
+//   - The parquet.GenericWriter[T].Write method uses a data-oriented design,
+//     accepting an slice of T instead of a single value, creating more
+//     opportunities to amortize the runtime cost of abstractions.
+//     This optimization is not available for parquet.Writer because its Write
+//     method's argument would be of type []interface{}, which would require
+//     conversions back and forth from concrete types to empty interfaces (since
+//     a []T cannot be interpreted as []interface{} in Go), would make the API
+//     more difficult to use and waste compute resources in the type conversions,
+//     defeating the purpose of the optimization in the first place.
 //
 // Note that this type is only available when compiling with Go 1.18 or later.
 type GenericWriter[T any] struct {


### PR DESCRIPTION
I believe these changes are only flagged if you are using Go 1.19 which we are still not testing against in parquet-go.