### PR TITLE
Fix bug that occurs when ReadAt returns EOF

### DIFF
--- a/file.go
+++ b/file.go
@@ -57,7 +57,7 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 	if cast, ok := f.reader.(interface{ SetMagicFooterSection(offset, length int64) }); ok {
 		cast.SetMagicFooterSection(size-8, 8)
 	}
-	if _, err := r.ReadAt(b[:8], size-8); err != nil {
+	if n, err := r.ReadAt(b[:8], size-8); n != 8 {
 		return nil, fmt.Errorf("reading magic footer of parquet file: %w", err)
 	}
 	if string(b[4:8]) != "PAR1" {


### PR DESCRIPTION
According to the Go documentation:

```
If the n = len(p) bytes returned by ReadAt are at the end of the input source, ReadAt may return either err == EOF or err == nil.
```

That is, returning EOF or nil is a reader-dependent behavior. I recently ran into this when changing the underlying reader I was using with the parquet-go library -- it returns EOF when ReadAt is called at end of file rather than nil.

This PR changes the behavior to check result size rather than error in this case. For other reads, it shouldn't be needed because they don't take place at the end of the file.