### PR TITLE
Add support for synchronous page reading

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -256,7 +256,7 @@ func (buf *Buffer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 //
 // The buffer and the returned reader share memory. Mutating the buffer
 // concurrently to reading rows may result in non-deterministic behavior.
-func (buf *Buffer) Rows() Rows { return &rowGroupRows{rowGroup: buf} }
+func (buf *Buffer) Rows() Rows { return newRowGroupRows(buf, PageReadModeAsync) }
 
 // bufferWriter is an adapter for Buffer which implements both RowWriter and
 // PageWriter to enable optimizations in CopyRows for types that support writing

--- a/buffer.go
+++ b/buffer.go
@@ -256,7 +256,7 @@ func (buf *Buffer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 //
 // The buffer and the returned reader share memory. Mutating the buffer
 // concurrently to reading rows may result in non-deterministic behavior.
-func (buf *Buffer) Rows() Rows { return newRowGroupRows(buf, PageReadModeAsync) }
+func (buf *Buffer) Rows() Rows { return newRowGroupRows(buf, ReadModeSync) }
 
 // bufferWriter is an adapter for Buffer which implements both RowWriter and
 // PageWriter to enable optimizations in CopyRows for types that support writing

--- a/config.go
+++ b/config.go
@@ -14,8 +14,8 @@ import (
 type ReadMode int
 
 const (
-	ReadModeAsync ReadMode = iota // ReadModeAsync reads pages asynchronously in the background.
-	ReadModeSync                  // ReadModeSync reads pages synchronously on demand.
+	ReadModeSync  ReadMode = iota // ReadModeSync reads pages synchronously on demand.
+	ReadModeAsync                 // ReadModeAsync reads pages asynchronously in the background.
 )
 
 const (

--- a/config.go
+++ b/config.go
@@ -10,6 +10,13 @@ import (
 	"github.com/segmentio/parquet-go/compress"
 )
 
+type PageReadMode int
+
+const (
+	PageReadModeAsync PageReadMode = iota
+	PageReadModeSync
+)
+
 const (
 	DefaultColumnIndexSizeLimit = 16
 	DefaultColumnBufferCapacity = 16 * 1024
@@ -83,6 +90,7 @@ type FileConfig struct {
 	SkipPageIndex    bool
 	SkipBloomFilters bool
 	ReadBufferSize   int
+	PageReadMode     PageReadMode
 }
 
 // DefaultFileConfig returns a new FileConfig value initialized with the
@@ -92,6 +100,7 @@ func DefaultFileConfig() *FileConfig {
 		SkipPageIndex:    DefaultSkipPageIndex,
 		SkipBloomFilters: DefaultSkipBloomFilters,
 		ReadBufferSize:   defaultReadBufferSize,
+		PageReadMode:     PageReadModeAsync,
 	}
 }
 
@@ -367,6 +376,15 @@ func SkipPageIndex(skip bool) FileOption {
 // Defaults to false.
 func SkipBloomFilters(skip bool) FileOption {
 	return fileOption(func(config *FileConfig) { config.SkipBloomFilters = skip })
+}
+
+// SetPageReadMode is a file configuration option which controls the way pages
+// are read. Currently the only two options are PageReadModeAsync and PageReadModeSync
+// which control whether or not pages are loaded asynchronously.
+//
+// Defaults to PageReadModeAsync.
+func SetPageReadMode(mode PageReadMode) FileOption {
+	return fileOption(func(config *FileConfig) { config.PageReadMode = mode })
 }
 
 // ReadBufferSize is a file configuration option which controls the default

--- a/config.go
+++ b/config.go
@@ -10,11 +10,12 @@ import (
 	"github.com/segmentio/parquet-go/compress"
 )
 
-type PageReadMode int
+// ReadMode is an enum that is used to configure the way that a File reads pages.
+type ReadMode int
 
 const (
-	PageReadModeAsync PageReadMode = iota
-	PageReadModeSync
+	ReadModeAsync ReadMode = iota // ReadModeAsync reads pages asynchronously in the background.
+	ReadModeSync                  // ReadModeSync reads pages synchronously on demand.
 )
 
 const (
@@ -27,6 +28,7 @@ const (
 	DefaultSkipPageIndex        = false
 	DefaultSkipBloomFilters     = false
 	DefaultMaxRowsPerRowGroup   = math.MaxInt64
+	DefaultReadMode             = ReadModeSync
 )
 
 const (
@@ -90,7 +92,7 @@ type FileConfig struct {
 	SkipPageIndex    bool
 	SkipBloomFilters bool
 	ReadBufferSize   int
-	PageReadMode     PageReadMode
+	ReadMode         ReadMode
 }
 
 // DefaultFileConfig returns a new FileConfig value initialized with the
@@ -100,7 +102,7 @@ func DefaultFileConfig() *FileConfig {
 		SkipPageIndex:    DefaultSkipPageIndex,
 		SkipBloomFilters: DefaultSkipBloomFilters,
 		ReadBufferSize:   defaultReadBufferSize,
-		PageReadMode:     PageReadModeAsync,
+		ReadMode:         DefaultReadMode,
 	}
 }
 
@@ -126,7 +128,7 @@ func (c *FileConfig) Apply(options ...FileOption) {
 func (c *FileConfig) ConfigureFile(config *FileConfig) {
 	*config = FileConfig{
 		SkipPageIndex:    config.SkipPageIndex,
-		SkipBloomFilters: config.SkipBloomFilters,
+		SkipBloomFilters: config.SkipBloomFilters, // jpe
 	}
 }
 
@@ -378,13 +380,13 @@ func SkipBloomFilters(skip bool) FileOption {
 	return fileOption(func(config *FileConfig) { config.SkipBloomFilters = skip })
 }
 
-// SetPageReadMode is a file configuration option which controls the way pages
+// FileReadMode is a file configuration option which controls the way pages
 // are read. Currently the only two options are PageReadModeAsync and PageReadModeSync
 // which control whether or not pages are loaded asynchronously.
 //
-// Defaults to PageReadModeAsync.
-func SetPageReadMode(mode PageReadMode) FileOption {
-	return fileOption(func(config *FileConfig) { config.PageReadMode = mode })
+// Defaults to ReadModeAsync.
+func FileReadMode(mode ReadMode) FileOption {
+	return fileOption(func(config *FileConfig) { config.ReadMode = mode })
 }
 
 // ReadBufferSize is a file configuration option which controls the default

--- a/config.go
+++ b/config.go
@@ -128,7 +128,9 @@ func (c *FileConfig) Apply(options ...FileOption) {
 func (c *FileConfig) ConfigureFile(config *FileConfig) {
 	*config = FileConfig{
 		SkipPageIndex:    config.SkipPageIndex,
-		SkipBloomFilters: config.SkipBloomFilters, // jpe
+		SkipBloomFilters: config.SkipBloomFilters,
+		ReadBufferSize:   config.ReadBufferSize,
+		ReadMode:         config.ReadMode,
 	}
 }
 

--- a/file.go
+++ b/file.go
@@ -404,7 +404,7 @@ func (g *fileRowGroup) Schema() *Schema                 { return g.schema }
 func (g *fileRowGroup) NumRows() int64                  { return g.rowGroup.NumRows }
 func (g *fileRowGroup) ColumnChunks() []ColumnChunk     { return g.columns }
 func (g *fileRowGroup) SortingColumns() []SortingColumn { return g.sorting }
-func (g *fileRowGroup) Rows() Rows                      { return newRowGroupRows(g, g.config.PageReadMode) }
+func (g *fileRowGroup) Rows() Rows                      { return newRowGroupRows(g, g.config.ReadMode) }
 
 type fileSortingColumn struct {
 	column     *Column

--- a/file.go
+++ b/file.go
@@ -363,11 +363,13 @@ type fileRowGroup struct {
 	rowGroup *format.RowGroup
 	columns  []ColumnChunk
 	sorting  []SortingColumn
+	config   *FileConfig
 }
 
 func (g *fileRowGroup) init(file *File, schema *Schema, columns []*Column, rowGroup *format.RowGroup) {
 	g.schema = schema
 	g.rowGroup = rowGroup
+	g.config = file.config
 	g.columns = make([]ColumnChunk, len(rowGroup.Columns))
 	g.sorting = make([]SortingColumn, len(rowGroup.SortingColumns))
 	fileColumnChunks := make([]fileColumnChunk, len(rowGroup.Columns))
@@ -402,7 +404,7 @@ func (g *fileRowGroup) Schema() *Schema                 { return g.schema }
 func (g *fileRowGroup) NumRows() int64                  { return g.rowGroup.NumRows }
 func (g *fileRowGroup) ColumnChunks() []ColumnChunk     { return g.columns }
 func (g *fileRowGroup) SortingColumns() []SortingColumn { return g.sorting }
-func (g *fileRowGroup) Rows() Rows                      { return &rowGroupRows{rowGroup: g} }
+func (g *fileRowGroup) Rows() Rows                      { return newRowGroupRows(g, g.config.PageReadMode) }
 
 type fileSortingColumn struct {
 	column     *Column

--- a/row_group.go
+++ b/row_group.go
@@ -295,16 +295,17 @@ func (r *rowGroupRows) init() {
 	done := make(chan struct{})
 	r.done = done
 
-	if r.pageReadMode == PageReadModeAsync {
+	switch r.pageReadMode {
+	case PageReadModeAsync:
 		for i, column := range columns {
 			r.readers[i] = &asyncPages{}
 			r.readers[i].(*asyncPages).init(column.Pages(), done)
 		}
-	} else if r.pageReadMode == PageReadModeSync {
+	case PageReadModeSync:
 		for i, column := range columns {
 			r.readers[i] = column.Pages()
 		}
-	} else {
+	default:
 		panic(fmt.Sprintf("parquet: invalid page read mode: %d", r.pageReadMode))
 	}
 

--- a/row_group.go
+++ b/row_group.go
@@ -292,11 +292,10 @@ func (r *rowGroupRows) init() {
 	r.readers = make([]Pages, len(columns))
 	r.columns = make([]columnChunkRows, len(columns))
 
-	done := make(chan struct{})
-	r.done = done
-
 	switch r.pageReadMode {
 	case PageReadModeAsync:
+		done := make(chan struct{})
+		r.done = done
 		for i, column := range columns {
 			r.readers[i] = &asyncPages{}
 			r.readers[i].(*asyncPages).init(column.Pages(), done)

--- a/row_group.go
+++ b/row_group.go
@@ -296,9 +296,10 @@ func (r *rowGroupRows) init() {
 	case PageReadModeAsync:
 		done := make(chan struct{})
 		r.done = done
+		readers := make([]asyncPages, len(columns))
 		for i, column := range columns {
-			r.readers[i] = &asyncPages{}
-			r.readers[i].(*asyncPages).init(column.Pages(), done)
+			readers[i].init(column.Pages(), done)
+			r.readers[i] = &readers[i]
 		}
 	case PageReadModeSync:
 		for i, column := range columns {


### PR DESCRIPTION
This PR adds a File level config option that controls whether or not pages are read synchronously. It defaults to async to maintain backwards compatibility.

I'm not married to any of the names in this PR so feel free to suggest alternatives.

cc @asubiotto 