### PR TITLE
Enable backward compatible map reads

### DIFF
--- a/node.go
+++ b/node.go
@@ -392,7 +392,12 @@ func listElementOf(node Node) Node {
 
 func mapKeyValueOf(node Node) Node {
 	if !node.Leaf() && (node.Required() || node.Optional()) {
-		if keyValue := childByName(node, "key_value"); keyValue != nil && !keyValue.Leaf() && keyValue.Repeated() {
+		var keyValue Node
+		if keyValue = childByName(node, "key_value"); keyValue == nil {
+			keyValue = childByName(node, "map")
+		}
+
+		if keyValue != nil && !keyValue.Leaf() && keyValue.Repeated() {
 			k := childByName(keyValue, "key")
 			v := childByName(keyValue, "value")
 			if k != nil && v != nil && k.Required() {

--- a/parquet_go18_test.go
+++ b/parquet_go18_test.go
@@ -344,9 +344,9 @@ func TestIssue415(t *testing.T) {
 		Operation                   uint8            `parquet:"operation,optional"`
 		SequenceNumber              string           `parquet:"sequencenumber,optional"`
 		ApproximateCreationDateTime deprecated.Int96 `parquet:"approximatecreationdatetime,optional"`
-		Keys                        map[string]AV    `parquet:"keys,optional" parquet-key:"," parquet-value:",optional"`
-		Old                         map[string]AV    `parquet:"old,optional" parquet-key:"," parquet-value:",optional"`
-		New                         map[string]AV    `parquet:"new,optional" parquet-key:"," parquet-value:",optional"`
+		Keys                        map[string]AV    `parquet:"keys,old_map,optional"`
+		Old                         map[string]AV    `parquet:"old,old_map,optional"`
+		New                         map[string]AV    `parquet:"new,old_map,optional"`
 	}
 
 	f, err := os.Open("testdata/issue415.parquet")
@@ -365,18 +365,14 @@ func TestIssue415(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	first := rows[0]
+	for _, row := range rows {
+		if len(row.Keys) == 0 {
+			t.Fatal("expected more than 0 entries")
+		}
 
-	if len(first.Keys) == 0 {
-		t.Error("expected more than 0 entries")
-	}
-
-	if len(first.Old) == 0 {
-		t.Error("expected more than 0 entries")
-	}
-
-	if len(first.New) == 0 {
-		t.Error("expected more than 0 entries")
+		if len(row.New) == 0 {
+			t.Fatal("expected more than 0 entries")
+		}
 	}
 }
 

--- a/schema.go
+++ b/schema.go
@@ -557,6 +557,11 @@ func nodeOf(t reflect.Type, tag []string) Node {
 				return
 			case "optional":
 				n = Optional(n)
+			case "old_map":
+				n = OldMap(
+					makeNodeOf(t.Key(), t.Name(), []string{keyTag}),
+					makeNodeOf(t.Elem(), t.Name(), []string{valueTag}),
+				)
 			default:
 				throwUnknownTag(t, "map", option)
 			}

--- a/type.go
+++ b/type.go
@@ -1858,6 +1858,15 @@ func Map(key, value Node) Node {
 	}}
 }
 
+func OldMap(key, value Node) Node {
+	return mapNode{Group{
+		"map": Repeated(Group{
+			"key":   Required(key),
+			"value": value,
+		}),
+	}}
+}
+
 type mapNode struct{ Group }
 
 func (mapNode) Type() Type { return &mapType{} }


### PR DESCRIPTION
Adds struct tag for `old_map` that applies to maps written by older parquet clients. 