### PR TITLE
Add missing Close call in WriteRowGroup

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -179,7 +179,9 @@ func (w *Writer) WriteRowGroup(rowGroup RowGroup) (int64, error) {
 		return 0, err
 	}
 	w.writer.configureBloomFilters(rowGroup.ColumnChunks())
-	n, err := CopyRows(w.writer, rowGroup.Rows())
+	rows := rowGroup.Rows()
+	defer rows.Close()
+	n, err := CopyRows(w.writer, rows)
 	if err != nil {
 		return n, err
 	}


### PR DESCRIPTION
WriteRowGroup would previously not call Close on the Rows passed in to CopyRows. This could cause goroutine leaks when reading pages asynchronously.

cc @achille-roussel 