### PR TITLE
Row pooling

### DIFF
--- a/column_buffer.go
+++ b/column_buffer.go
@@ -520,7 +520,8 @@ func (col *repeatedColumnBuffer) Page() Page {
 
 			if numValues > 0 {
 				if numValues > cap(col.buffer) {
-					col.buffer = make([]Value, numValues)
+					rows.put(col.buffer)
+					col.buffer = rows.get(numValues)
 				} else {
 					col.buffer = col.buffer[:numValues]
 				}

--- a/column_buffer.go
+++ b/column_buffer.go
@@ -520,7 +520,7 @@ func (col *repeatedColumnBuffer) Page() Page {
 
 			if numValues > 0 {
 				if numValues > cap(col.buffer) {
-					rows.put(col.buffer)
+					(Row)(col.buffer).Repool()
 					col.buffer = rows.get(numValues)
 				} else {
 					col.buffer = col.buffer[:numValues]

--- a/convert.go
+++ b/convert.go
@@ -136,7 +136,7 @@ func (c *conversion) convertFuncOfLeaf(tgtIdx int16, node Node) (int16, convertF
 			}
 		}
 
-		tgt = append(tgt, value)
+		tgt = appendRow(tgt, value)
 		return tgt, nil
 	}
 }
@@ -195,14 +195,14 @@ func (c *conversion) Convert(target, source Row) (Row, error) {
 			value.kind = ^int8(typ.Kind())
 			value.columnIndex = ^targetIndex
 			buf.types[targetIndex] = typ
-			buf.columns[targetIndex] = append(buf.columns[targetIndex], value)
+			buf.columns[targetIndex] = appendRow(buf.columns[targetIndex], value)
 		}
 	}
 
 	// Fill empty columns
 	for i, values := range buf.columns {
 		if len(values) == 0 {
-			buf.columns[i] = append(buf.columns[i], Value{
+			buf.columns[i] = appendRow(buf.columns[i], Value{
 				kind:        ^int8(c.targetColumnTypes[i].Kind()),
 				columnIndex: ^int16(i),
 			})
@@ -223,7 +223,7 @@ func (c *conversion) Schema() *Schema {
 
 type identity struct{ schema *Schema }
 
-func (id identity) Convert(dst, src Row) (Row, error) { return append(dst, src...), nil }
+func (id identity) Convert(dst, src Row) (Row, error) { return appendRow(dst, src...), nil }
 func (id identity) Column(i int) int                  { return i }
 func (id identity) Schema() *Schema                   { return id.schema }
 
@@ -522,7 +522,7 @@ func (c *convertedRows) ReadRows(rows []Row) (int, error) {
 		if err != nil {
 			return i, err
 		}
-		rows[i] = append(row[:0], c.buf...)
+		rows[i] = appendRow(row[:0], c.buf...)
 	}
 
 	return n, err

--- a/dictionary.go
+++ b/dictionary.go
@@ -1462,7 +1462,7 @@ func (col *indexedColumnBuffer) ReadRowAt(row Row, index int64) (Row, error) {
 	default:
 		v := col.typ.dict.Index(col.values[index])
 		v.columnIndex = col.columnIndex
-		return append(row, v), nil
+		return appendRow(row, v), nil
 	}
 }
 

--- a/merge.go
+++ b/merge.go
@@ -110,7 +110,7 @@ func (r *mergedRowGroupRows) ReadRows(rows []Row) (n int, err error) {
 		}
 
 		if r.index >= r.seek {
-			rows[n] = append(rows[n][:0], r.values1...)
+			rows[n] = appendRow(rows[n][:0], r.values1...)
 			n++
 		}
 		r.index++
@@ -234,7 +234,7 @@ func (cur *bufferedRowGroupCursor) close() error {
 }
 
 func (cur *bufferedRowGroupCursor) readRow(row Row) (Row, error) {
-	return append(row, cur.rowbuf[0]...), nil
+	return appendRow(row, cur.rowbuf[0]...), nil
 }
 
 func (cur *bufferedRowGroupCursor) readNext() error {
@@ -247,13 +247,13 @@ func (cur *bufferedRowGroupCursor) readNext() error {
 	}
 	for _, v := range cur.rowbuf[0] {
 		columnIndex := v.Column()
-		cur.columns[columnIndex] = append(cur.columns[columnIndex], v)
+		cur.columns[columnIndex] = appendRow(cur.columns[columnIndex], v)
 	}
 	return nil
 }
 
 func (cur *bufferedRowGroupCursor) nextRowValuesOf(values []Value, columnIndex int16) []Value {
-	return append(values, cur.columns[columnIndex]...)
+	return appendRow(values, cur.columns[columnIndex]...)
 }
 
 /*

--- a/row.go
+++ b/row.go
@@ -529,7 +529,7 @@ func deconstructFuncOfLeaf(columnIndex int16, node Node) (int16, deconstructFunc
 		v.repetitionLevel = levels.repetitionLevel
 		v.definitionLevel = levels.definitionLevel
 		v.columnIndex = valueColumnIndex
-		return append(row, v)
+		return appendRow(row, v)
 	}
 }
 

--- a/row.go
+++ b/row.go
@@ -62,6 +62,9 @@ func (row Row) Equal(other Row) bool {
 
 // Repool readds the row to the internal pool.
 func (row Row) Repool() {
+	for i := range row {
+		row[i] = Value{}
+	}
 	rows.put(row)
 }
 

--- a/writer.go
+++ b/writer.go
@@ -695,7 +695,7 @@ func (w *writer) WriteRows(rows []Row) (int, error) {
 		for _, row := range rows[start:end] {
 			for _, value := range row {
 				columnIndex := value.Column()
-				w.values[columnIndex] = append(w.values[columnIndex], value)
+				w.values[columnIndex] = appendRow(w.values[columnIndex], value)
 			}
 		}
 


### PR DESCRIPTION
So I can't say I expect this PR to survive exactly as is, but we are seeing significant performance improvements with this diff and I would like to get some form of row pooling into parquet-go.

- Adds a rowPool
  - This is basically a copy of the buffer pool and generics would make it easy to combine the two. Once parquet-go requires go 1.18 I think we should combine these into `slicepool[T]`
- Adds pooling mechanisms for rows
  - append is used throughout the codebase but old rows are just thrown away. `appendRow` allows us to keep the old memory and reuse it.
  - `row.Repool` and `RowFromPool` these are the changes I dislike the most, but we need the application using parquet-go to have a way to take from the pool and return to it for maximum effectiveness.
- Replaces all (that I could find) appends on rows with `appendRow`