### PR TITLE
Fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,9 @@ mechanisms to read column values:
 
 ```go
 pages := column.Pages()
-defer checkErr(pages.Close())
+defer func() {
+    checkErr(pages.Close())
+}()
 
 for {
     p, err := pages.ReadPage()


### PR DESCRIPTION
The readme example, as written, will call `pages.Close()` before the loop.