### PR TITLE
Change the memory layout of parquet.Row

### DIFF
--- a/column_buffer.go
+++ b/column_buffer.go
@@ -705,6 +705,21 @@ func (col *repeatedColumnBuffer) ReadValuesAt(values []Value, offset int64) (int
 	panic("NOT IMPLEMENTED")
 }
 
+// repeatedRowLength gives the length of the repeated row starting at the
+// beginning of the repetitionLevels slice.
+func repeatedRowLength(repetitionLevels []byte) int {
+	// If a repetition level exists, at least one value is required to represent
+	// the column.
+	if len(repetitionLevels) > 0 {
+		// The subsequent levels will represent the start of a new record when
+		// they go back to zero.
+		if i := bytes.IndexByte(repetitionLevels[1:], 0); i >= 0 {
+			return i + 1
+		}
+	}
+	return len(repetitionLevels)
+}
+
 // =============================================================================
 // The types below are in-memory implementations of the ColumnBuffer interface
 // for each parquet type.

--- a/column_mapping.go
+++ b/column_mapping.go
@@ -52,6 +52,42 @@ func (group columnMappingGroup) lookup(path columnPath) leafColumn {
 	return leafColumn{columnIndex: -1}
 }
 
+func (group columnMappingGroup) lookupClosest(path columnPath) leafColumn {
+	for len(path) > 0 {
+		g, ok := group[path[0]].(columnMappingGroup)
+		if ok {
+			group, path = g, path[1:]
+		} else {
+			firstName := ""
+			firstLeaf := (*columnMappingLeaf)(nil)
+			for name, child := range group {
+				if leaf, ok := child.(*columnMappingLeaf); ok {
+					if firstLeaf == nil || name < firstName {
+						firstName, firstLeaf = name, leaf
+					}
+				}
+			}
+			if firstLeaf != nil {
+				return firstLeaf.column
+			}
+			break
+		}
+	}
+	return leafColumn{columnIndex: -1}
+}
+
+func (group columnMappingGroup) lookupClosestParent(path columnPath) columnPath {
+	for i := 0; i < len(path); i++ {
+		g, ok := group[path[i]].(columnMappingGroup)
+		if ok {
+			group = g
+		} else {
+			return path[:i]
+		}
+	}
+	return nil
+}
+
 type columnMappingLeaf struct {
 	column leafColumn
 }

--- a/column_mapping.go
+++ b/column_mapping.go
@@ -76,18 +76,6 @@ func (group columnMappingGroup) lookupClosest(path columnPath) leafColumn {
 	return leafColumn{columnIndex: -1}
 }
 
-func (group columnMappingGroup) lookupClosestParent(path columnPath) columnPath {
-	for i := 0; i < len(path); i++ {
-		g, ok := group[path[i]].(columnMappingGroup)
-		if ok {
-			group = g
-		} else {
-			return path[:i]
-		}
-	}
-	return nil
-}
-
 type columnMappingLeaf struct {
 	column leafColumn
 }

--- a/column_path.go
+++ b/column_path.go
@@ -100,7 +100,7 @@ func forEachLeafColumn(node Node, path columnPath, columnIndex, maxRepetitionLev
 
 func lookupColumnPath(node Node, path columnPath) Node {
 	for node != nil && len(path) > 0 {
-		node = childByName(node, path[0])
+		node = fieldByName(node, path[0])
 		path = path[1:]
 	}
 	return node

--- a/convert.go
+++ b/convert.go
@@ -41,7 +41,7 @@ func (e *ConvertError) Error() string {
 type Conversion interface {
 	// Applies the conversion logic on the src row, returning the result
 	// appended to dst.
-	Convert(dst, src Row) (Row, error)
+	Convert(rows []Row) (int, error)
 	// Converts the given column index in the target schema to the original
 	// column index in the source schema of the conversion.
 	Column(int) int
@@ -50,171 +50,167 @@ type Conversion interface {
 }
 
 type conversion struct {
-	targetColumnTypes   []Type
-	targetToSourceIndex []int16
-	sourceToTargetIndex []int16
-	convertFunc         convertFunc
-	schema              *Schema
-	buffers             sync.Pool
+	columns []conversionColumn
+	schema  *Schema
+	buffers sync.Pool
+	// This field is used to size the column buffers held in the sync.Pool since
+	// they are intended to the source rows being converted from.
+	numberOfSourceColumns int
 }
 
 type conversionBuffer struct {
-	types   []Type
 	columns [][]Value
+}
+
+type conversionColumn struct {
+	sourceIndex   int
+	convertValues conversionFunc
+}
+
+type conversionFunc func([]Value) error
+
+func convertToSelf(column []Value) error { return nil }
+
+//go:noinline
+func convertToType(targetType, sourceType Type) conversionFunc {
+	return func(column []Value) error {
+		for i, v := range column {
+			v, err := sourceType.ConvertValue(v, targetType)
+			if err != nil {
+				return err
+			}
+			column[i].ptr = v.ptr
+			column[i].u64 = v.u64
+			column[i].kind = v.kind
+		}
+		return nil
+	}
+}
+
+//go:noinline
+func convertToValue(value Value) conversionFunc {
+	return func(column []Value) error {
+		for i := range column {
+			column[i] = value
+		}
+		return nil
+	}
+}
+
+//go:noinline
+func convertToZero(kind Kind) conversionFunc {
+	return func(column []Value) error {
+		for i := range column {
+			column[i].ptr = nil
+			column[i].u64 = 0
+			column[i].kind = ^int8(kind)
+		}
+		return nil
+	}
+}
+
+//go:noinline
+func convertToLevels(repetitionLevels, definitionLevels []byte) conversionFunc {
+	return func(column []Value) error {
+		for i := range column {
+			r := column[i].repetitionLevel
+			d := column[i].definitionLevel
+			column[i].repetitionLevel = repetitionLevels[r]
+			column[i].definitionLevel = definitionLevels[d]
+		}
+		return nil
+	}
+}
+
+//go:noinline
+func multiConversionFunc(conversions []conversionFunc) conversionFunc {
+	switch len(conversions) {
+	case 0:
+		return convertToSelf
+	case 1:
+		return conversions[0]
+	default:
+		return func(column []Value) error {
+			for _, conv := range conversions {
+				if err := conv(column); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
 }
 
 func (c *conversion) getBuffer() *conversionBuffer {
 	b, _ := c.buffers.Get().(*conversionBuffer)
 	if b == nil {
-		n := len(c.targetColumnTypes)
-		columns, values, types := make([][]Value, n), make([]Value, n), make([]Type, n)
-		for i := range columns {
-			columns[i] = values[i : i : i+1]
+		b = &conversionBuffer{
+			columns: make([][]Value, c.numberOfSourceColumns),
 		}
-		b = &conversionBuffer{types: types, columns: columns}
+		values := make([]Value, c.numberOfSourceColumns)
+		for i := range b.columns {
+			b.columns[i] = values[i : i : i+1]
+		}
 	}
 	return b
 }
 
 func (c *conversion) putBuffer(b *conversionBuffer) {
-	for i, values := range b.columns {
-		clearValues(values)
-		b.columns[i] = values[:0]
-	}
 	c.buffers.Put(b)
 }
 
-// convertFunc takes a target and source row, then copies data
-// from the source to the target according to the heuristics determined
-// by the target schema given in makeConvertFunc
-type convertFunc func(Row, levels, *conversionBuffer) (Row, error)
+// Convert here satisfies the Conversion interface, and does the actual work
+// to convert between the source and target Rows.
+func (c *conversion) Convert(rows []Row) (int, error) {
+	source := c.getBuffer()
+	defer c.putBuffer(source)
 
-func (c *conversion) makeConvertFunc(node Node) (convert convertFunc) {
-	if !node.Leaf() {
-		_, convert = c.convertFuncOf(0, node)
-	}
-	return convert
-}
-
-func (c *conversion) convertFuncOf(tgtIdx int16, node Node) (int16, convertFunc) {
-	switch {
-	case node.Repeated():
-		return c.convertFuncOfRepeated(tgtIdx, node)
-	default:
-		return c.convertFuncOfRequired(tgtIdx, node)
-	}
-}
-
-func (c *conversion) convertFuncOfRequired(tgtIdx int16, node Node) (int16, convertFunc) {
-	switch {
-	case node.Leaf():
-		return c.convertFuncOfLeaf(tgtIdx, node)
-	default:
-		return c.convertFuncOfGroup(tgtIdx, node)
-	}
-}
-
-// convertFuncOfLeaf is the base case to our schema-tree traversal, doing the
-// actual copy of the value from the old Row (via conversionBuffer) to the new Row
-func (c *conversion) convertFuncOfLeaf(tgtIdx int16, node Node) (int16, convertFunc) {
-	return tgtIdx + 1, func(tgt Row, _ levels, src *conversionBuffer) (Row, error) {
-		value := Value{}
-		if tgtIdx >= 0 && len(src.columns[tgtIdx]) > 0 {
-			// Pop the top value and remove from the buffer.
-			value = src.columns[tgtIdx][0]
-			src.columns[tgtIdx] = src.columns[tgtIdx][1:]
+	for n, row := range rows {
+		for i, values := range source.columns {
+			source.columns[i] = values[:0]
 		}
-		value.kind = ^int8(c.targetColumnTypes[tgtIdx].Kind())
-		value.columnIndex = ^tgtIdx
+		row.Range(func(columnIndex int, columnValues []Value) bool {
+			source.columns[columnIndex] = append(source.columns[columnIndex], columnValues...)
+			return true
+		})
+		row = row[:0]
 
-		var err error
-		srcType := src.types[tgtIdx]
-		if srcType != nil {
-			value, err = node.Type().ConvertValue(value, srcType)
-			if err != nil {
-				return nil, err
+		for columnIndex, conv := range c.columns {
+			columnOffset := len(row)
+			if conv.sourceIndex < 0 {
+				// When there is no source column, we put a single value as
+				// placeholder in the column. This is a condition where the
+				// target contained a column which did not exist at had not
+				// other columns existing at that same level.
+				row = append(row, Value{})
+			} else {
+				// We must copy to the output row first and not mutate the
+				// source columns because multiple target columns may map to
+				// the same source column.
+				row = append(row, source.columns[conv.sourceIndex]...)
+			}
+			columnValues := row[columnOffset:]
+
+			if err := conv.convertValues(columnValues); err != nil {
+				return n, err
+			}
+
+			// Since the column index may have changed between the source and
+			// taget columns we ensure that the right value is always written
+			// to the output row.
+			for i := range columnValues {
+				columnValues[i].columnIndex = ^int16(columnIndex)
 			}
 		}
 
-		tgt = append(tgt, value)
-		return tgt, nil
-	}
-}
-
-func (c *conversion) convertFuncOfGroup(tgtIdx int16, node Node) (int16, convertFunc) {
-	fields := node.Fields()
-	funcs := make([]convertFunc, len(fields))
-
-	for i, field := range fields {
-		tgtIdx, funcs[i] = c.convertFuncOf(tgtIdx, field)
+		rows[n] = row
 	}
 
-	return tgtIdx, func(tgt Row, levels levels, src *conversionBuffer) (Row, error) {
-		var err error
-		for i, convFunc := range funcs {
-			if tgt, err = convFunc(tgt, levels, src); err != nil {
-				err = fmt.Errorf("%s → %w", fields[i].Name(), err)
-				break
-			}
-		}
-		return tgt, err
-	}
-}
-
-func (c *conversion) convertFuncOfRepeated(tgtIdx int16, node Node) (int16, convertFunc) {
-	nextIdx, convFunc := c.convertFuncOf(tgtIdx, Required(node))
-	return nextIdx, func(tgt Row, levels levels, src *conversionBuffer) (Row, error) {
-		var err error
-
-		levels.repetitionDepth++
-
-		for _, elem := range src.columns[tgtIdx] {
-			if elem.repetitionLevel != levels.repetitionLevel {
-				break
-			}
-			tgt, err = convFunc(tgt, levels, src)
-			levels.repetitionLevel = levels.repetitionDepth
-		}
-
-		return tgt, err
-	}
-}
-
-// Convert here satisfies the Conversion interface, and does the actual work to
-// convert between the source and target Rows.
-func (c *conversion) Convert(target, source Row) (Row, error) {
-	buf := c.getBuffer()
-	defer c.putBuffer(buf)
-
-	// Build conversion buffer
-	for _, value := range source {
-		sourceIndex := value.Column()
-		targetIndex := c.sourceToTargetIndex[sourceIndex]
-		if targetIndex >= 0 {
-			typ := c.targetColumnTypes[targetIndex]
-			value.kind = ^int8(typ.Kind())
-			value.columnIndex = ^targetIndex
-			buf.types[targetIndex] = typ
-			buf.columns[targetIndex] = append(buf.columns[targetIndex], value)
-		}
-	}
-
-	// Fill empty columns
-	for i, values := range buf.columns {
-		if len(values) == 0 {
-			buf.columns[i] = append(buf.columns[i], Value{
-				kind:        ^int8(c.targetColumnTypes[i].Kind()),
-				columnIndex: ^int16(i),
-			})
-		}
-	}
-
-	// Construct row from buffer
-	return c.convertFunc(target, levels{}, buf)
+	return len(rows), nil
 }
 
 func (c *conversion) Column(i int) int {
-	return int(c.targetToSourceIndex[i])
+	return c.columns[i].sourceIndex
 }
 
 func (c *conversion) Schema() *Schema {
@@ -223,9 +219,9 @@ func (c *conversion) Schema() *Schema {
 
 type identity struct{ schema *Schema }
 
-func (id identity) Convert(dst, src Row) (Row, error) { return append(dst, src...), nil }
-func (id identity) Column(i int) int                  { return i }
-func (id identity) Schema() *Schema                   { return id.schema }
+func (id identity) Convert(rows []Row) (int, error) { return len(rows), nil }
+func (id identity) Column(i int) int                { return i }
+func (id identity) Schema() *Schema                 { return id.schema }
 
 // Convert constructs a conversion function from one parquet schema to another.
 //
@@ -248,48 +244,95 @@ func Convert(to, from Node) (conv Conversion, err error) {
 
 	targetMapping, targetColumns := columnMappingOf(to)
 	sourceMapping, sourceColumns := columnMappingOf(from)
-
-	columnIndexBuffer := make([]int16, len(targetColumns)+len(sourceColumns))
-	targetColumnTypes := make([]Type, len(targetColumns))
-	targetToSourceIndex := columnIndexBuffer[:len(targetColumns)]
-	sourceToTargetIndex := columnIndexBuffer[len(targetColumns):]
+	columns := make([]conversionColumn, len(targetColumns))
 
 	for i, path := range targetColumns {
-		sourceColumn := sourceMapping.lookup(path)
 		targetColumn := targetMapping.lookup(path)
-		targetToSourceIndex[i] = sourceColumn.columnIndex
-		targetColumnTypes[i] = targetColumn.node.Type()
-	}
-
-	for i, path := range sourceColumns {
 		sourceColumn := sourceMapping.lookup(path)
-		targetColumn := targetMapping.lookup(path)
 
-		if targetColumn.node != nil {
-			sourceType := sourceColumn.node.Type()
+		conversions := []conversionFunc{}
+		if sourceColumn.node != nil {
 			targetType := targetColumn.node.Type()
-			if sourceType.Kind() != targetType.Kind() {
-				return nil, &ConvertError{Path: path, From: sourceColumn.node, To: targetColumn.node}
+			sourceType := sourceColumn.node.Type()
+			if !typesAreEqual(targetType, sourceType) {
+				conversions = append(conversions,
+					convertToType(targetType, sourceType),
+				)
 			}
 
-			sourceRepetition := fieldRepetitionTypeOf(sourceColumn.node)
-			targetRepetition := fieldRepetitionTypeOf(targetColumn.node)
-			if sourceRepetition != targetRepetition {
-				return nil, &ConvertError{Path: path, From: sourceColumn.node, To: targetColumn.node}
+			repetitionLevels := make([]byte, len(path)+1)
+			definitionLevels := make([]byte, len(path)+1)
+			targetRepetitionLevel := byte(0)
+			targetDefinitionLevel := byte(0)
+			sourceRepetitionLevel := byte(0)
+			sourceDefinitionLevel := byte(0)
+			targetNode := to
+			sourceNode := from
+
+			for j := 0; j < len(path); j++ {
+				targetNode = fieldByName(targetNode, path[j])
+				sourceNode = fieldByName(sourceNode, path[j])
+
+				targetRepetitionLevel, targetDefinitionLevel = applyFieldRepetitionType(
+					fieldRepetitionTypeOf(targetNode),
+					targetRepetitionLevel,
+					targetDefinitionLevel,
+				)
+				sourceRepetitionLevel, sourceDefinitionLevel = applyFieldRepetitionType(
+					fieldRepetitionTypeOf(sourceNode),
+					sourceRepetitionLevel,
+					sourceDefinitionLevel,
+				)
+
+				repetitionLevels[sourceRepetitionLevel] = targetRepetitionLevel
+				definitionLevels[sourceDefinitionLevel] = targetDefinitionLevel
+			}
+
+			repetitionLevels = repetitionLevels[:sourceRepetitionLevel+1]
+			definitionLevels = definitionLevels[:sourceDefinitionLevel+1]
+
+			if !isDirectLevelMapping(repetitionLevels) || !isDirectLevelMapping(definitionLevels) {
+				conversions = append(conversions,
+					convertToLevels(repetitionLevels, definitionLevels),
+				)
+			}
+
+		} else {
+			targetType := targetColumn.node.Type()
+			targetKind := targetType.Kind()
+			sourceColumn = sourceMapping.lookupClosest(path)
+			if sourceColumn.node != nil {
+				conversions = append(conversions,
+					convertToZero(targetKind),
+				)
+			} else {
+				conversions = append(conversions,
+					convertToValue(ZeroValue(targetKind)),
+				)
 			}
 		}
 
-		sourceToTargetIndex[i] = targetColumn.columnIndex
+		columns[i] = conversionColumn{
+			sourceIndex:   int(sourceColumn.columnIndex),
+			convertValues: multiConversionFunc(conversions),
+		}
 	}
 
 	c := &conversion{
-		targetColumnTypes:   targetColumnTypes,
-		targetToSourceIndex: targetToSourceIndex,
-		sourceToTargetIndex: sourceToTargetIndex,
-		schema:              schema,
+		columns:               columns,
+		schema:                schema,
+		numberOfSourceColumns: len(sourceColumns),
 	}
-	c.convertFunc = c.makeConvertFunc(schema)
 	return c, nil
+}
+
+func isDirectLevelMapping(levels []byte) bool {
+	for i, level := range levels {
+		if level != byte(i) {
+			return false
+		}
+	}
+	return true
 }
 
 // ConvertRowGroup constructs a wrapper of the given row group which applies
@@ -500,30 +543,18 @@ func ConvertRowReader(rows RowReader, conv Conversion) RowReaderWithSchema {
 type convertedRows struct {
 	io.Closer
 	rows RowReadSeeker
-	buf  Row
 	conv Conversion
 }
 
 func (c *convertedRows) ReadRows(rows []Row) (int, error) {
-	maxRowLen := 0
-	defer func() {
-		clearValues(c.buf[:maxRowLen])
-	}()
-
 	n, err := c.rows.ReadRows(rows)
-
-	for i, row := range rows[:n] {
-		var err error
-		c.buf, err = c.conv.Convert(c.buf[:0], row)
-		if len(c.buf) > maxRowLen {
-			maxRowLen = len(c.buf)
+	if n > 0 {
+		var convErr error
+		n, convErr = c.conv.Convert(rows[:n])
+		if convErr != nil {
+			err = convErr
 		}
-		if err != nil {
-			return i, err
-		}
-		rows[i] = append(row[:0], c.buf...)
 	}
-
 	return n, err
 }
 

--- a/convert_test.go
+++ b/convert_test.go
@@ -465,13 +465,6 @@ func TestConvert(t *testing.T) {
 			}
 			row = rowbuf[0]
 
-			// row.Range(func(i int, v []parquet.Value) bool {
-			// 	t.Logf("%d. %+v\n", i, v)
-			// 	return true
-			// })
-
-			//t.Logf("%+v\n", row)
-
 			value := reflect.New(reflect.TypeOf(test.to))
 			if err := to.Reconstruct(value.Interface(), row); err != nil {
 				t.Fatal(err)

--- a/convert_test.go
+++ b/convert_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/segmentio/parquet-go"
 )
 
+type AddressBook1 struct {
+	Owner             string   `parquet:"owner,zstd"`
+	OwnerPhoneNumbers []string `parquet:"ownerPhoneNumbers,gzip"`
+}
+
 type AddressBook2 struct {
 	Owner             string    `parquet:"owner,zstd"`
 	OwnerPhoneNumbers []string  `parquet:"ownerPhoneNumbers,gzip"`
@@ -49,6 +54,10 @@ type SimpleAddressBook2 struct {
 	Name    string
 	Contact SimpleContact
 	Extra   string
+}
+
+type ListOfIDs struct {
+	IDs []uint64
 }
 
 var conversionTests = [...]struct {
@@ -141,6 +150,49 @@ var conversionTests = [...]struct {
 	},
 
 	{
+		scenario: "extra required column from repeated",
+		from: struct{ ListOfIDs ListOfIDs }{
+			ListOfIDs: ListOfIDs{IDs: []uint64{0, 1, 2}},
+		},
+		to: struct {
+			MainID    uint64
+			ListOfIDs ListOfIDs
+		}{
+			ListOfIDs: ListOfIDs{IDs: []uint64{0, 1, 2}},
+		},
+	},
+
+	{
+		scenario: "extra fields in repeated group",
+		from: struct{ Books []AddressBook1 }{
+			Books: []AddressBook1{
+				{
+					Owner:             "me",
+					OwnerPhoneNumbers: []string{"123-456-7890", "321-654-0987"},
+				},
+				{
+					Owner:             "you",
+					OwnerPhoneNumbers: []string{"000-000-0000"},
+				},
+			},
+		},
+		to: struct{ Books []AddressBook2 }{
+			Books: []AddressBook2{
+				{
+					Owner:             "me",
+					OwnerPhoneNumbers: []string{"123-456-7890", "321-654-0987"},
+					Contacts:          []Contact{},
+				},
+				{
+					Owner:             "you",
+					OwnerPhoneNumbers: []string{"000-000-0000"},
+					Contacts:          []Contact{},
+				},
+			},
+		},
+	},
+
+	{
 		scenario: "extra column on complex struct",
 		from: AddressBook{
 			Owner:             "Julien Le Dem",
@@ -168,6 +220,126 @@ var conversionTests = [...]struct {
 				},
 			},
 		},
+	},
+
+	{
+		scenario: "required to optional leaf",
+		from:     struct{ Name string }{Name: "Luke"},
+		to:       struct{ Name *string }{Name: newString("Luke")},
+	},
+
+	{
+		scenario: "required to repeated leaf",
+		from:     struct{ Name string }{Name: "Luke"},
+		to:       struct{ Name []string }{Name: []string{"Luke"}},
+	},
+
+	{
+		scenario: "optional to required leaf",
+		from:     struct{ Name *string }{Name: newString("Luke")},
+		to:       struct{ Name string }{Name: "Luke"},
+	},
+
+	{
+		scenario: "optional to repeated leaf",
+		from:     struct{ Name *string }{Name: newString("Luke")},
+		to:       struct{ Name []string }{Name: []string{"Luke"}},
+	},
+
+	{
+		scenario: "optional to repeated leaf (null)",
+		from:     struct{ Name *string }{Name: nil},
+		to:       struct{ Name []string }{Name: []string{}},
+	},
+
+	{
+		scenario: "repeated to required leaf",
+		from:     struct{ Name []string }{Name: []string{"Luke", "Han", "Leia"}},
+		to:       struct{ Name string }{Name: "Luke"},
+	},
+
+	{
+		scenario: "repeated to optional leaf",
+		from:     struct{ Name []string }{Name: []string{"Luke", "Han", "Leia"}},
+		to:       struct{ Name *string }{Name: newString("Luke")},
+	},
+
+	{
+		scenario: "required to optional group",
+		from: struct{ Book AddressBook }{
+			Book: AddressBook{
+				Owner: "Julien Le Dem",
+				OwnerPhoneNumbers: []string{
+					"555 123 4567",
+					"555 666 1337",
+				},
+				Contacts: []Contact{
+					{
+						Name:        "Dmitriy Ryaboy",
+						PhoneNumber: "555 987 6543",
+					},
+					{
+						Name: "Chris Aniszczyk",
+					},
+				},
+			},
+		},
+		to: struct{ Book *AddressBook }{
+			Book: &AddressBook{
+				Owner: "Julien Le Dem",
+				OwnerPhoneNumbers: []string{
+					"555 123 4567",
+					"555 666 1337",
+				},
+				Contacts: []Contact{
+					{
+						Name:        "Dmitriy Ryaboy",
+						PhoneNumber: "555 987 6543",
+					},
+					{
+						Name: "Chris Aniszczyk",
+					},
+				},
+			},
+		},
+	},
+
+	{
+		scenario: "required to optional group (empty)",
+		from: struct{ Book AddressBook }{
+			Book: AddressBook{},
+		},
+		to: struct{ Book *AddressBook }{
+			Book: &AddressBook{
+				OwnerPhoneNumbers: []string{},
+				Contacts:          []Contact{},
+			},
+		},
+	},
+
+	{
+		scenario: "optional to required group (null)",
+		from: struct{ Book *AddressBook }{
+			Book: nil,
+		},
+		to: struct{ Book AddressBook }{
+			Book: AddressBook{
+				OwnerPhoneNumbers: []string{},
+				Contacts:          []Contact{},
+			},
+		},
+	},
+
+	{
+		scenario: "optional to repeated group (null)",
+		from:     struct{ Book *AddressBook }{Book: nil},
+		to:       struct{ Book []AddressBook }{Book: []AddressBook{}},
+	},
+
+	{
+		scenario: "optional to repeated optional group (null)",
+		from:     struct{ Book *AddressBook }{Book: nil},
+		to:       struct{ Book []*AddressBook }{Book: []*AddressBook{}},
 	},
 
 	{
@@ -282,18 +454,23 @@ func TestConvert(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			oldRow := from.Deconstruct(nil, test.from)
-			row, err := conv.Convert(nil, oldRow)
+			row := from.Deconstruct(nil, test.from)
+			rowbuf := []parquet.Row{row}
+			n, err := conv.Convert(rowbuf)
 			if err != nil {
 				t.Fatal(err)
 			}
+			if n != 1 {
+				t.Errorf("wrong number of rows got converted: want=1 got=%d", n)
+			}
+			row = rowbuf[0]
 
-			// Helpful debugging info
-			// newRow := to.Deconstruct(nil, test.to)
-			// fmt.Printf("conv: %+v\n", conv)
-			// fmt.Printf("old row: %+v\n", oldRow)
-			// fmt.Printf("new row (desired state): %+v\n", newRow)
-			// fmt.Printf("new row (converted from old): %+v\n", row)
+			// row.Range(func(i int, v []parquet.Value) bool {
+			// 	t.Logf("%d. %+v\n", i, v)
+			// 	return true
+			// })
+
+			//t.Logf("%+v\n", row)
 
 			value := reflect.New(reflect.TypeOf(test.to))
 			if err := to.Reconstruct(value.Interface(), row); err != nil {
@@ -302,7 +479,7 @@ func TestConvert(t *testing.T) {
 
 			value = value.Elem()
 			if !reflect.DeepEqual(value.Interface(), test.to) {
-				t.Errorf("converted value mismatch:\nwant = %+v\ngot  = %+v", test.to, value.Interface())
+				t.Errorf("converted value mismatch:\nwant = %#v\ngot  = %#v", test.to, value.Interface())
 			}
 		})
 	}

--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package parquet
 
 import (
 	"errors"
+	"fmt"
 )
 
 var (
@@ -74,4 +75,8 @@ func (e errno) check() {
 	default:
 		panic("BUG: unknown error code")
 	}
+}
+
+func errRowIndexOutOfBounds(rowIndex, rowCount int64) error {
+	return fmt.Errorf("row index out of bounds: %d/%d", rowIndex, rowCount)
 }

--- a/errors.go
+++ b/errors.go
@@ -54,10 +54,6 @@ var (
 	// ErrTooManyRowGroups is returned when attempting to generate a parquet
 	// file with more than MaxRowGroups row groups.
 	ErrTooManyRowGroups = errors.New("the limit of 32767 row groups has been reached")
-
-	// ErrShortBuffer is returned when an output buffer is not large enough to
-	// hold the number of values to be written to it.
-	ErrShortBuffer = errors.New("short buffer")
 )
 
 type errno int

--- a/page_test.go
+++ b/page_test.go
@@ -486,7 +486,7 @@ func TestRepeatedPageTrailingNulls(t *testing.T) {
 	defer reader.Close()
 
 	n, err := reader.ReadRows(rows)
-	if err != io.EOF {
+	if err != nil && err != io.EOF {
 		t.Fatal("reading rows:", err)
 	}
 

--- a/row.go
+++ b/row.go
@@ -1,7 +1,6 @@
 package parquet
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -9,17 +8,55 @@ import (
 )
 
 const (
-	defaultRowBufferSize = 20
+	defaultRowBufferSize = 42
 )
 
 // Row represents a parquet row as a slice of values.
 //
 // Each value should embed a column index, repetition level, and definition
 // level allowing the program to determine how to reconstruct the original
-// object from the row. Repeated values share the same column index, their
-// relative position of repeated values is represented by their relative
-// position in the row.
+// object from the row.
 type Row []Value
+
+// MakeRow constructs a Row from a list of column values.
+//
+// The function panics if the column indexes of values in each column do not
+// match their position in the argument list.
+func MakeRow(columns ...[]Value) Row { return AppendRow(nil, columns...) }
+
+// AppendRow appends to row the given list of column values.
+//
+// AppendRow can be used to construct a Row value from columns, while retaining
+// the underlying memory buffer to avoid reallocation; for example:
+//
+// The function panics if the column indexes of values in each column do not
+// match their position in the argument list.
+func AppendRow(row Row, columns ...[]Value) Row {
+	numValues := 0
+
+	for expectedColumnIndex, column := range columns {
+		numValues += len(column)
+
+		for _, value := range column {
+			if value.columnIndex != ^int16(expectedColumnIndex) {
+				panic(fmt.Sprintf("value of column %d has column index %d", expectedColumnIndex, value.Column()))
+			}
+		}
+	}
+
+	if capacity := cap(row) - len(row); capacity < numValues {
+		row = append(make(Row, 0, len(row)+numValues), row...)
+	}
+
+	return appendRow(row, columns)
+}
+
+func appendRow(row Row, columns [][]Value) Row {
+	for _, column := range columns {
+		row = append(row, column...)
+	}
+	return row
+}
 
 // Clone creates a copy of the row which shares no pointers.
 //
@@ -56,8 +93,24 @@ func (row Row) Equal(other Row) bool {
 	return true
 }
 
-func (row Row) startsWith(columnIndex int16) bool {
-	return len(row) > 0 && row[0].Column() == int(columnIndex)
+// Range calls f for each column of row.
+func (row Row) Range(f func(columnIndex int, columnValues []Value) bool) {
+	columnIndex := 0
+
+	for i := 0; i < len(row); {
+		j := i + 1
+
+		for j < len(row) && row[j].columnIndex == ^int16(columnIndex) {
+			j++
+		}
+
+		if !f(columnIndex, row[i:j:j]) {
+			break
+		}
+
+		columnIndex++
+		i = j
+	}
 }
 
 // RowSeeker is an interface implemented by readers of parquet rows which can be
@@ -329,80 +382,6 @@ func targetSchemaOf(w RowWriter) *Schema {
 	return nil
 }
 
-func errRowIndexOutOfBounds(rowIndex, rowCount int64) error {
-	return fmt.Errorf("row index out of bounds: %d/%d", rowIndex, rowCount)
-}
-
-func hasRepeatedRowValues(values []Value) bool {
-	for _, v := range values {
-		if v.repetitionLevel != 0 {
-			return true
-		}
-	}
-	return false
-}
-
-// repeatedRowLength gives the length of the repeated row starting at the
-// beginning of the repetitionLevels slice.
-func repeatedRowLength(repetitionLevels []byte) int {
-	// If a repetition level exists, at least one value is required to represent
-	// the column.
-	if len(repetitionLevels) > 0 {
-		// The subsequent levels will represent the start of a new record when
-		// they go back to zero.
-		if i := bytes.IndexByte(repetitionLevels[1:], 0); i >= 0 {
-			return i + 1
-		}
-	}
-	return len(repetitionLevels)
-}
-
-func countRowsOf(values []Value) (numRows int) {
-	if !hasRepeatedRowValues(values) {
-		return len(values) // Faster path when there are no repeated values.
-	}
-	if len(values) > 0 {
-		// The values may have not been at the start of a repeated row,
-		// it could be the continuation of a repeated row. Skip until we
-		// find the beginning of a row before starting to count how many
-		// rows there are.
-		if values[0].repetitionLevel != 0 {
-			_, values = splitRowValues(values)
-		}
-		for len(values) > 0 {
-			numRows++
-			_, values = splitRowValues(values)
-		}
-	}
-	return numRows
-}
-
-func limitRowValues(values []Value, rowCount int) []Value {
-	if !hasRepeatedRowValues(values) {
-		if len(values) > rowCount {
-			values = values[:rowCount]
-		}
-	} else {
-		var row Row
-		var limit int
-		for len(values) > 0 {
-			row, values = splitRowValues(values)
-			limit += len(row)
-		}
-		values = values[:limit]
-	}
-	return values
-}
-
-func splitRowValues(values []Value) (head, tail []Value) {
-	for i, v := range values {
-		if v.repetitionLevel == 0 {
-			return values[:i+1], values[i+1:]
-		}
-	}
-	return values, nil
-}
-
 // =============================================================================
 // Functions returning closures are marked with "go:noinline" below to prevent
 // losing naming information of the closure in stack traces.
@@ -424,7 +403,7 @@ type levels struct {
 // the current column onto, and returns the row minus the deserialied value(s)
 // It recurses until it hits a leaf node, then deserializes that value
 // individually as the base case.
-type deconstructFunc func(Row, levels, reflect.Value) Row
+type deconstructFunc func([][]Value, levels, reflect.Value)
 
 func deconstructFuncOf(columnIndex int16, node Node) (int16, deconstructFunc) {
 	switch {
@@ -444,7 +423,7 @@ func deconstructFuncOf(columnIndex int16, node Node) (int16, deconstructFunc) {
 //go:noinline
 func deconstructFuncOfOptional(columnIndex int16, node Node) (int16, deconstructFunc) {
 	columnIndex, deconstruct := deconstructFuncOf(columnIndex, Required(node))
-	return columnIndex, func(row Row, levels levels, value reflect.Value) Row {
+	return columnIndex, func(columns [][]Value, levels levels, value reflect.Value) {
 		if value.IsValid() {
 			if value.IsZero() {
 				value = reflect.Value{}
@@ -455,27 +434,26 @@ func deconstructFuncOfOptional(columnIndex int16, node Node) (int16, deconstruct
 				levels.definitionLevel++
 			}
 		}
-		return deconstruct(row, levels, value)
+		deconstruct(columns, levels, value)
 	}
 }
 
 //go:noinline
 func deconstructFuncOfRepeated(columnIndex int16, node Node) (int16, deconstructFunc) {
 	columnIndex, deconstruct := deconstructFuncOf(columnIndex, Required(node))
-	return columnIndex, func(row Row, levels levels, value reflect.Value) Row {
+	return columnIndex, func(columns [][]Value, levels levels, value reflect.Value) {
 		if !value.IsValid() || value.Len() == 0 {
-			return deconstruct(row, levels, reflect.Value{})
+			deconstruct(columns, levels, reflect.Value{})
+			return
 		}
 
 		levels.repetitionDepth++
 		levels.definitionLevel++
 
 		for i, n := 0, value.Len(); i < n; i++ {
-			row = deconstruct(row, levels, value.Index(i))
+			deconstruct(columns, levels, value.Index(i))
 			levels.repetitionLevel = levels.repetitionDepth
 		}
-
-		return row
 	}
 }
 
@@ -499,10 +477,11 @@ func deconstructFuncOfMap(columnIndex int16, node Node) (int16, deconstructFunc)
 	keyValueElem := keyValueType.Elem()
 	keyType := keyValueElem.Field(0).Type
 	valueType := keyValueElem.Field(1).Type
-	columnIndex, deconstruct := deconstructFuncOf(columnIndex, schemaOf(keyValueElem))
-	return columnIndex, func(row Row, levels levels, mapValue reflect.Value) Row {
+	nextColumnIndex, deconstruct := deconstructFuncOf(columnIndex, schemaOf(keyValueElem))
+	return nextColumnIndex, func(columns [][]Value, levels levels, mapValue reflect.Value) {
 		if !mapValue.IsValid() || mapValue.Len() == 0 {
-			return deconstruct(row, levels, reflect.Value{})
+			deconstruct(columns, levels, reflect.Value{})
+			return
 		}
 
 		levels.repetitionDepth++
@@ -515,11 +494,9 @@ func deconstructFuncOfMap(columnIndex int16, node Node) (int16, deconstructFunc)
 		for _, key := range mapValue.MapKeys() {
 			k.Set(key.Convert(keyType))
 			v.Set(mapValue.MapIndex(key).Convert(valueType))
-			row = deconstruct(row, levels, elem)
+			deconstruct(columns, levels, elem)
 			levels.repetitionLevel = levels.repetitionDepth
 		}
-
-		return row
 	}
 }
 
@@ -530,17 +507,16 @@ func deconstructFuncOfGroup(columnIndex int16, node Node) (int16, deconstructFun
 	for i, field := range fields {
 		columnIndex, funcs[i] = deconstructFuncOf(columnIndex, field)
 	}
-	return columnIndex, func(row Row, levels levels, value reflect.Value) Row {
+	return columnIndex, func(columns [][]Value, levels levels, value reflect.Value) {
 		if value.IsValid() {
 			for i, f := range funcs {
-				row = f(row, levels, fields[i].Value(value))
+				f(columns, levels, fields[i].Value(value))
 			}
 		} else {
 			for _, f := range funcs {
-				row = f(row, levels, value)
+				f(columns, levels, value)
 			}
 		}
-		return row
 	}
 }
 
@@ -553,7 +529,7 @@ func deconstructFuncOfLeaf(columnIndex int16, node Node) (int16, deconstructFunc
 	kind := typ.Kind()
 	lt := typ.LogicalType()
 	valueColumnIndex := ^columnIndex
-	return columnIndex + 1, func(row Row, levels levels, value reflect.Value) Row {
+	return columnIndex + 1, func(columns [][]Value, levels levels, value reflect.Value) {
 		v := Value{}
 
 		if value.IsValid() {
@@ -563,11 +539,12 @@ func deconstructFuncOfLeaf(columnIndex int16, node Node) (int16, deconstructFunc
 		v.repetitionLevel = levels.repetitionLevel
 		v.definitionLevel = levels.definitionLevel
 		v.columnIndex = valueColumnIndex
-		return append(row, v)
+
+		columns[columnIndex] = append(columns[columnIndex], v)
 	}
 }
 
-type reconstructFunc func(reflect.Value, levels, Row) (Row, error)
+type reconstructFunc func(reflect.Value, levels, [][]Value) error
 
 func reconstructFuncOf(columnIndex int16, node Node) (int16, reconstructFunc) {
 	switch {
@@ -591,26 +568,13 @@ func reconstructFuncOfOptional(columnIndex int16, node Node) (int16, reconstruct
 	// returned closure (see levels.definitionLevel++), but we don't actually do
 	// deserialization here, that happens in the leaf function, hence this line.
 	nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, Required(node))
-	rowLength := nextColumnIndex - columnIndex
 
-	return nextColumnIndex, func(value reflect.Value, levels levels, row Row) (Row, error) {
-		if !row.startsWith(columnIndex) {
-			return row, fmt.Errorf("row is missing optional column %d", columnIndex)
-		}
-		if len(row) < int(rowLength) {
-			return row, fmt.Errorf(
-				"expected optional column %d to have at least %d values but got %d",
-				columnIndex,
-				rowLength,
-				len(row),
-			)
-		}
-
+	return nextColumnIndex, func(value reflect.Value, levels levels, columns [][]Value) error {
 		levels.definitionLevel++
 
-		if row[0].definitionLevel < levels.definitionLevel {
+		if columns[0][0].definitionLevel < levels.definitionLevel {
 			value.Set(reflect.Zero(value.Type()))
-			return row[rowLength:], nil
+			return nil
 		}
 
 		if value.Kind() == reflect.Ptr {
@@ -620,80 +584,77 @@ func reconstructFuncOfOptional(columnIndex int16, node Node) (int16, reconstruct
 			value = value.Elem()
 		}
 
-		return reconstruct(value, levels, row)
+		return reconstruct(value, levels, columns)
 	}
+}
+
+func setMakeSlice(v reflect.Value, n int) (s reflect.Value) {
+	if t := v.Type(); t.Kind() == reflect.Interface {
+		t = reflect.TypeOf(([]interface{})(nil))
+		s = reflect.MakeSlice(t, n, n)
+	} else {
+		s = reflect.MakeSlice(t, n, n)
+	}
+	v.Set(s)
+	return s
 }
 
 //go:noinline
 func reconstructFuncOfRepeated(columnIndex int16, node Node) (int16, reconstructFunc) {
 	nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, Required(node))
-	rowLength := nextColumnIndex - columnIndex
-	return nextColumnIndex, func(value reflect.Value, lvls levels, row Row) (Row, error) {
-		t := value.Type()
-		s := value
-		c := 0
+	return nextColumnIndex, func(value reflect.Value, levels levels, columns [][]Value) error {
+		levels.repetitionDepth++
+		levels.definitionLevel++
+
+		if columns[0][0].definitionLevel < levels.definitionLevel {
+			setMakeSlice(value, 0)
+			return nil
+		}
+
+		values := make([][]Value, len(columns))
+		column := columns[0]
 		n := 0
-		const defaultCapacity = 10
 
-		defer func() {
-			value.Set(s.Slice(0, n))
-		}()
-
-		if t.Kind() == reflect.Interface {
-			var v []interface{}
-			c = defaultCapacity
-			t = reflect.TypeOf(v)
-			s = reflect.MakeSlice(t, c, c)
-		} else if c = s.Cap(); c > 0 {
-			s = s.Slice(0, c)
-		} else {
-			c = defaultCapacity
-			s = reflect.MakeSlice(t, c, c)
+		for i, column := range columns {
+			values[i] = column[0:0:len(column)]
 		}
 
-		return reconstructRepeated(columnIndex, rowLength, lvls, row, func(levels levels, row Row) (Row, error) {
-			if n == c {
-				c *= 2
-				newSlice := reflect.MakeSlice(t, c, c)
-				reflect.Copy(newSlice, s)
-				s = newSlice
-			}
-			row, err := reconstruct(s.Index(n), levels, row)
+		for i := 0; i < len(column); {
+			i++
 			n++
-			return row, err
-		})
-	}
-}
 
-func reconstructRepeated(columnIndex, rowLength int16, levels levels, row Row, do func(levels, Row) (Row, error)) (Row, error) {
-	if !row.startsWith(columnIndex) {
-		return row, fmt.Errorf("row is missing repeated column %d: %+v", columnIndex, row)
-	}
-	if len(row) < int(rowLength) {
-		return row, fmt.Errorf(
-			"expected repeated column %d to have at least %d values but got %d",
-			columnIndex,
-			rowLength,
-			len(row),
-		)
-	}
-
-	levels.repetitionDepth++
-	levels.definitionLevel++
-
-	if row[0].definitionLevel < levels.definitionLevel {
-		return row[rowLength:], nil
-	}
-
-	var err error
-	for row.startsWith(columnIndex) && row[0].repetitionLevel == levels.repetitionLevel {
-		// TODO: check specific error here.
-		if row, err = do(levels, row); err != nil {
-			break
+			for i < len(column) && column[i].repetitionLevel > levels.repetitionDepth {
+				i++
+			}
 		}
-		levels.repetitionLevel = levels.repetitionDepth
+
+		value = setMakeSlice(value, n)
+
+		for i := 0; i < n; i++ {
+			for j, column := range values {
+				column = column[:cap(column)]
+				k := 1
+
+				for k < len(column) && column[k].repetitionLevel > levels.repetitionDepth {
+					k++
+				}
+
+				values[j] = column[:k]
+			}
+
+			if err := reconstruct(value.Index(i), levels, values); err != nil {
+				return err
+			}
+
+			for j, column := range values {
+				values[j] = column[len(column):len(column):cap(column)]
+			}
+
+			levels.repetitionLevel = levels.repetitionDepth
+		}
+
+		return nil
 	}
-	return row, err
 }
 
 func reconstructFuncOfRequired(columnIndex int16, node Node) (int16, reconstructFunc) {
@@ -716,25 +677,66 @@ func reconstructFuncOfMap(columnIndex int16, node Node) (int16, reconstructFunc)
 	keyValueElem := keyValueType.Elem()
 	keyValueZero := reflect.Zero(keyValueElem)
 	nextColumnIndex, reconstruct := reconstructFuncOf(columnIndex, schemaOf(keyValueElem))
-	rowLength := nextColumnIndex - columnIndex
-	return nextColumnIndex, func(mapValue reflect.Value, lvls levels, row Row) (Row, error) {
-		t := mapValue.Type()
+	return nextColumnIndex, func(value reflect.Value, levels levels, columns [][]Value) error {
+		levels.repetitionDepth++
+		levels.definitionLevel++
+
+		if columns[0][0].definitionLevel < levels.definitionLevel {
+			value.Set(reflect.MakeMap(value.Type()))
+			return nil
+		}
+
+		values := make([][]Value, len(columns))
+		column := columns[0]
+		t := value.Type()
 		k := t.Key()
 		v := t.Elem()
+		n := 0
 
-		if mapValue.IsNil() {
-			mapValue.Set(reflect.MakeMap(t))
+		for i, column := range columns {
+			values[i] = column[0:0:len(column)]
+		}
+
+		for i := 0; i < len(column); {
+			i++
+			n++
+
+			for i < len(column) && column[i].repetitionLevel > levels.repetitionDepth {
+				i++
+			}
+		}
+
+		if value.IsNil() {
+			value.Set(reflect.MakeMapWithSize(t, n))
 		}
 
 		elem := reflect.New(keyValueElem).Elem()
-		return reconstructRepeated(columnIndex, rowLength, lvls, row, func(levels levels, row Row) (Row, error) {
-			row, err := reconstruct(elem, levels, row)
-			if err == nil {
-				mapValue.SetMapIndex(elem.Field(0).Convert(k), elem.Field(1).Convert(v))
-				elem.Set(keyValueZero)
+		for i := 0; i < n; i++ {
+			for j, column := range values {
+				column = column[:cap(column)]
+				k := 1
+
+				for k < len(column) && column[k].repetitionLevel > levels.repetitionDepth {
+					k++
+				}
+
+				values[j] = column[:k]
 			}
-			return row, err
-		})
+
+			if err := reconstruct(elem, levels, values); err != nil {
+				return err
+			}
+
+			for j, column := range values {
+				values[j] = column[len(column):len(column):cap(column)]
+			}
+
+			value.SetMapIndex(elem.Field(0).Convert(k), elem.Field(1).Convert(v))
+			elem.Set(keyValueZero)
+			levels.repetitionLevel = levels.repetitionDepth
+		}
+
+		return nil
 	}
 }
 
@@ -742,16 +744,15 @@ func reconstructFuncOfMap(columnIndex int16, node Node) (int16, reconstructFunc)
 func reconstructFuncOfGroup(columnIndex int16, node Node) (int16, reconstructFunc) {
 	fields := node.Fields()
 	funcs := make([]reconstructFunc, len(fields))
-	columnIndexes := make([]int16, len(fields))
+	columnOffsets := make([]int16, len(fields))
+	firstColumnIndex := columnIndex
 
 	for i, field := range fields {
 		columnIndex, funcs[i] = reconstructFuncOf(columnIndex, field)
-		columnIndexes[i] = columnIndex
+		columnOffsets[i] = columnIndex - firstColumnIndex
 	}
 
-	return columnIndex, func(value reflect.Value, levels levels, row Row) (Row, error) {
-		var err error
-
+	return columnIndex, func(value reflect.Value, levels levels, columns [][]Value) error {
 		if value.Kind() == reflect.Interface {
 			value.Set(reflect.MakeMap(reflect.TypeOf((map[string]interface{})(nil))))
 			value = value.Elem()
@@ -767,37 +768,44 @@ func reconstructFuncOfGroup(columnIndex int16, node Node) (int16, reconstructFun
 				value.Set(reflect.MakeMap(value.Type()))
 			}
 
+			off := int16(0)
+
 			for i, f := range funcs {
 				name.SetString(fields[i].Name())
-				if row, err = f(elem, levels, row); err != nil {
-					err = fmt.Errorf("%s → %w", name, err)
-					break
+				end := columnOffsets[i]
+				err := f(elem, levels, columns[off:end:end])
+				if err != nil {
+					return fmt.Errorf("%s → %w", name, err)
 				}
+				off = end
 				value.SetMapIndex(name, elem)
 				elem.Set(zero)
 			}
 		} else {
+			off := int16(0)
+
 			for i, f := range funcs {
-				if row, err = f(fields[i].Value(value), levels, row); err != nil {
-					err = fmt.Errorf("%s → %w", fields[i].Name(), err)
-					break
+				end := columnOffsets[i]
+				err := f(fields[i].Value(value), levels, columns[off:end:end])
+				if err != nil {
+					return fmt.Errorf("%s → %w", fields[i].Name(), err)
 				}
+				off = end
 			}
 		}
 
-		return row, err
+		return nil
 	}
 }
 
 //go:noinline
 func reconstructFuncOfLeaf(columnIndex int16, node Node) (int16, reconstructFunc) {
 	typ := node.Type()
-	return columnIndex + 1, func(value reflect.Value, _ levels, row Row) (Row, error) {
-		if !row.startsWith(columnIndex) {
-			return row, fmt.Errorf("no values found in parquet row for column %d", columnIndex)
+	return columnIndex + 1, func(value reflect.Value, _ levels, columns [][]Value) error {
+		column := columns[0]
+		if len(column) == 0 {
+			return fmt.Errorf("no values found in parquet row for column %d", columnIndex)
 		}
-
-		err := typ.AssignValue(value, row[0])
-		return row[1:], err
+		return typ.AssignValue(value, column[0])
 	}
 }

--- a/row.go
+++ b/row.go
@@ -588,13 +588,12 @@ func reconstructFuncOfOptional(columnIndex int16, node Node) (int16, reconstruct
 	}
 }
 
-func setMakeSlice(v reflect.Value, n int) (s reflect.Value) {
-	if t := v.Type(); t.Kind() == reflect.Interface {
+func setMakeSlice(v reflect.Value, n int) reflect.Value {
+	t := v.Type()
+	if t.Kind() == reflect.Interface {
 		t = reflect.TypeOf(([]interface{})(nil))
-		s = reflect.MakeSlice(t, n, n)
-	} else {
-		s = reflect.MakeSlice(t, n, n)
 	}
+	s := reflect.MakeSlice(t, n, n)
 	v.Set(s)
 	return s
 }

--- a/row_group.go
+++ b/row_group.go
@@ -423,7 +423,6 @@ func (r *rowGroupRows) ReadRows(rows []Row) (int, error) {
 		return 0, io.EOF
 	}
 
-	//n, err := r.Schema().readRows(r, rows[:numRows], 0)
 	n, err := r.readRows(rows[:numRows])
 
 	for i := range r.columns {
@@ -477,7 +476,6 @@ func (r *rowGroupRows) readRows(rows []Row) (int, error) {
 				skip = 0
 			}
 		}
-		//fmt.Printf("> %+v\n", rows[i])
 	}
 	return len(rows), nil
 }

--- a/schema.go
+++ b/schema.go
@@ -24,7 +24,6 @@ type Schema struct {
 	root        Node
 	deconstruct deconstructFunc
 	reconstruct reconstructFunc
-	readRows    readRowsFunc
 	mapping     columnMapping
 	columns     [][]string
 }
@@ -129,7 +128,6 @@ func NewSchema(name string, root Node) *Schema {
 		root:        root,
 		deconstruct: makeDeconstructFunc(root),
 		reconstruct: makeReconstructFunc(root),
-		readRows:    makeReadRowsFunc(root),
 		mapping:     mapping,
 		columns:     columns,
 	}
@@ -160,11 +158,6 @@ func makeReconstructFunc(node Node) (reconstruct reconstructFunc) {
 		_, reconstruct = reconstructFuncOf(0, node)
 	}
 	return reconstruct
-}
-
-func makeReadRowsFunc(node Node) readRowsFunc {
-	_, readRows := readRowsFuncOf(node, 0, 0)
-	return readRows
 }
 
 // ConfigureRowGroup satisfies the RowGroupOption interface, allowing Schema
@@ -221,18 +214,26 @@ func (s *Schema) GoType() reflect.Type { return s.root.GoType() }
 // The method panics is the structure of the go value does not match the
 // parquet schema.
 func (s *Schema) Deconstruct(row Row, value interface{}) Row {
-	v := reflect.ValueOf(value)
-	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
-		if v.IsNil() {
-			v = reflect.Value{}
+	columns := make([][]Value, len(s.columns))
+	values := make([]Value, len(s.columns))
+
+	for i := range columns {
+		columns[i] = values[i : i : i+1]
+	}
+
+	s.deconstructValueToColumns(columns, reflect.ValueOf(value))
+	return appendRow(row, columns)
+}
+
+func (s *Schema) deconstructValueToColumns(columns [][]Value, value reflect.Value) {
+	for value.Kind() == reflect.Ptr || value.Kind() == reflect.Interface {
+		if value.IsNil() {
+			value = reflect.Value{}
 			break
 		}
-		v = v.Elem()
+		value = value.Elem()
 	}
-	if s.deconstruct != nil {
-		row = s.deconstruct(row, levels{}, v)
-	}
-	return row
+	s.deconstruct(columns, levels{}, value)
 }
 
 // Reconstruct reconstructs a Go value from a row.
@@ -259,21 +260,16 @@ func (s *Schema) Reconstruct(value interface{}, row Row) error {
 		}
 		v = v.Elem()
 	}
-	var err error
 
-	if s.reconstruct != nil {
-		row, err = s.reconstruct(v, levels{}, row)
-		if len(row) > 0 && err == nil {
-			err = fmt.Errorf(
-				"%d values remain unused after reconstructing go value of type %s from parquet row",
-				len(row),
-				v.Type(),
-			)
+	columns := make([][]Value, len(s.columns))
+	row.Range(func(columnIndex int, columnValues []Value) bool {
+		if columnIndex < len(columns) {
+			columns[columnIndex] = columnValues
 		}
-	} else {
-		panic(fmt.Sprintf("Reconstruct called when undefined on schema: %v", s))
-	}
-	return err
+		return true
+	})
+
+	return s.reconstruct(v, levels{}, columns)
 }
 
 // Lookup returns the leaf column at the given path.

--- a/transform.go
+++ b/transform.go
@@ -3,100 +3,50 @@ package parquet
 // TransformRowReader constructs a RowReader which applies the given transform
 // to each row rad from reader.
 //
-// The transformation function writes the transformed src row to dst, returning
-// the number of rows it has written. It is possible for a single row to be
-// transformed to zero or more rows; transforming to zero rows is similar to
-// applying a filter since the row will be skipped. If the dst buffer is not
-// large enough to contain the transformation, the function must return the
-// sentinel error parquet.ErrShortBuffer.
-func TransformRowReader(reader RowReader, transform func(dst []Row, src Row) (int, error)) RowReader {
+// The transformation function appends the transformed src row to dst, returning
+// dst and any error that occured during the transformation. If dst is returned
+// unchanged, the row is skipped.
+func TransformRowReader(reader RowReader, transform func(dst, src Row) (Row, error)) RowReader {
 	return &transformRowReader{reader: reader, transform: transform}
 }
 
 type transformRowReader struct {
 	reader    RowReader
-	transform func([]Row, Row) (int, error)
-	input     transformRowBuffer
-	output    transformRowBuffer
+	transform func(Row, Row) (Row, error)
+	rows      []Row
+	offset    int
+	length    int
 }
 
 func (t *transformRowReader) ReadRows(rows []Row) (n int, err error) {
-	if t.input.cap() == 0 {
-		t.input.init(len(rows))
+	if len(t.rows) == 0 {
+		t.rows = makeRows(len(rows))
 	}
 
-	// Ensure that the transform function will always be called with empty rows,
-	// whether we are writing directly to the rows buffer or using the local
-	// output buffer.
-	for i, row := range rows {
-		rows[i] = row[:0]
-	}
-
-readRows:
 	for {
-		if t.output.len() > 0 {
-			for _, row := range t.output.rows() {
-				rows[n] = append(rows[n], row...)
-				n++
-				t.output.discard()
-			}
-		}
-
-		for {
-			if n == len(rows) {
-				return n, nil
-			}
-
-			if t.input.len() == 0 {
-				break
-			}
-
-			tn, err := t.transform(rows[n:], t.input.rows()[0])
-			switch err {
-			case nil:
-				// The transform may have produced zero rows but that's OK.
-				// Transforms can be used as a filtering mechanism as well even
-				// if it is not their primary intent.
-				n += tn
-				t.input.discard()
-
-			case ErrShortBuffer:
-				if n > 0 {
-					// There is no more space in the rows slice to transform the
-					// next row but we already have results in the output so we
-					// can simply return these rows and let the caller invoke us
-					// again.
-					return n, nil
-				}
-				for {
-					// The rows slice is too small to contain a single row
-					// transformation, we need to use the intermediary output
-					// buffer to temporarily hold the results before we move
-					// forward.
-					if t.output.cap() == 0 {
-						t.output.init(2 * (len(rows) - n))
-					} else {
-						t.output.init(2 * t.output.cap())
-					}
-					tn, err := t.transform(t.output.buffer, t.input.rows()[0])
-					if err == nil {
-						t.output.reset(tn)
-						continue readRows
-					} else if err != ErrShortBuffer {
-						return n, err
-					}
-				}
-
-			default:
+		for n < len(rows) && t.offset < t.length {
+			dst := rows[n][:0]
+			src := t.rows[t.offset]
+			rows[n], err = t.transform(dst, src)
+			if err != nil {
 				return n, err
 			}
+			clearValues(src)
+			t.rows[t.offset] = src[:0]
+			t.offset++
+			n++
 		}
 
-		rn, err := t.reader.ReadRows(t.input.buffer)
-		if err != nil && rn == 0 {
+		if n == len(rows) {
+			return n, nil
+		}
+
+		r, err := t.reader.ReadRows(t.rows)
+		if r == 0 && err != nil {
 			return n, err
 		}
-		t.input.reset(rn)
+		t.offset = 0
+		t.length = r
 	}
 }
 
@@ -142,21 +92,17 @@ func (b *transformRowBuffer) len() int {
 // TransformRowWriter constructs a RowWriter which applies the given transform
 // to each row writter to writer.
 //
-// The transformation function writes the transformed src row to dst, returning
-// the number of rows it has written. It is possible for a single row to be
-// transformed to zero or more rows; transforming to zero rows is similar to
-// applying a filter since the row will be skipped. If the dst buffer is not
-// large enough to contain the transformation, the function must return the
-// sentinel error parquet.ErrShortBuffer.
-func TransformRowWriter(writer RowWriter, transform func(dst []Row, src Row) (int, error)) RowWriter {
+// The transformation function appends the transformed src row to dst, returning
+// dst and any error that occured during the transformation. If dst is returned
+// unchanged, the row is skipped.
+func TransformRowWriter(writer RowWriter, transform func(dst, src Row) (Row, error)) RowWriter {
 	return &transformRowWriter{writer: writer, transform: transform}
 }
 
 type transformRowWriter struct {
 	writer    RowWriter
-	transform func([]Row, Row) (int, error)
+	transform func(Row, Row) (Row, error)
 	rows      []Row
-	length    int
 }
 
 func (t *transformRowWriter) WriteRows(rows []Row) (n int, err error) {
@@ -165,38 +111,33 @@ func (t *transformRowWriter) WriteRows(rows []Row) (n int, err error) {
 	}
 
 	for n < len(rows) {
-		tn, err := t.transform(t.rows[t.length:], rows[n])
-
-		switch err {
-		case nil:
-			if t.length += tn; t.length == len(t.rows) {
-				err = t.flushRows()
-			}
-
-		case ErrShortBuffer:
-			if t.length == 0 {
-				t.rows = makeRows(2 * len(t.rows))
-				continue
-			} else {
-				err = t.flushRows()
-			}
+		numRows := len(rows) - n
+		if numRows > len(t.rows) {
+			numRows = len(t.rows)
 		}
-
-		if err != nil {
+		if err := t.writeRows(rows[n : n+numRows]); err != nil {
 			return n, err
 		}
-
-		n++
+		n += numRows
 	}
 
-	return n, t.flushRows()
+	return n, nil
 }
 
-func (t *transformRowWriter) flushRows() error {
-	defer func() {
-		clearRows(t.rows[:t.length])
-		t.length = 0
-	}()
-	_, err := t.writer.WriteRows(t.rows[:t.length])
+func (t *transformRowWriter) writeRows(rows []Row) (err error) {
+	numRows := 0
+	defer func() { clearRows(t.rows[:numRows]) }()
+
+	for _, row := range rows {
+		t.rows[numRows], err = t.transform(t.rows[numRows][:0], row)
+		if err != nil {
+			return err
+		}
+		if len(t.rows[numRows]) != 0 {
+			numRows++
+		}
+	}
+
+	_, err = t.writer.WriteRows(t.rows[:numRows])
 	return err
 }

--- a/transform_test.go
+++ b/transform_test.go
@@ -16,23 +16,18 @@ func TestTransformRowReader(t *testing.T) {
 	}
 
 	want := []parquet.Row{
-		{parquet.Int64Value(0)},
-		{parquet.Int64Value(0)},
-		{parquet.Int64Value(1)},
-		{parquet.Int64Value(2)},
-		{parquet.Int64Value(2)},
-		{parquet.Int64Value(4)},
-		{parquet.Int64Value(3)},
-		{parquet.Int64Value(6)},
-		{parquet.Int64Value(4)},
-		{parquet.Int64Value(8)},
+		{parquet.Int64Value(0), parquet.Int64Value(0).Level(0, 0, 1)},
+		{parquet.Int64Value(1), parquet.Int64Value(2).Level(0, 0, 1)},
+		{parquet.Int64Value(2), parquet.Int64Value(4).Level(0, 0, 1)},
+		{parquet.Int64Value(3), parquet.Int64Value(6).Level(0, 0, 1)},
+		{parquet.Int64Value(4), parquet.Int64Value(8).Level(0, 0, 1)},
 	}
 
 	reader := parquet.TransformRowReader(&bufferedRows{rows: rows},
-		func(dst []parquet.Row, src parquet.Row) (int, error) {
-			dst[0] = append(dst[0], src[0])
-			dst[1] = append(dst[1], parquet.Int64Value(2*src[0].Int64()))
-			return 2, nil
+		func(dst, src parquet.Row) (parquet.Row, error) {
+			dst = append(dst, src[0])
+			dst = append(dst, parquet.Int64Value(2*src[0].Int64()).Level(0, 0, 1))
+			return dst, nil
 		},
 	)
 
@@ -61,13 +56,11 @@ func TestTransformRowWriter(t *testing.T) {
 
 	buffer := &bufferedRows{}
 	writer := parquet.TransformRowWriter(buffer,
-		func(dst []parquet.Row, src parquet.Row) (int, error) {
-			if (src[0].Int64() % 2) == 0 {
-				return 0, nil
-			} else {
-				dst[0] = append(dst[0], src[0])
-				return 1, nil
+		func(dst, src parquet.Row) (parquet.Row, error) {
+			if (src[0].Int64() % 2) != 0 {
+				dst = append(dst, src[0])
 			}
+			return dst, nil
 		},
 	)
 

--- a/value.go
+++ b/value.go
@@ -214,6 +214,9 @@ func ValueOf(v interface{}) Value {
 	return makeValue(k, nil, reflect.ValueOf(v))
 }
 
+// ZeroValue constructs a zero value of the given kind.
+func ZeroValue(kind Kind) Value { return makeValueKind(kind) }
+
 // BooleanValue constructs a BOOLEAN parquet value from the bool passed as
 // argument.
 func BooleanValue(value bool) Value { return makeValueBoolean(value) }
@@ -331,6 +334,10 @@ func makeValue(k Kind, lt *format.LogicalType, v reflect.Value) Value {
 	}
 
 	panic("cannot create parquet value of type " + k.String() + " from go value of type " + v.Type().String())
+}
+
+func makeValueKind(kind Kind) Value {
+	return Value{kind: ^int8(kind)}
 }
 
 func makeValueBoolean(value bool) Value {

--- a/writer.go
+++ b/writer.go
@@ -705,10 +705,10 @@ func (w *writer) WriteRows(rows []Row) (int, error) {
 		// using the writer after getting an error, but maybe we could ensure that
 		// we are preventing further use as well?
 		for _, row := range rows[start:end] {
-			for _, value := range row {
-				columnIndex := value.Column()
-				w.values[columnIndex] = append(w.values[columnIndex], value)
-			}
+			row.Range(func(columnIndex int, columnValues []Value) bool {
+				w.values[columnIndex] = append(w.values[columnIndex], columnValues...)
+				return true
+			})
 		}
 
 		for i, values := range w.values {


### PR DESCRIPTION
This PR modifies the in-memory layout of `parquet.Row` to keep values of columns contiguous in memory.

Prior to this change, it was difficult to work with repeated groups materialized in `parquet.Row` because the values of their inner columns would be interleaved. For a parquet schema such as:
```
message {
  repeated group Object {
    string key;
    string value;
  }
}
```
parquet-go would lay out values in `parquet.Row` like this:
```
[key-0, value-0, key-1, value-1, key-2, value-2]
```
With this PR, the layout will be:
```
[key-0, key-1, key-2, value-0, value-1, value-2]
```
All values of each column are now contiguous in the slice, which brings a few improvements:

- the column indexes of values in a `parquet.Row` are now guaranteed to be incrementing, whereas they could have 
- it is now possible to write methods like `parquet.Row.Range` without requiring copying the row to intermediary buffers
- it is possible to deconstruct a `parquet.Row` into a `[][]parquet.Value` and back into a `parquet.Row` without using a schema (and applying a recursive algorithm to walk through the nodes)
- many of the internal algorithms are simplified thanks to this new memory layout (a lot of recursive code has been removed, comparison functions are simpler to write, etc...)
- new conversion rules can be implemented which were difficult to do before

This PR also supersedes and simplifies the transform APIs introduced in https://github.com/segmentio/parquet-go/pull/452