### PR TITLE
Add File Schema Option

### DIFF
--- a/config.go
+++ b/config.go
@@ -93,6 +93,7 @@ type FileConfig struct {
 	SkipBloomFilters bool
 	ReadBufferSize   int
 	ReadMode         ReadMode
+	Schema           *Schema
 }
 
 // DefaultFileConfig returns a new FileConfig value initialized with the
@@ -103,6 +104,7 @@ func DefaultFileConfig() *FileConfig {
 		SkipBloomFilters: DefaultSkipBloomFilters,
 		ReadBufferSize:   defaultReadBufferSize,
 		ReadMode:         DefaultReadMode,
+		Schema:           nil,
 	}
 }
 
@@ -131,6 +133,7 @@ func (c *FileConfig) ConfigureFile(config *FileConfig) {
 		SkipBloomFilters: c.SkipBloomFilters,
 		ReadBufferSize:   coalesceInt(c.ReadBufferSize, config.ReadBufferSize),
 		ReadMode:         ReadMode(coalesceInt(int(c.ReadMode), int(config.ReadMode))),
+		Schema:           coalesceSchema(c.Schema, config.Schema),
 	}
 }
 
@@ -467,6 +470,15 @@ func FileReadMode(mode ReadMode) FileOption {
 // Defaults to 4096.
 func ReadBufferSize(size int) FileOption {
 	return fileOption(func(config *FileConfig) { config.ReadBufferSize = size })
+}
+
+// FileSchema is used to pass a known schema in while opening a Parquet file.
+// This optimization is only useful if your application is currently opening
+// an extremely large number of parquet files with the same, known schema.
+//
+// Defaults to nil.
+func FileSchema(schema *Schema) FileOption {
+	return fileOption(func(config *FileConfig) { config.Schema = schema })
 }
 
 // PageBufferSize configures the size of column page buffers on parquet writers.

--- a/file.go
+++ b/file.go
@@ -91,7 +91,12 @@ func OpenFile(r io.ReaderAt, size int64, options ...FileOption) (*File, error) {
 		return nil, fmt.Errorf("opening columns of parquet file: %w", err)
 	}
 
-	schema := NewSchema(f.root.Name(), f.root)
+	var schema *Schema
+	if c.Schema != nil {
+		schema = c.Schema
+	} else {
+		schema = NewSchema(f.root.Name(), f.root)
+	}
 	columns := make([]*Column, 0, numLeafColumnsOf(f.root))
 	f.schema = schema
 	f.root.forEachLeaf(func(c *Column) { columns = append(columns, c) })


### PR DESCRIPTION
In Tempo we have a process that can hold 1000s of Parquet files open in a highly multitenant environment. In this case we can have millions of schema objects on the heap.

This PR adds the ability to pass a schema into the `File` object on `OpenFile`. By passing in a known, shared schema we can drastically reduce the total number of objects on the heap.

![image](https://user-images.githubusercontent.com/2272392/207134047-c049020a-316d-4a1a-bc5f-22782c005d3c.png)
