### PR TITLE
when available, make use of io.ReaderFrom in parquet writer

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -1404,6 +1404,13 @@ func (w *offsetTrackingWriter) WriteString(s string) (int, error) {
 	return n, err
 }
 
+func (w *offsetTrackingWriter) ReadFrom(r io.Reader) (int64, error) {
+	// io.Copy will make use of io.ReaderFrom if w.writer implements it.
+	n, err := io.Copy(w.writer, r)
+	w.offset += n
+	return n, err
+}
+
 var (
 	_ RowWriterWithSchema = (*Writer)(nil)
 	_ RowReaderFrom       = (*Writer)(nil)
@@ -1413,4 +1420,7 @@ var (
 	_ ValueWriter = (*writer)(nil)
 
 	_ ValueWriter = (*writerColumn)(nil)
+
+	_ io.ReaderFrom   = (*offsetTrackingWriter)(nil)
+	_ io.StringWriter = (*offsetTrackingWriter)(nil)
 )


### PR DESCRIPTION
This optimization avoids the allocation of a 32KiB buffer for each call to `io.Copy`.