### PR TITLE
Fix MultiRowGroup pageReadMode

### DIFF
--- a/multi_row_group.go
+++ b/multi_row_group.go
@@ -6,7 +6,7 @@ import (
 
 // MultiRowGroup wraps multiple row groups to appear as if it was a single
 // RowGroup. RowGroups must have the same schema or it will error.
-func MultiRowGroup(rowGroups ...RowGroup) RowGroup {
+func MultiRowGroup(pageReadMode ReadMode, rowGroups ...RowGroup) RowGroup {
 	if len(rowGroups) == 0 {
 		return &emptyRowGroup{}
 	}
@@ -22,7 +22,9 @@ func MultiRowGroup(rowGroups ...RowGroup) RowGroup {
 	rowGroupsCopy := make([]RowGroup, len(rowGroups))
 	copy(rowGroupsCopy, rowGroups)
 
-	c := new(multiRowGroup)
+	c := &multiRowGroup{
+		pageReadMode: pageReadMode,
+	}
 	c.init(schema, rowGroupsCopy)
 	return c
 }
@@ -84,9 +86,10 @@ func compatibleSchemaOf(rowGroups []RowGroup) (*Schema, error) {
 }
 
 type multiRowGroup struct {
-	schema    *Schema
-	rowGroups []RowGroup
-	columns   []ColumnChunk
+	schema       *Schema
+	rowGroups    []RowGroup
+	columns      []ColumnChunk
+	pageReadMode ReadMode
 }
 
 func (c *multiRowGroup) NumRows() (numRows int64) {
@@ -102,7 +105,7 @@ func (c *multiRowGroup) SortingColumns() []SortingColumn { return nil }
 
 func (c *multiRowGroup) Schema() *Schema { return c.schema }
 
-func (c *multiRowGroup) Rows() Rows { return &rowGroupRows{rowGroup: c} }
+func (c *multiRowGroup) Rows() Rows { return newRowGroupRows(c, c.pageReadMode) }
 
 type multiColumnChunk struct {
 	rowGroup *multiRowGroup

--- a/multi_row_group.go
+++ b/multi_row_group.go
@@ -6,7 +6,11 @@ import (
 
 // MultiRowGroup wraps multiple row groups to appear as if it was a single
 // RowGroup. RowGroups must have the same schema or it will error.
-func MultiRowGroup(pageReadMode ReadMode, rowGroups ...RowGroup) RowGroup {
+func MultiRowGroup(rowGroups ...RowGroup) RowGroup {
+	return newMultiRowGroup(ReadModeSync, rowGroups...)
+}
+
+func newMultiRowGroup(pageReadMode ReadMode, rowGroups ...RowGroup) RowGroup {
 	if len(rowGroups) == 0 {
 		return &emptyRowGroup{}
 	}

--- a/reader.go
+++ b/reader.go
@@ -108,7 +108,7 @@ func fileRowGroupOf(f *File) RowGroup {
 	default:
 		// TODO: should we attempt to merge the row groups via MergeRowGroups
 		// to preserve the global order of sorting columns within the file?
-		return MultiRowGroup(f.config.ReadMode, rowGroups...)
+		return newMultiRowGroup(f.config.ReadMode, rowGroups...)
 	}
 }
 

--- a/reader.go
+++ b/reader.go
@@ -108,7 +108,7 @@ func fileRowGroupOf(f *File) RowGroup {
 	default:
 		// TODO: should we attempt to merge the row groups via MergeRowGroups
 		// to preserve the global order of sorting columns within the file?
-		return MultiRowGroup(rowGroups...)
+		return MultiRowGroup(f.config.ReadMode, rowGroups...)
 	}
 }
 


### PR DESCRIPTION
Previously we added the ability to configure a "sync" or "async" page read mode:

https://github.com/segmentio/parquet-go/pull/417

This PR corrects an issue where this configuration option is not respected when using MultiRowGroup.