### PR TITLE
parquet: add option to reset SortingWriter with a different sortRowCount

### DIFF
--- a/sorting.go
+++ b/sorting.go
@@ -133,9 +133,14 @@ func (w *SortingWriter[T]) Flush() error {
 }
 
 func (w *SortingWriter[T]) Reset(output io.Writer) {
+	w.ResetWithSortRowCount(output, w.maxRows)
+}
+
+func (w *SortingWriter[T]) ResetWithSortRowCount(output io.Writer, sortRowCount int64) {
 	w.output.Reset(output)
 	w.rowbuf.Reset()
 	w.resetSortingBuffer()
+	w.maxRows = sortRowCount
 }
 
 func (w *SortingWriter[T]) resetSortingBuffer() {


### PR DESCRIPTION
The motivation for this is to allow callers that know how many rows they want to write to be able to reuse pooled SortingWriters.

This is a proposal for now, I have yet to integrate this into our (Polar Signals') usage, but I foresee us needing something like this. Happy to discuss.