### PR TITLE
Reuse thrift pageheader buffers

### DIFF
--- a/file.go
+++ b/file.go
@@ -525,8 +525,10 @@ func (f *filePages) ReadPage() (Page, error) {
 		return nil, io.EOF
 	}
 
+	header := getPageHeader()
+	defer putPageHeader(header)
+
 	for {
-		header := new(format.PageHeader)
 		if err := f.decoder.Decode(header); err != nil {
 			return nil, err
 		}
@@ -588,7 +590,9 @@ func (f *filePages) readDictionary() error {
 	defer putBufioReader(rbuf, pool)
 
 	decoder := thrift.NewDecoder(f.protocol.NewReader(rbuf))
-	header := new(format.PageHeader)
+
+	header := getPageHeader()
+	defer putPageHeader(header)
 
 	if err := decoder.Decode(header); err != nil {
 		return err
@@ -759,4 +763,18 @@ func getBufioReaderPool(size int) *sync.Pool {
 	pool := &sync.Pool{}
 	bufioReaderPool[size] = pool
 	return pool
+}
+
+var pageHeaderPool = &sync.Pool{}
+
+func getPageHeader() *format.PageHeader {
+	h, _ := pageHeaderPool.Get().(*format.PageHeader)
+	if h != nil {
+		return h
+	}
+	return new(format.PageHeader)
+}
+
+func putPageHeader(h *format.PageHeader) {
+	pageHeaderPool.Put(h)
 }

--- a/file.go
+++ b/file.go
@@ -776,5 +776,8 @@ func getPageHeader() *format.PageHeader {
 }
 
 func putPageHeader(h *format.PageHeader) {
-	pageHeaderPool.Put(h)
+	if h != nil {
+		h.CRC = 0
+		pageHeaderPool.Put(h)
+	}
 }


### PR DESCRIPTION
This PR pools the `format.PageHeader` buffers used when decoding pages.  For applications that scan many pages this offers significant memory improvements.  Not sure which is the most appropriate benchmark in this repo to highlight the difference, but for some Tempo search patterns it's very significant.

Example:
```
name                                     old time/op    new time/op    delta
BackendBlockTraceQL/mixedNameNoMatch-12     2.46s ± 2%     2.17s ± 1%  -11.84%  (p=0.000 n=9+8)

name                                     old speed      new speed      delta
BackendBlockTraceQL/mixedNameNoMatch-12  10.6MB/s ± 2%  12.0MB/s ± 1%  +13.43%  (p=0.000 n=9+8)

name                                     old alloc/op   new alloc/op   delta
BackendBlockTraceQL/mixedNameNoMatch-12     422MB ± 3%      25MB ± 8%  -94.01%  (p=0.000 n=10+8)

name                                     old allocs/op  new allocs/op  delta
BackendBlockTraceQL/mixedNameNoMatch-12     6.29M ± 0%     0.00M ± 1%  -99.97%  (p=0.000 n=9+8)
```