### PR TITLE
Fix issue #493 - generic Read index out of range across page boundaries

### DIFF
--- a/parquet_go18_test.go
+++ b/parquet_go18_test.go
@@ -422,7 +422,7 @@ func TestReadFileGenericMultipleRowGroupsMultiplePages(t *testing.T) {
 	}
 	path := tmp.Name()
 	defer os.Remove(path)
-	t.Log("TestReadFileMultiplePages:", path)
+	t.Log("file:", path)
 
 	// The page buffer size ensures we get multiple pages out of this example.
 	w := parquet.NewGenericWriter[MyRow](tmp, parquet.PageBufferSize(maxPageBytes))
@@ -458,8 +458,9 @@ func TestReadFileGenericMultipleRowGroupsMultiplePages(t *testing.T) {
 	if err != nil {
 		t.Fatal("parquet.ReadFile: ", err)
 	}
+
 	if len(rows) != numRows {
-		t.Fatal("parquet.ReadFile returned", len(rows), "rows instead of", numRows)
+		t.Fatalf("not enough values were read: want=%d got=%d", len(rows), numRows)
 	}
 	for i, row := range rows {
 		id := [16]byte{15: byte(i)}
@@ -467,7 +468,7 @@ func TestReadFileGenericMultipleRowGroupsMultiplePages(t *testing.T) {
 		index := int64(i)
 
 		if row.ID != id || row.File != file || row.Index != index {
-			t.Error("rows mismatch at ", i, "got ", row)
+			t.Fatalf("rows mismatch at index: %d got: %+v", i, row)
 		}
 	}
 }

--- a/reader_go18.go
+++ b/reader_go18.go
@@ -142,27 +142,33 @@ func (r *GenericReader[T]) Close() error {
 // The method returns the number of rows read and io.EOF when no more rows
 // can be read from the reader.
 func (r *GenericReader[T]) readRows(rows []T) (int, error) {
-	if cap(r.base.rowbuf) < len(rows) {
-		r.base.rowbuf = make([]Row, len(rows))
+	nRequest := len(rows)
+	if cap(r.base.rowbuf) < nRequest {
+		r.base.rowbuf = make([]Row, nRequest)
 	} else {
-		r.base.rowbuf = r.base.rowbuf[:len(rows)]
+		r.base.rowbuf = r.base.rowbuf[:nRequest]
 	}
 
 	var n, nTotal int
 	var err error
 	for {
-		n, err = r.base.ReadRows(r.base.rowbuf)
+		// ReadRows reads the minimum remaining rows in a column page across all columns
+		// of the underlying reader, unless the length of the slice passed to it is smaller.
+		// In that case, ReadRows will read the number of rows equal to the length of the
+		// given slice argument. We limit that length to never be more than requested
+		// because sequential reads can cross page boundaries.
+		n, err = r.base.ReadRows(r.base.rowbuf[:nRequest-nTotal])
 		if n > 0 {
 			schema := r.base.Schema()
 
 			for i, row := range r.base.rowbuf[:n] {
-				if err := schema.Reconstruct(&rows[nTotal+i], row); err != nil {
-					return i, err
+				if err2 := schema.Reconstruct(&rows[nTotal+i], row); err2 != nil {
+					return nTotal + i, err2
 				}
 			}
 		}
 		nTotal += n
-		if n == 0 || nTotal == len(rows) {
+		if n == 0 || nTotal == nRequest || err != nil {
 			break
 		}
 	}

--- a/reader_go18_test.go
+++ b/reader_go18_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"os"
 	"reflect"
 	"testing"
 
@@ -125,6 +126,101 @@ func TestIssue400(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expect[0], values[0]) {
 		t.Errorf("want %q got %q", values[0], expect[0])
+	}
+}
+
+func TestReadMinPageSize(t *testing.T) {
+	// NOTE: min page size is 307 for MyRow schema
+	t.Run("test read less than min page size", func(t *testing.T) { testReadMinPageSize(128, t) })
+	t.Run("test read equal to min page size", func(t *testing.T) { testReadMinPageSize(307, t) })
+	t.Run("test read more than min page size", func(t *testing.T) { testReadMinPageSize(384, t) })
+	// NOTE: num rows is 20,000
+	t.Run("test read equal to num rows", func(t *testing.T) { testReadMinPageSize(20_000, t) })
+	t.Run("test read more than num rows", func(t *testing.T) { testReadMinPageSize(25_000, t) })
+}
+
+func testReadMinPageSize(readSize int, t *testing.T) {
+	type MyRow struct {
+		ID    [16]byte `parquet:"id,delta,uuid"`
+		File  string   `parquet:"file,dict,zstd"`
+		Index int64    `parquet:"index,delta,zstd"`
+	}
+
+	numRows := 20_000
+	maxPageBytes := 5000
+
+	tmp, err := os.CreateTemp("/tmp", "*.parquet")
+	if err != nil {
+		t.Fatal("os.CreateTemp: ", err)
+	}
+	path := tmp.Name()
+	defer os.Remove(path)
+	t.Log("file:", path)
+
+	// The page buffer size ensures we get multiple pages out of this example.
+	w := parquet.NewGenericWriter[MyRow](tmp, parquet.PageBufferSize(maxPageBytes))
+	// Need to write 1 row at a time here as writing many at once disregards PageBufferSize option.
+	for i := 0; i < numRows; i++ {
+		row := MyRow{
+			ID:    [16]byte{15: byte(i)},
+			File:  "hi" + fmt.Sprint(i),
+			Index: int64(i),
+		}
+		_, err := w.Write([]MyRow{row})
+		if err != nil {
+			t.Fatal("w.Write: ", err)
+		}
+		// Flush writes rows as row group. 4 total (20k/5k) in this file.
+		if (i+1)%maxPageBytes == 0 {
+			err = w.Flush()
+			if err != nil {
+				t.Fatal("w.Flush: ", err)
+			}
+		}
+	}
+	err = w.Close()
+	if err != nil {
+		t.Fatal("w.Close: ", err)
+	}
+	err = tmp.Close()
+	if err != nil {
+		t.Fatal("tmp.Close: ", err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal("os.Open", err)
+	}
+	reader := parquet.NewGenericReader[MyRow](file)
+	read := int64(0)
+	nRows := reader.NumRows()
+	rows := make([]MyRow, 0, nRows)
+	buf := make([]MyRow, readSize) // NOTE: min page size is 307 for MyRow schema
+
+	for read < nRows {
+		num, err := reader.Read(buf)
+		read += int64(num)
+		if err != nil && !errors.Is(err, io.EOF) {
+			t.Fatal("Read:", err)
+		}
+		rows = append(rows, buf...)
+	}
+
+	if err := reader.Close(); err != nil {
+		t.Fatal("Close", err)
+	}
+
+	if len(rows) < numRows {
+		t.Fatalf("not enough values were read: want=%d got=%d", len(rows), numRows)
+	}
+	for i, row := range rows[:numRows] {
+		id := [16]byte{15: byte(i)}
+		file := "hi" + fmt.Sprint(i)
+		index := int64(i)
+
+		if row.ID != id || row.File != file || row.Index != index {
+			t.Fatalf("rows mismatch at index: %d got: %+v", i, row)
+		}
 	}
 }
 

--- a/reader_go18_test.go
+++ b/reader_go18_test.go
@@ -83,7 +83,7 @@ func testGenericReaderRows[Row any](rows []Row) error {
 		return fmt.Errorf("not enough values were read: want=%d got=%d", len(rows), n)
 	}
 	if !reflect.DeepEqual(rows, result) {
-		return fmt.Errorf("rows mismatch:\nwant: %+v\ngot:  %+v", rows, result)
+		return fmt.Errorf("rows mismatch:\nwant: %+v\ngot: %+v", rows, result)
 	}
 	return nil
 }


### PR DESCRIPTION
PR #489 didn't handle the case where a `ReadRows` happened at the end of the page, but didn't fill up the given slice. The following `ReadRows` call would read from the beginning of a new page up to the original given slice size, which would overflow the remaining space available in the slice.

This fixes #493. I added test coverage around these various conditions.

Also fix the unhappy path when errors can occur to correctly report the number of rows read.