### PR TITLE
Fix #501

### DIFF
--- a/column_buffer.go
+++ b/column_buffer.go
@@ -848,7 +848,7 @@ func (col *booleanColumnBuffer) writeValues(rows sparse.Array, _ columnLevels) {
 			}
 			x := uint(col.numValues) / 8
 			y := uint(col.numValues) % 8
-			col.bits[x] |= (b << y) | (col.bits[x] & ^(0xFF << y))
+			col.bits[x] = (b << y) | (col.bits[x] & ^(0xFF << y))
 			col.numValues += int32(i)
 		}
 

--- a/column_buffer_test.go
+++ b/column_buffer_test.go
@@ -1,6 +1,8 @@
 package parquet
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestBroadcastValueInt32(t *testing.T) {
 	buf := make([]int32, 123)
@@ -38,4 +40,38 @@ func BenchmarkBroadcastRangeInt32(b *testing.B) {
 		broadcastRangeInt32(buf, 0)
 	}
 	b.SetBytes(4 * int64(len(buf)))
+}
+
+// https://github.com/segmentio/parquet-go/issues/501
+func TestIssue501(t *testing.T) {
+	col := newBooleanColumnBuffer(BooleanType, 0, 2055208)
+
+	// write all trues and then flush the buffer
+	_, err := col.WriteBooleans([]bool{true, true, true, true, true, true, true, true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	col.Reset()
+
+	// write a single false, we are trying to trip a certain line of code in WriteBooleans
+	_, err = col.WriteBooleans([]bool{false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// now write 7 booleans at once, this will cause WriteBooleans to attempt its "alignment" logic
+	_, err = col.WriteBooleans([]bool{false, false, false, false, false, false, false})
+	if err != nil {
+		panic(err)
+	}
+
+	for i := 0; i < 8; i++ {
+		read := make([]Value, 1)
+		_, err = col.ReadValuesAt(read, int64(i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if read[0].Boolean() {
+			t.Fatalf("expected false at index %d", i)
+		}
+	}
 }


### PR DESCRIPTION
This PR aims to fix #501. I'm not 100% confident in this fix, but based on my understanding of the code in question this is valid.

The issue appears to be this line here:

https://github.com/segmentio/parquet-go/blob/main/column_buffer.go#L851

The code builds a bitmask and assigns the value to `b` to set relevant booleans in the current bit. Then it `|=`s the bitmask against the current bit. Interestingly using `|=` guarantees that this path can never drop an existing bit flag to 0 and whatever happened to be leftover in the buffer persists.

Currently running the Tempo test suite against this.