### PR TITLE
add support for parsing schema of converted type decimals

### DIFF
--- a/column.go
+++ b/column.go
@@ -451,8 +451,10 @@ func schemaElementTypeOf(s *format.SchemaElement) Type {
 							panic("DECIMAL using FIXED_LEN_BYTE_ARRAY must specify a length")
 						}
 						typ = FixedLenByteArrayType(int(*s.TypeLength))
+					case ByteArray:
+						typ = ByteArrayType
 					default:
-						panic("DECIMAL must be of type INT32, INT64, or FIXED_LEN_BYTE_ARRAY but got " + kind.String())
+						panic("DECIMAL must be of type INT32, INT64, BYTE_ARRAY or FIXED_LEN_BYTE_ARRAY but got " + kind.String())
 					}
 					return &decimalType{
 						decimal: format.DecimalType{

--- a/column.go
+++ b/column.go
@@ -437,7 +437,32 @@ func schemaElementTypeOf(s *format.SchemaElement) Type {
 		case deprecated.Enum:
 			return &enumType{}
 		case deprecated.Decimal:
-			// TODO
+			if s.Scale != nil && s.Precision != nil {
+				// A parquet decimal can be one of several different physical types.
+				if t := s.Type; t != nil {
+					var typ Type
+					switch kind := Kind(*s.Type); kind {
+					case Int32:
+						typ = Int32Type
+					case Int64:
+						typ = Int64Type
+					case FixedLenByteArray:
+						if s.TypeLength == nil {
+							panic("DECIMAL using FIXED_LEN_BYTE_ARRAY must specify a length")
+						}
+						typ = FixedLenByteArrayType(int(*s.TypeLength))
+					default:
+						panic("DECIMAL must be of type INT32, INT64, or FIXED_LEN_BYTE_ARRAY but got " + kind.String())
+					}
+					return &decimalType{
+						decimal: format.DecimalType{
+							Scale:     *s.Scale,
+							Precision: *s.Precision,
+						},
+						Type: typ,
+					}
+				}
+			}
 		case deprecated.Date:
 			return &dateType{}
 		case deprecated.TimeMillis:


### PR DESCRIPTION
The code here is 90% the same as the for LogicalType but gets the scale and precision from the schema element itself.

I was wondering if there was a good way to put in some automated tests around this addition, I tried looking at https://github.com/segmentio/parquet-go/pull/406 (which added the support for the Decimal LogicalType) but that didn't seem to add any tests.

The main impetus here is that I am working with files created from AWS DMS and it is creating the decimals with converted type, so when I am processing files and rewriting them (while making some modifications to other columns) the type is being dropped