### PR TITLE
Add support for writing Go int16 type

### DIFF
--- a/buffer_go18_test.go
+++ b/buffer_go18_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestGenericBuffer(t *testing.T) {
 	testGenericBuffer[booleanColumn](t)
+	testGenericBuffer[int16Column](t)
 	testGenericBuffer[int32Column](t)
 	testGenericBuffer[int64Column](t)
 	testGenericBuffer[int96Column](t)
@@ -103,6 +104,7 @@ type generator[T any] interface {
 func BenchmarkGenericBuffer(b *testing.B) {
 	benchmarkGenericBuffer[benchmarkRowType](b)
 	benchmarkGenericBuffer[booleanColumn](b)
+	benchmarkGenericBuffer[int16Column](b)
 	benchmarkGenericBuffer[int32Column](b)
 	benchmarkGenericBuffer[int64Column](b)
 	benchmarkGenericBuffer[floatColumn](b)

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -58,6 +58,14 @@ func (row int32Column) generate(prng *rand.Rand) int32Column {
 	return int32Column{Value: prng.Int31n(100)}
 }
 
+type int16Column struct {
+	Value int16 `parquet:",delta"`
+}
+
+func (row int16Column) generate(prng *rand.Rand) int16Column {
+	return int16Column{Value: int16(prng.Intn(100))}
+}
+
 type int64Column struct {
 	Value int64 `parquet:",delta"`
 }

--- a/reader_go18_test.go
+++ b/reader_go18_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestGenericReader(t *testing.T) {
 	testGenericReader[booleanColumn](t)
+	testGenericReader[int16Column](t)
 	testGenericReader[int32Column](t)
 	testGenericReader[int64Column](t)
 	testGenericReader[int96Column](t)
@@ -227,6 +228,7 @@ func testReadMinPageSize(readSize int, t *testing.T) {
 func BenchmarkGenericReader(b *testing.B) {
 	benchmarkGenericReader[benchmarkRowType](b)
 	benchmarkGenericReader[booleanColumn](b)
+	benchmarkGenericReader[int16Column](b)
 	benchmarkGenericReader[int32Column](b)
 	benchmarkGenericReader[int64Column](b)
 	benchmarkGenericReader[floatColumn](b)

--- a/reader_test.go
+++ b/reader_test.go
@@ -40,6 +40,11 @@ var readerTests = []struct {
 	},
 
 	{
+		scenario: "INT16",
+		model:    int16Column{},
+	},
+
+	{
 		scenario: "INT32",
 		model:    int32Column{},
 	},

--- a/row_buffer_test.go
+++ b/row_buffer_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestRowBuffer(t *testing.T) {
 	testRowBuffer[booleanColumn](t)
+	testRowBuffer[int16Column](t)
 	testRowBuffer[int32Column](t)
 	testRowBuffer[int64Column](t)
 	testRowBuffer[int96Column](t)

--- a/schema.go
+++ b/schema.go
@@ -742,7 +742,7 @@ func makeNodeOf(t reflect.Type, name string, tag []string) Node {
 
 		case "delta":
 			switch t.Kind() {
-			case reflect.Int, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint32, reflect.Uint64:
+			case reflect.Int, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint32, reflect.Uint64, reflect.Int16, reflect.Uint16:
 				setEncoding(&DeltaBinaryPacked)
 			case reflect.String:
 				setEncoding(&DeltaByteArray)

--- a/schema_test.go
+++ b/schema_test.go
@@ -181,6 +181,17 @@ func TestSchemaOf(t *testing.T) {
 	}
 }`,
 		},
+
+		{
+			value: new(struct {
+				Ushort uint16 `parquet:"ushort"`
+				Short  int16  `parquet:"short"`
+			}),
+			print: `message {
+	required int32 ushort (INT(16,false));
+	required int32 short (INT(16,true));
+}`,
+		},
 	}
 
 	for _, test := range tests {

--- a/sparse/array.go
+++ b/sparse/array.go
@@ -104,7 +104,7 @@ func (a Int8Array) UnsafeArray() Array       { return Array{a.array} }
 type Int16Array struct{ array }
 
 func MakeInt16Array(values []int16) Int16Array {
-	return Int16Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 8)}
+	return Int16Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 2)}
 }
 
 func UnsafeInt16Array(base unsafe.Pointer, length int, offset uintptr) Int16Array {
@@ -212,7 +212,7 @@ func (a Uint8Array) UnsafeArray() Array        { return Array{a.array} }
 type Uint16Array struct{ array }
 
 func MakeUint16Array(values []uint16) Uint16Array {
-	return Uint16Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 8)}
+	return Uint16Array{makeArray(*(*unsafe.Pointer)(unsafe.Pointer(&values)), uintptr(len(values)), 2)}
 }
 
 func UnsafeUint16Array(base unsafe.Pointer, length int, offset uintptr) Uint16Array {

--- a/value_test.go
+++ b/value_test.go
@@ -41,6 +41,11 @@ func TestValueClone(t *testing.T) {
 		},
 
 		{
+			scenario: "INT16",
+			values:   []interface{}{int16(0), int16(1), int16(math.MinInt16), int16(math.MaxInt16)},
+		},
+
+		{
 			scenario: "INT32",
 			values:   []interface{}{int32(0), int32(1), int32(math.MinInt32), int32(math.MaxInt32)},
 		},

--- a/writer_go18_test.go
+++ b/writer_go18_test.go
@@ -15,6 +15,7 @@ import (
 func BenchmarkGenericWriter(b *testing.B) {
 	benchmarkGenericWriter[benchmarkRowType](b)
 	benchmarkGenericWriter[booleanColumn](b)
+	benchmarkGenericWriter[int16Column](b)
 	benchmarkGenericWriter[int32Column](b)
 	benchmarkGenericWriter[int64Column](b)
 	benchmarkGenericWriter[floatColumn](b)

--- a/writer_test.go
+++ b/writer_test.go
@@ -85,6 +85,10 @@ type event struct {
 	Category string  `parquet:"-"`
 }
 
+type usesShort struct {
+	Size int16 `parquet:"size"`
+}
+
 var writerTests = []struct {
 	scenario string
 	version  int
@@ -448,6 +452,31 @@ DOUBLE value
 *** row group 1 of 1, values 1 to 2 ***
 value 1: R:0 D:0 V:42.0
 value 2: R:0 D:0 V:1.0
+`,
+	},
+
+	{
+		scenario: "int16",
+		version:  v2,
+		rows: []interface{}{
+			usesShort{Size: 0},
+			usesShort{Size: 32767},
+			usesShort{Size: -32768},
+		},
+		dump: `row group 0
+--------------------------------------------------------------------------------
+size:  INT32 UNCOMPRESSED DO:0 FPO:4 SZ:40/40/1.00 VC:3 ENC:PLAIN ST:[min: -32768, max: 32767, num_nulls not defined]
+
+    size TV=3 RL=0 DL=0
+    ----------------------------------------------------------------------------
+    page 0:  DLE:RLE RLE:RLE VLE:PLAIN ST:[no stats for this column] SZ:12 VC:3
+
+INT32 size
+--------------------------------------------------------------------------------
+*** row group 1 of 1, values 1 to 3 ***
+value 1: R:0 D:0 V:0
+value 2: R:0 D:0 V:32767
+value 3: R:0 D:0 V:-32768
 `,
 	},
 }


### PR DESCRIPTION
This PR adds support for writing int16 values. (Currently trying to write a Go struct with int16 values causes the error `panic: cannot convert Go values of type int16 to parquet value`.)

I based the `writeRowsFuncOfInt16` function on the existing `writeRowsFuncOfTime` and tried to add test cases wherever they seemed appropriate.

The "int16" scenario in `writer_test.go` is comparing against output from my locally built version of parquet-tools, and I noticed that it's creating slightly different output for some of the other scenarios, so it may need to be changed to pass the official build process.