### PR TITLE
Support reading int96 as timestamp

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -83,7 +83,7 @@ func convertToSelf(column []Value) error { return nil }
 func convertToType(targetType, sourceType Type) conversionFunc {
 	return func(column []Value) error {
 		for i, v := range column {
-			v, err := sourceType.ConvertValue(v, targetType)
+			v, err := targetType.ConvertValue(v, sourceType)
 			if err != nil {
 				return err
 			}
@@ -719,6 +719,12 @@ func convertInt96ToDouble(v Value) (Value, error) {
 
 func convertInt96ToByteArray(v Value) (Value, error) {
 	return v.convertToByteArray(v.byteArray()), nil
+}
+
+func convertInt96ToTimestamp(v Value, u format.TimeUnit, tz *time.Location) (Value, error) {
+	t := v.int96().Time()
+	d := timeUnitDuration(u)
+	return v.convertToInt64(int64(t.In(tz).Sub(unixEpoch) / d)), nil
 }
 
 func convertInt96ToFixedLenByteArray(v Value, size int) (Value, error) {

--- a/deprecated/int96.go
+++ b/deprecated/int96.go
@@ -3,6 +3,7 @@ package deprecated
 import (
 	"math/big"
 	"math/bits"
+	"time"
 	"unsafe"
 )
 
@@ -79,6 +80,22 @@ func (i Int96) Int32() int32 {
 // Int64 converts i to a int64, potentially truncating the value.
 func (i Int96) Int64() int64 {
 	return int64(i[1])<<32 | int64(i[0])
+}
+
+const (
+	EPOCH_AS_JULIAN_DAY        = 2440588
+	NANOS_PER_DAY       uint64 = 86400 * 1000 * 1000 * 1000
+)
+
+// Time converts i to a Time
+// More information on the use of Int96 to store timestamps can be found here:
+// https://github.com/apache/parquet-format/pull/49
+func (i Int96) Time() time.Time {
+	nanos := uint64(i[1])<<32 | uint64(i[0])
+	days := i[2]
+
+	totalNanos := uint64(days-EPOCH_AS_JULIAN_DAY)*NANOS_PER_DAY + nanos
+	return time.Unix(0, int64(totalNanos)).UTC()
 }
 
 // String returns a string representation of i.

--- a/type.go
+++ b/type.go
@@ -323,6 +323,9 @@ func (t booleanType) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t booleanType) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	switch typ.(type) {
 	case *stringType:
 		return convertStringToBoolean(val)
@@ -406,6 +409,9 @@ func (t int32Type) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t int32Type) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	switch typ.(type) {
 	case *stringType:
 		return convertStringToInt32(val)
@@ -489,6 +495,9 @@ func (t int64Type) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t int64Type) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	switch typ.(type) {
 	case *stringType:
 		return convertStringToInt64(val)
@@ -566,6 +575,9 @@ func (t int96Type) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t int96Type) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	switch typ.(type) {
 	case *stringType:
 		return convertStringToInt96(val)
@@ -647,6 +659,9 @@ func (t floatType) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t floatType) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	switch typ.(type) {
 	case *stringType:
 		return convertStringToFloat(val)
@@ -728,6 +743,9 @@ func (t doubleType) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t doubleType) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	switch typ.(type) {
 	case *stringType:
 		return convertStringToDouble(val)
@@ -812,6 +830,9 @@ func (t byteArrayType) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t byteArrayType) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	switch typ.Kind() {
 	case Boolean:
 		return convertBooleanToByteArray(val)
@@ -916,6 +937,9 @@ func (t fixedLenByteArrayType) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t fixedLenByteArrayType) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	switch typ.(type) {
 	case *stringType:
 		return convertStringToFixedLenByteArray(val, t.length)
@@ -1054,6 +1078,9 @@ func (t be128Type) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t be128Type) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	return fixedLenByteArrayType{length: 16}.ConvertValue(val, typ)
 }
 
@@ -1223,6 +1250,9 @@ func (t *intType) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t *intType) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	if t.BitWidth == 64 {
 		return int64Type{}.ConvertValue(val, typ)
 	} else {
@@ -1338,6 +1368,9 @@ func (t *stringType) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t *stringType) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	switch t2 := typ.(type) {
 	case *dateType:
 		return convertDateToString(val)
@@ -1754,6 +1787,9 @@ func (t *dateType) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t *dateType) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	switch src := typ.(type) {
 	case *stringType:
 		return convertStringToDate(val, time.UTC)
@@ -1896,6 +1932,9 @@ func (t *timeType) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t *timeType) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	switch src := typ.(type) {
 	case *stringType:
 		tz := t.tz()
@@ -2021,11 +2060,16 @@ func (t *timestampType) AssignValue(dst reflect.Value, src Value) error {
 }
 
 func (t *timestampType) ConvertValue(val Value, typ Type) (Value, error) {
+	if val.IsNull() {
+		return val, nil
+	}
 	switch src := typ.(type) {
 	case *timestampType:
 		return convertTimestampToTimestamp(val, src.Unit, t.Unit)
 	case *dateType:
 		return convertDateToTimestamp(val, t.Unit, t.tz())
+	case int96Type:
+		return convertInt96ToTimestamp(val, t.Unit, t.tz())
 	}
 	return int64Type{}.ConvertValue(val, typ)
 }


### PR DESCRIPTION
By default Spark writes parquet files with int96 timestamps, even though the type has been deprecated for a while.  There are details of the format and some discussion here:
https://github.com/apache/parquet-format/pull/49

This PR adds support for reading int96 values into timestamps.  (Just reading, not writing.)

During implementation I found that the `convertToType()` function in `convert.go` was converting in the wrong direction.  I've added a test scenario "string to int" in `convert_test.go` which fails with the existing code and succeeds with the updated version.
Also, converting types with null values failed in some situations, so I added null checks to the `ConvertValue` functions in `type.go` and added the "nils" scenario in `convert_test.go`.