### PR TITLE
Value.Bytes() return value directly

### DIFF
--- a/value.go
+++ b/value.go
@@ -579,7 +579,26 @@ func (v Value) Column() int { return v.column() }
 // Bytes returns the binary representation of v.
 //
 // If v is the null value, an nil byte slice is returned.
-func (v Value) Bytes() []byte { return v.AppendBytes(nil) }
+func (v Value) Bytes() []byte {
+	switch v.Kind() {
+	case Boolean:
+		buf := [8]byte{}
+		binary.LittleEndian.PutUint32(buf[:4], v.uint32())
+		return buf[0:1]
+	case Int32, Float:
+		buf := [8]byte{}
+		binary.LittleEndian.PutUint32(buf[:4], v.uint32())
+		return buf[:4]
+	case Int64, Double:
+		buf := [8]byte{}
+		binary.LittleEndian.PutUint64(buf[:8], v.uint64())
+		return buf[:8]
+	case ByteArray, FixedLenByteArray, Int96:
+		return v.byteArray()
+	default:
+		return nil
+	}
+}
 
 // AppendBytes appends the binary representation of v to b.
 //


### PR DESCRIPTION
Previously the Value.Bytes() function was calling AppendBytes for it's implementation. This causes uncessary memory to be allocated.

This changes the Bytes function to directly return the values instead of performing an append to nil.

Running a benchmark that read in a large amount of data from Parquet files we see the following improvements
```
name              old time/op    new time/op    delta
_PreAggregate-10     4.84s ± 1%     4.39s ± 3%   -9.18%  (p=0.000 n=10+10)

name              old alloc/op   new alloc/op   delta
_PreAggregate-10    14.6GB ± 0%    10.5GB ± 1%  -27.96%  (p=0.000 n=10+10)

name              old allocs/op  new allocs/op  delta
_PreAggregate-10      162M ± 0%      128M ± 0%  -21.44%  (p=0.000 n=10+10)
```